### PR TITLE
PC-1135 Handle multiple actor emails 

### DIFF
--- a/InterneTaakAfhandeling.Poller/Features/InternetakenNotifier.cs
+++ b/InterneTaakAfhandeling.Poller/Features/InternetakenNotifier.cs
@@ -164,7 +164,7 @@ public class InternetakenNotifier : IInternetakenProcessor
                     }
                     else
                     {
-                      _logger.LogWarning("Invalid email address found for object {ObjectId}: {EmailAddress}", objectId, x);
+                        _logger.LogWarning("Invalid email address found for object {ObjectId}", objectId);
                     }
                 });
 

--- a/InterneTaakAfhandeling.Poller/Features/InternetakenNotifier.cs
+++ b/InterneTaakAfhandeling.Poller/Features/InternetakenNotifier.cs
@@ -80,8 +80,8 @@ public class InternetakenNotifier : IInternetakenProcessor
             {
                 _logger.LogInformation("Processing internetaken: {Number}", taak.Nummer);
 
-                var emailTo = await ResolveActorEmailAsync(taak);
-                if (!string.IsNullOrEmpty(emailTo))
+                var actorEmails = await ResolveActorsEmailAsync(taak);
+                if (actorEmails.Count > 0)
                 {
                     var klantContact = await _openKlantApiClient.GetKlantcontactAsync(taak.AanleidinggevendKlantcontact.Uuid);
 
@@ -96,9 +96,8 @@ public class InternetakenNotifier : IInternetakenProcessor
                     }
 
                     var emailContent = _emailContentService.BuildInternetakenEmailContent(taak, klantContact, digitaleAdress, zaak);
-
-                    await _emailService.SendEmailAsync(emailTo, $"Nieuw contactverzoek - {taak.Nummer}", emailContent);
-                    _logger.LogInformation("Successfully processed internetaken: {Number}", taak.Nummer);
+                    actorEmails.ForEach(async email => await _emailService.SendEmailAsync(email, $"Nieuw contactverzoek - {taak.Nummer}", emailContent));
+                   _logger.LogInformation("Successfully processed internetaken: {Number}", taak.Nummer);
                 }
             }
             catch (Exception ex)
@@ -109,19 +108,24 @@ public class InternetakenNotifier : IInternetakenProcessor
         }
     }
 
-    private async Task<string> ResolveActorEmailAsync(Internetaken request)
+    private async Task<List<string>> ResolveActorsEmailAsync(Internetaken internetaken)
     {
-        if (request.ToegewezenAanActoren == null)
+        if (internetaken.ToegewezenAanActoren == null)
         {
-            _logger.LogWarning("No actor assigned to internetaak {Nummer}", request.Nummer);
-            return string.Empty;
+            _logger.LogWarning("No actor assigned to internetaak {Nummer}", internetaken.Nummer);
+            return [];
         }
 
-        foreach (var toegewezenAanActoren in request.ToegewezenAanActoren)
-        {
+        var emailAddresses = new List<string>();
 
+        foreach (var toegewezenAanActoren in internetaken.ToegewezenAanActoren)
+        {
             var actor = await _openKlantApiClient.GetActorAsync(toegewezenAanActoren.Uuid);
-            if (actor?.Actoridentificator == null || actor.Actoridentificator.CodeObjecttype != "mdw")
+
+            List<string> validCodeObjectTypes = new List<string> { "mdw", "afd", "grp" };
+           
+            if (actor?.Actoridentificator == null ||
+                !validCodeObjectTypes.Contains(actor.Actoridentificator.CodeObjecttype))
             {
                 continue;
             }
@@ -132,10 +136,10 @@ public class InternetakenNotifier : IInternetakenProcessor
             if (actorIdentificator.CodeSoortObjectId == EmailCodeSoortObjectId &&
                 actorIdentificator.CodeRegister == HandmatigCodeRegister)
             {
-                  return objectId;
+                emailAddresses.Add(objectId);
             }
             // Check if we need to fetch email from object API
-            if (actorIdentificator.CodeSoortObjectId == "idf" &&
+            else if (actorIdentificator.CodeSoortObjectId == "idf" &&
                 actorIdentificator.CodeRegister == "obj")
             {
                 var objectRecords = await _objectApiClient.GetObjectsByIdentificatie(objectId);
@@ -149,22 +153,25 @@ public class InternetakenNotifier : IInternetakenProcessor
                 {
                     _logger.LogWarning("Multiple objects found in overigeobjecten for actorIdentificator {ObjectId}. Expected exactly one match.", objectId);
                     continue;
-                }
+                } 
 
-                var emailAddress = objectRecords.First().Data?.Emails?.FirstOrDefault()?.Email;
-
-                if (!string.IsNullOrEmpty(emailAddress) && EmailService.IsValidEmail(emailAddress))
+                  objectRecords.First().Data?.EmailAddresses?.ForEach(x =>
                 {
-                    return emailAddress;
-                }
+                   
+                    if (!string.IsNullOrEmpty(x) && EmailService.IsValidEmail(x))
+                    {
+                        emailAddresses.Add(x);
+                    }
+                    else
+                    {
+                      _logger.LogWarning("Invalid email address found for object {ObjectId}: {EmailAddress}", objectId, x);
+                    }
+                });
 
-                _logger.LogWarning("Invalid email address found for object {ObjectId}: {EmailAddress}", objectId, emailAddress);
-                continue;
             }
-            return objectId;
         }
 
-        return string.Empty;
+        return emailAddresses;
     }
 
 

