### PR TITLE
Handle Creating missing user actor 

### DIFF
--- a/InterneTaakAfhandeling.Web.Server/Features/AssignInternetaakToMyself/AssignInternetaakToMyselfService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/AssignInternetaakToMyself/AssignInternetaakToMyselfService.cs
@@ -15,11 +15,15 @@ namespace InterneTaakAfhandeling.Web.Server.Features.AssignInternetaakToMyself
         private readonly IOpenKlantApiClient _openKlantApiClient = openKlantApiClient;
         public async Task<Common.Services.OpenKlantApi.Models.Internetaken> ToSelfAsync(string internetakenId, ITAUser user)
         {
-            var currentUserActor = await GetActor(user) ?? throw new Exception("Actor not found.");
-
+            var currentUserActor = await GetActor(user) ?? await CreateEntraActor(user);
             var internetaken = await _openKlantApiClient.GetInternetakenByIdAsync(internetakenId) ?? throw new Exception($"Internetaken with ID {internetakenId} not found.");
 
             var actors = await GetAssignedOrganisationalUnitActors(internetaken);
+
+            if (currentUserActor == null)
+            {
+                throw new ArgumentNullException("Current user actor cannot be null.");
+            }
 
             actors.Add(currentUserActor);
 
@@ -29,14 +33,13 @@ namespace InterneTaakAfhandeling.Web.Server.Features.AssignInternetaakToMyself
                 GevraagdeHandeling = internetaken.GevraagdeHandeling,
                 AanleidinggevendKlantcontact = new UuidObject { Uuid = Guid.Parse(internetaken.AanleidinggevendKlantcontact.Uuid) },
                 ToegewezenAanActoren = actors
-            .Select(x => new UuidObject { Uuid = Guid.Parse(x.Uuid) })
-            .ToList(),
+                    .Select(x => new UuidObject { Uuid = Guid.Parse(x.Uuid) })
+                    .ToList(),
                 Toelichting = internetaken.Toelichting ?? string.Empty,
                 Status = internetaken.Status
             };
 
             return await _openKlantApiClient.UpdateInternetakenAsync(internetakenUpdateRequest, internetaken.Uuid) ?? throw new Exception($"Unable to update Internetaken with ID {internetakenId}.");
-
         }
 
         private async Task<List<Actor>> GetAssignedOrganisationalUnitActors(Common.Services.OpenKlantApi.Models.Internetaken internetaken)
@@ -67,6 +70,22 @@ namespace InterneTaakAfhandeling.Web.Server.Features.AssignInternetaakToMyself
 
             return null;
         }
-
+        private async Task<Actor?> CreateEntraActor(ITAUser user)
+        {
+            var actorRequest = new ActorRequest
+            {
+                SoortActor = SoortActor.medewerker.ToString(),
+                Naam = user.Name,
+                Actoridentificator = new Actoridentificator
+                {
+                    CodeObjecttype = KnownMedewerkerIdentificators.EmailFromEntraId.CodeObjecttype,
+                    CodeRegister = KnownMedewerkerIdentificators.EmailFromEntraId.CodeRegister,
+                    CodeSoortObjectId = KnownMedewerkerIdentificators.EmailFromEntraId.CodeSoortObjectId,
+                    ObjectId = user.Email
+                },
+                IndicatieActief = true
+            };
+            return await _openKlantApiClient.CreateActorAsync(actorRequest);
+        }
     }
 }


### PR DESCRIPTION
Updated `ToSelfAsync` to handle missing user actors by attempting to create one using the new `CreateEntraActor` method.