### PR TITLE
Fix/subchart naming conflicts

### DIFF
--- a/charts/internetaakafhandeling/Chart.yaml
+++ b/charts/internetaakafhandeling/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: internetaakafhandeling
 description: Helm chart for InterneTaakAfhandeling including Web API and Poller
 type: application
-version: 0.2.1
+version: 1.0.1
 appVersion: 0.2.0
 dependencies:
   - name: postgresql

--- a/charts/internetaakafhandeling/Chart.yaml
+++ b/charts/internetaakafhandeling/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: internetaakafhandeling
 description: Helm chart for InterneTaakAfhandeling including Web API and Poller
 type: application
-version: 1.0.1
-appVersion: 1.0.1
+version: 0.0.0
+appVersion: 0.0.0
 dependencies:
   - name: postgresql
     version: 12.5.6

--- a/charts/internetaakafhandeling/Chart.yaml
+++ b/charts/internetaakafhandeling/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: internetaakafhandeling
 description: Helm chart for InterneTaakAfhandeling including Web API and Poller
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: 0.2.0
 dependencies:
   - name: postgresql

--- a/charts/internetaakafhandeling/Chart.yaml
+++ b/charts/internetaakafhandeling/Chart.yaml
@@ -3,7 +3,7 @@ name: internetaakafhandeling
 description: Helm chart for InterneTaakAfhandeling including Web API and Poller
 type: application
 version: 1.0.1
-appVersion: 0.2.0
+appVersion: 1.0.1
 dependencies:
   - name: postgresql
     version: 12.5.6