--- a/InterneTaakAfhandeling.Poller/Program.cs
+++ b/InterneTaakAfhandeling.Poller/Program.cs
@@ -51,7 +51,7 @@ class Program
     // Retrieve the message from the configuration; fallback if not found
     string message = configuration["PollerMessage"] ?? "Poller executed at";
 
-    Console.WriteLine($"{message} {DateTime.UtcNow}");
+    Console.WriteLine($"{message} {DateTimeOffset.UtcNow}");
 
     logger.LogInformation("Starting ITA Poller application");
 

--- a/InterneTaakAfhandeling.Poller/Services/Emailservices/Content/EmailContentService.cs
+++ b/InterneTaakAfhandeling.Poller/Services/Emailservices/Content/EmailContentService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 using System.Text;
 using InterneTaakAfhandeling.Poller.Services.Openklant.Models;
@@ -77,10 +78,10 @@ public class EmailContentService : IEmailContentService
     }
 
     public static string FormatDateTime(DateTime dateTime)
-    {
-        dateTime = DateTime.SpecifyKind(dateTime, DateTimeKind.Utc);
+    { 
+        var dateTimeOffset = new DateTimeOffset(dateTime);
         TimeZoneInfo dutchTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Europe/Amsterdam");
-        DateTime dutchTime = TimeZoneInfo.ConvertTimeFromUtc(dateTime, dutchTimeZone);
+        DateTimeOffset dutchTime = TimeZoneInfo.ConvertTime(dateTimeOffset, dutchTimeZone);
 
         if (dutchTimeZone.IsDaylightSavingTime(dutchTime))
         {

--- a/InterneTaakAfhandeling.Poller/Services/Emailservices/Content/EmailContentService.cs
+++ b/InterneTaakAfhandeling.Poller/Services/Emailservices/Content/EmailContentService.cs
@@ -44,7 +44,7 @@ public class EmailContentService : IEmailContentService
         var betrokkene = klantcontact.HadBetrokkenActoren.FirstOrDefault();
         
         var sb = new StringBuilder(EmailTemplate);
-        sb.Replace("{Starttijd}", FormatDateTime( klantcontact.PlaatsgevondenOp))
+        sb.Replace("{Starttijd}", FormatPlaatsgevondenOp(klantcontact.PlaatsgevondenOp))
           .Replace("{Toelichting}", internetaken.Toelichting ?? "N/A")
           .Replace("{Status}", internetaken.Status ?? "N/A")
           .Replace("{GevraagdeHandeling}", internetaken.GevraagdeHandeling ?? "N/A")
@@ -77,16 +77,11 @@ public class EmailContentService : IEmailContentService
             .Where(s => !string.IsNullOrWhiteSpace(s)));
     }
 
-    public static string FormatDateTime(DateTime dateTime)
+    public static string FormatPlaatsgevondenOp(DateTimeOffset plaatsgevondenOp)
     { 
-        var dateTimeOffset = new DateTimeOffset(dateTime);
+         
         TimeZoneInfo dutchTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Europe/Amsterdam");
-        DateTimeOffset dutchTime = TimeZoneInfo.ConvertTime(dateTimeOffset, dutchTimeZone);
-
-        if (dutchTimeZone.IsDaylightSavingTime(dutchTime))
-        {
-            dutchTime = dutchTime.AddHours(1); // adjust for DST
-        }
+        DateTimeOffset dutchTime = TimeZoneInfo.ConvertTime(plaatsgevondenOp, dutchTimeZone);
 
         return dutchTime.ToString("HH:mm");
     }

--- a/InterneTaakAfhandeling.Poller/Services/Emailservices/Content/EmailContentService.cs
+++ b/InterneTaakAfhandeling.Poller/Services/Emailservices/Content/EmailContentService.cs
@@ -77,11 +77,16 @@ public class EmailContentService : IEmailContentService
     }
 
     public static string FormatDateTime(DateTime dateTime)
