### PR TITLE
fix(auth): restrict /api/internetaken to beheerders only

### DIFF
--- a/InterneTaakAfhandeling.Web.Server/Features/InterneTakenOverzicht/AlleOverzicht/AlleContactverzoekenController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/InterneTakenOverzicht/AlleOverzicht/AlleContactverzoekenController.cs
@@ -8,7 +8,7 @@ namespace InterneTaakAfhandeling.Web.Server.Features.InterneTakenOverzicht.AlleO
 {
     [Route("api/internetaken")]
     [ApiController]
-    [Authorize(Policy = ITAPolicy.Name)]
+    [Authorize(Policy = FunctioneelBeheerderPolicy.Name)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public class AlleOverzichtController(


### PR DESCRIPTION
## Summary

Secures the "Alle contactverzoeken" API endpoint so only users with the "Beheerder" role can access it. Non-admin users now receive 403 Forbidden, unauthenticated users receive 401. This fulfils Feature #359 (Beheerder kan exclusief alle contactverzoeken raadplegen) within Epic #358.

## Changes

- Replaced `ITAPolicy` with `FunctioneelBeheerderPolicy` on `AlleOverzichtController`, restricting access to administrators only.

## Test plan

- [x] Beheerder kan het API-endpoint aanroepen (200)
- [x] Medewerker zonder beheerderrol krijgt 403 op het API-endpoint
- [x] Niet-geauthenticeerde gebruiker krijgt 401 op het API-endpoint

## Related

Closes #363
