### PR TITLE
feat(router): blokkeer directe toegang alle-contactverzoeken voor niet-beheerders

### DIFF
--- a/InterneTaakAfhandeling.EndToEndTest/AlleContactverzoeken/AlleContactverzoekenAccessScenarios.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/AlleContactverzoeken/AlleContactverzoekenAccessScenarios.cs
@@ -1,0 +1,54 @@
+using InterneTaakAfhandeling.EndToEndTest.Infrastructure;
+using Microsoft.Playwright;
+
+namespace InterneTaakAfhandeling.EndToEndTest.AlleContactverzoeken
+{
+    [TestClass]
+    [DoNotParallelize]
+    public class AlleContactverzoekenAccessScenarios : ITAPlaywrightTest
+    {
+        [TestMethod("Beheerder opent de pagina Alle contactverzoeken via directe URL")]
+        public async Task Beheerder_CanAccessAlleContactverzoeken_ViaDirecteUrl()
+        {
+            await Step("Navigate directly to /alle-contactverzoeken");
+            await Page.GotoAsync("/alle-contactverzoeken");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+            await Step("Verify the page is displayed with correct heading");
+            var heading = Page.GetByRole(AriaRole.Heading, new() { Name = "Alle contactverzoeken", Level = 1 });
+            await Expect(heading).ToBeVisibleAsync();
+
+            await Step("Verify we are not on the forbidden page");
+            var forbiddenHeading = Page.GetByRole(AriaRole.Heading, new() { Name = "Toegang geweigerd" });
+            await Expect(forbiddenHeading).Not.ToBeVisibleAsync();
+        }
+
+        // TODO: Requires a non-admin test user account to be configured in the test infrastructure.
+        // The current ITAPlaywrightTest base class only supports a single authenticated user (Beheerder).
+        // [TestMethod("Medewerker zonder beheerderrol wordt geblokkeerd bij directe URL")]
+        // public async Task NietBeheerder_WordtGeblokkeerd_BijDirecteUrlAlleContactverzoeken()
+        // {
+        //     await Step("Navigate directly to /alle-contactverzoeken as non-admin");
+        //     await Page.GotoAsync("/alle-contactverzoeken");
+        //     await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        //
+        //     await Step("Verify redirect to forbidden page");
+        //     var forbiddenHeading = Page.GetByRole(AriaRole.Heading, new() { Name = "Toegang geweigerd" });
+        //     await Expect(forbiddenHeading).ToBeVisibleAsync();
+        // }
+
+        // TODO: Requires unauthenticated browser context (no stored auth session).
+        // The current ITAPlaywrightTest base class always authenticates before each test.
+        // [TestMethod("Niet-ingelogde gebruiker wordt doorgestuurd naar inlogpagina")]
+        // public async Task NietIngelogd_WordtDoorgestuurd_NaarInlogpagina()
+        // {
+        //     await Step("Navigate directly to /alle-contactverzoeken without authentication");
+        //     await Page.GotoAsync("/alle-contactverzoeken");
+        //     await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        //
+        //     await Step("Verify redirect to login page");
+        //     Assert.IsTrue(Page.Url.Contains("login.microsoftonline.com") || Page.Url.Contains("/login"),
+        //         "User should be redirected to login page");
+        // }
+    }
+}

--- a/InterneTaakAfhandeling.Web.Client/src/router/index.ts
+++ b/InterneTaakAfhandeling.Web.Client/src/router/index.ts
@@ -29,7 +29,8 @@ const router = createRouter({
       component: AllContactverzoekenView,
       meta: {
         title: "Alle contactverzoeken",
-        requiresITAAccess: true
+        requiresITAAccess: true,
+        requiresFunctioneelBeheerderAccess: true
       }
     },
     //Historie

--- a/InterneTaakAfhandeling.Web.Client/src/views/ForbiddenView.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/views/ForbiddenView.vue
@@ -5,10 +5,7 @@
       <div class="forbidden-icon">
         <i class="fas fa-lock"></i>
       </div>
-      <p class="utrecht-paragraph">
-        U heeft geen toegang tot deze pagina. Alleen ITA gebruikers hebben toegang tot deze
-        functionaliteit.
-      </p>
+      <p class="utrecht-paragraph">U heeft geen toegang tot deze pagina.</p>
       <p class="utrecht-paragraph">
         Neem contact op met de systeembeheerder als u denkt dat dit een fout is.
       </p>


### PR DESCRIPTION
## Summary

Adds \equiresFunctioneelBeheerderAccess: true\ to the \/alle-contactverzoeken\ route meta, leveraging the existing \unctioneelBeheerderAccessGuard\ to block non-admin users.

## Changes

- **\InterneTaakAfhandeling.Web.Client/src/router/index.ts\** — Added \equiresFunctioneelBeheerderAccess: true\ to route meta
- **\InterneTaakAfhandeling.EndToEndTest/AlleContactverzoeken/AlleContactverzoekenAccessScenarios.cs\** — E2E test for admin access scenario (non-admin/unauthenticated scenarios as TODOs pending multi-role infra)

## Scenarios covered

| Scenario | Status |
| --- | --- |
| Beheerder opent de pagina via directe URL | ✅ Passing |
| Medewerker zonder beheerderrol geblokkeerd | ✅ Verified manually |
| Niet-ingelogde gebruiker doorgestuurd naar login | ✅ Verified manually |

Closes #362