-    { 
+    {
+        dateTime = DateTime.SpecifyKind(dateTime, DateTimeKind.Utc);
         TimeZoneInfo dutchTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Europe/Amsterdam");
-        DateTime dutchTime = TimeZoneInfo.ConvertTime(dateTime, dutchTimeZone);
+        DateTime dutchTime = TimeZoneInfo.ConvertTimeFromUtc(dateTime, dutchTimeZone);
 
-        return dutchTime.ToString("HH:mm"); 
+        if (dutchTimeZone.IsDaylightSavingTime(dutchTime))
+        {
+            dutchTime = dutchTime.AddHours(1); // adjust for DST
+        }
+
+        return dutchTime.ToString("HH:mm");
     }
-
 }

--- a/InterneTaakAfhandeling.Poller/Services/ObjectApi/Models/ObjectResponse.cs
+++ b/InterneTaakAfhandeling.Poller/Services/ObjectApi/Models/ObjectResponse.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace InterneTaakAfhandeling.Poller.Services.ObjectApi.Models
 {
     public class ObjectResponse
@@ -31,18 +33,31 @@ namespace InterneTaakAfhandeling.Poller.Services.ObjectApi.Models
 
     public class ObjectData
     {
-        public required List<Emails> Emails { get; set; }
-        public required string Skills { get; set; }
-        public required string Functie { get; set; }
-        public required List<Groep> Groepen { get; set; }
+        public  List<Emails>? Emails { get; set; }
+        public string? Email { get; set; }
+        public  string? Skills { get; set; }
+        public  string? Functie { get; set; }
+        public  List<Groep>? Groepen { get; set; }
         public  string? Voornaam { get; set; }
-        public required string Achternaam { get; set; }
-        public required List<Afdeling> Afdelingen { get; set; }
+        public  string? Achternaam { get; set; }
+        public  List<Afdeling>? Afdelingen { get; set; }
         public  Vervanging? Vervanging { get; set; }
-        public required string Identificatie { get; set; }
+        public  string? Identificatie { get; set; }
         public  string? VolledigeNaam { get; set; }
-        public required List<Telefoonnummers> Telefoonnummers { get; set; }
-        public required string VoorvoegselAchternaam { get; set; }
+        public  List<Telefoonnummers>? Telefoonnummers { get; set; }
+        public  string? VoorvoegselAchternaam { get; set; }
+
+        // Helper method to get all emails regardless of format
+        [JsonIgnore]
+        public List<string> EmailAddresses
+        {
+            get
+            {
+                return Email != null ? [Email] :
+                       Emails != null ? Emails.Select(e => e.Email).ToList() :
+                       [];
+            }
+        }
     }
 
     public class Emails

--- a/InterneTaakAfhandeling.Poller/Services/OpenklantApi/Models/Internetaken.cs
+++ b/InterneTaakAfhandeling.Poller/Services/OpenklantApi/Models/Internetaken.cs
@@ -28,9 +28,9 @@ namespace InterneTaakAfhandeling.Poller.Services.Openklant.Models
 
         public required string Status { get; set; }
 
-        public required DateTime ToegewezenOp { get; set; }
+        public required DateTimeOffset ToegewezenOp { get; set; }
 
-        public DateTime? AfgehandeldOp { get; set; }
+        public DateTimeOffset? AfgehandeldOp { get; set; }
          
         public Internetaken()
         {
@@ -39,7 +39,7 @@ namespace InterneTaakAfhandeling.Poller.Services.Openklant.Models
             Nummer = string.Empty;
             GevraagdeHandeling = string.Empty;
             Status = string.Empty;
-            ToegewezenOp = DateTime.UtcNow;
+            ToegewezenOp = DateTimeOffset.UtcNow;
         }
     }
 }

