### PR TITLE
removed schema, created link to schema in github

### DIFF
--- a/docs/installation/objecttypen.rst
+++ b/docs/installation/objecttypen.rst
@@ -2,8 +2,7 @@
 Objecttypen
 ===========
 
-ITA slaat de history rondom de afhandeling van een Contactverzoek op in de Objecten API.
-Dit gebeurt in een logboek-objecttype genaamd Activiteitenlog.
+ITA slaat de history rondom de afhandeling van een Contactverzoek op in de Objecten API. Dit gebeurt in een logboek-objecttype genaamd Activiteitenlog.
 
 - Bij de installatie van ITA moet men ervoor zorgen dat dit objecttype aanwezig is in een Objecttypen API en dat deze correct geregistreerd is in de Objecten API. Zie de documentatie (https://objects-and-objecttypes-api.readthedocs.io/en/latest/) voor instructies. 
 - Het schema van het objecttype staat in de repository vanvan ITA: `https://github.com/Interne-Taak-Afhandeling/ITA/blob/main/docs/schema/Logboek-schema.json <https://github.com/Interne-Taak-Afhandeling/ITA/blob/main/docs/schema/Logboek-schema.json>`_ 


### PR DESCRIPTION
Now that the Schema for the logboek Objecttype `Activiteitenlog` is published in this repository, i have removed the code blob from the documentation and replaced it with a link to the schema in this repo.