--- a/charts/internetaakafhandeling/templates/_helpers.tpl
+++ b/charts/internetaakafhandeling/templates/_helpers.tpl
@@ -1,20 +1,47 @@
 {{/* Common names and labels */}}
 {{- define "internetaakafhandeling.name" -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "internetaakafhandeling.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* ConfigMap name helper */}}
+{{- define "internetaakafhandeling.configMapName" -}}
+{{- if .Values.configMapName -}}
+{{- .Values.configMapName | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-config" (include "internetaakafhandeling.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Secret name helper */}}
+{{- define "internetaakafhandeling.secretName" -}}
+{{- if .Values.secretName -}}
+{{- .Values.secretName | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-secret" (include "internetaakafhandeling.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/* Web specific names */}}
 {{- define "internetaakafhandeling.web.name" -}}
-{{- printf "%s-web" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-web" (include "internetaakafhandeling.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/* Poller specific names */}}
 {{- define "internetaakafhandeling.poller.name" -}}
-{{- printf "%s-poller" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-poller" (include "internetaakafhandeling.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/* Common labels */}}
@@ -41,18 +68,18 @@ app.kubernetes.io/component: poller
 {{/* Selector labels */}}
 {{- define "internetaakafhandeling.web.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "internetaakafhandeling.web.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/instance: {{ include "internetaakafhandeling.fullname" . }}
 {{- end -}}
 
 {{- define "internetaakafhandeling.poller.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "internetaakafhandeling.poller.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/instance: {{ include "internetaakafhandeling.fullname" . }}
 {{- end -}}
 
 {{/* Database connection string helper */}}
 {{- define "internetaakafhandeling.databaseConnectionString" -}}
 {{- if .Values.postgresql.enabled -}}
-  {{- printf "Host=%s-postgresql;Port=%s;Database=%s;Username=%s;Password=%s;" .Release.Name .Values.database.port .Values.database.name .Values.database.username .Values.database.password -}}
+  {{- printf "Host=%s-postgresql;Port=%s;Database=%s;Username=%s;Password=%s;" (include "internetaakafhandeling.fullname" .) .Values.database.port .Values.database.name .Values.database.username .Values.database.password -}}
 {{- else -}}
   {{- printf "Host=%s;Port=%s;Database=%s;Username=%s;Password=%s;" .Values.database.host .Values.database.port .Values.database.name .Values.database.username .Values.database.password -}}
 {{- end -}}

--- a/charts/internetaakafhandeling/templates/_helpers.tpl
+++ b/charts/internetaakafhandeling/templates/_helpers.tpl
@@ -6,13 +6,10 @@
 {{- define "internetaakafhandeling.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else if .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/internetaakafhandeling/templates/_helpers.tpl
+++ b/charts/internetaakafhandeling/templates/_helpers.tpl
@@ -16,24 +16,6 @@
 {{- end -}}
 {{- end -}}
 
-{{/* ConfigMap name helper */}}
-{{- define "internetaakafhandeling.configMapName" -}}
-{{- if .Values.configMapName -}}
-{{- .Values.configMapName | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-config" (include "internetaakafhandeling.fullname" .) | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-
-{{/* Secret name helper */}}
-{{- define "internetaakafhandeling.secretName" -}}
-{{- if .Values.secretName -}}
-{{- .Values.secretName | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-secret" (include "internetaakafhandeling.fullname" .) | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-
 {{/* Web specific names */}}
 {{- define "internetaakafhandeling.web.name" -}}
 {{- printf "%s-web" (include "internetaakafhandeling.fullname" .) | trunc 63 | trimSuffix "-" -}}

--- a/charts/internetaakafhandeling/templates/config.yaml
+++ b/charts/internetaakafhandeling/templates/config.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "internetaakafhandeling.configMapName" . }}
+  name: {{ include "internetaakafhandeling.fullname" . }}-config
   labels:
     {{- include "internetaakafhandeling.labels" . | nindent 4 }}
 data:

--- a/charts/internetaakafhandeling/templates/config.yaml
+++ b/charts/internetaakafhandeling/templates/config.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "internetaakafhandeling.fullname" . }}-config
+  name: {{ include "internetaakafhandeling.configMapName" . }}
   labels:
     {{- include "internetaakafhandeling.labels" . | nindent 4 }}
 data:

--- a/charts/internetaakafhandeling/templates/secrets.yaml
+++ b/charts/internetaakafhandeling/templates/secrets.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "internetaakafhandeling.secretName" . }}
+  name: {{ include "internetaakafhandeling.fullname" . }}-secrets
   labels:
     {{- include "internetaakafhandeling.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/internetaakafhandeling/templates/secrets.yaml
+++ b/charts/internetaakafhandeling/templates/secrets.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "internetaakafhandeling.fullname" . }}-secrets
+  name: {{ include "internetaakafhandeling.secretName" . }}
   labels:
     {{- include "internetaakafhandeling.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/internetaakafhandeling/templates/web-deployment.yaml
+++ b/charts/internetaakafhandeling/templates/web-deployment.yaml
@@ -41,9 +41,9 @@ spec:
               subPath: appsettings.json
           envFrom:
             - configMapRef:
-                name: {{ include "internetaakafhandeling.configMapName" . }}
+                name: {{ include "internetaakafhandeling.fullname" . }}-config
             - secretRef:
-                name: {{ include "internetaakafhandeling.secretName" . }}
+                name: {{ include "internetaakafhandeling.fullname" . }}-secrets
       volumes:
         - name: appsettings-volume
           configMap:

--- a/charts/internetaakafhandeling/templates/web-deployment.yaml
+++ b/charts/internetaakafhandeling/templates/web-deployment.yaml
@@ -41,9 +41,9 @@ spec:
               subPath: appsettings.json
           envFrom:
             - configMapRef:
-                name: {{ include "internetaakafhandeling.fullname" . }}-config
+                name: {{ include "internetaakafhandeling.configMapName" . }}
             - secretRef:
-                name: {{ include "internetaakafhandeling.fullname" . }}-secrets
+                name: {{ include "internetaakafhandeling.secretName" . }}
       volumes:
         - name: appsettings-volume
           configMap:

--- a/charts/internetaakafhandeling/values.yaml
+++ b/charts/internetaakafhandeling/values.yaml
@@ -1,3 +1,9 @@
+# Naming overrides - useful when used as subchart
+nameOverride: ""
+fullnameOverride: ""
+configMapName: ""
+secretName: ""
+
 # Global PostgreSQL configuration
 postgresql:
   enabled: true

--- a/charts/internetaakafhandeling/values.yaml
+++ b/charts/internetaakafhandeling/values.yaml
@@ -1,8 +1,6 @@
 # Naming overrides - useful when used as subchart
 nameOverride: ""
 fullnameOverride: ""
-configMapName: ""
-secretName: ""
 
 # Global PostgreSQL configuration
 postgresql:


### PR DESCRIPTION
  When used as a subchart with fullnameOverride: "ita", resources will
  now be named:
  - ita-config (ConfigMap)
  - ita-secrets (Secret)
  - ita-web (Deployment)
  - ita-poller (CronJob)

  Instead of inheriting the parent release name and causing conflicts.

  Testing

  This change maintains backward compatibility - existing deployments
  will continue to work unchanged. The fix only takes effect when
  fullnameOverride or nameOverride are explicitly set.