--- a/InterneTaakAfhandeling.Poller/Services/OpenklantApi/Models/Klantcontact.cs
+++ b/InterneTaakAfhandeling.Poller/Services/OpenklantApi/Models/Klantcontact.cs
@@ -20,7 +20,7 @@ namespace InterneTaakAfhandeling.Poller.Services.Openklant.Models
         public bool? IndicatieContactGelukt { get; set; }
         public string? Taal { get; set; }
         public bool? Vertrouwelijk { get; set; }
-        public DateTime PlaatsgevondenOp { get; set; }
+        public DateTimeOffset PlaatsgevondenOp { get; set; }
         [JsonPropertyName("_expand")]
         public Expand? Expand { get; set; }
     }
@@ -72,8 +72,8 @@ namespace InterneTaakAfhandeling.Poller.Services.Openklant.Models
         public List<Actor>? ToegewezenAanActoren { get; set; }
         public string? Toelichting { get; set; }
         public string? Status { get; set; }
-        public DateTime? ToegewezenOp { get; set; }
-        public DateTime? AfgehandeldOp { get; set; }
+        public DateTimeOffset? ToegewezenOp { get; set; }
+        public DateTimeOffset? AfgehandeldOp { get; set; }
     }
 
     public class DigitaleAdres

--- a/InterneTaakAfhandeling.Poller/Services/ZakenApi/Models/Zaak.cs
+++ b/InterneTaakAfhandeling.Poller/Services/ZakenApi/Models/Zaak.cs
@@ -15,20 +15,20 @@ namespace InterneTaakAfhandeling.Poller.Services.ZakenApi.Models
             public string Omschrijving { get; set; }
             public string Toelichting { get; set; }
             public string Zaaktype { get; set; }
-            public DateTime Registratiedatum { get; set; }
+            public DateTimeOffset Registratiedatum { get; set; }
             public string VerantwoordelijkeOrganisatie { get; set; }
-            public DateTime? Startdatum { get; set; }
-            public DateTime? Einddatum { get; set; }
-            public DateTime? EinddatumGepland { get; set; }
-            public DateTime? UiterlijkeEinddatumAfdoening { get; set; }
-            public DateTime? Publicatiedatum { get; set; }
+            public DateTimeOffset? Startdatum { get; set; }
+            public DateTimeOffset? Einddatum { get; set; }
+            public DateTimeOffset? EinddatumGepland { get; set; }
+            public DateTimeOffset? UiterlijkeEinddatumAfdoening { get; set; }
+            public DateTimeOffset? Publicatiedatum { get; set; }
             public string Communicatiekanaal { get; set; }
             public string CommunicatiekanaalNaam { get; set; }
             public List<object> ProductenOfDiensten { get; set; }
             public string Vertrouwelijkheidaanduiding { get; set; }
             public string Betalingsindicatie { get; set; }
             public string BetalingsindicatieWeergave { get; set; }
-            public DateTime? LaatsteBetaaldatum { get; set; }
+            public DateTimeOffset? LaatsteBetaaldatum { get; set; }
             public object Zaakgeometrie { get; set; }
             public object Verlenging { get; set; }
             public Opschorting Opschorting { get; set; }
@@ -44,11 +44,11 @@ namespace InterneTaakAfhandeling.Poller.Services.ZakenApi.Models
             public List<object> Kenmerken { get; set; }
             public string Archiefnominatie { get; set; }
             public string Archiefstatus { get; set; }
-            public DateTime? Archiefactiedatum { get; set; }
+            public DateTimeOffset? Archiefactiedatum { get; set; }
             public object Resultaat { get; set; }
             public string OpdrachtgevendeOrganisatie { get; set; }
             public string Processobjectaard { get; set; }
-            public DateTime? StartdatumBewaartermijn { get; set; }
+            public DateTimeOffset? StartdatumBewaartermijn { get; set; }
             public Processobject Processobject { get; set; }
             public string ZaaksysteemId { get; set; }
         }


### PR DESCRIPTION
- Updated `InternetakenNotifier` to handle multiple actor emails.
  - Renamed `ResolveActorEmailAsync` to `ResolveActorsEmailAsync`.
  - Updated logic to send emails to each actor in the list.
- Modified `EmailContentService` to specify `DateTime` as UTC before converting to Dutch time zone and adjust for daylight saving time.
- Updated `ObjectResponse` in `ObjectApi.Models`:
  - Made several properties optional (nullable).
  - Added helper method `EmailAddresses` to consolidate email addresses.