### PR TITLE
feat(internetaak): add OrigineleContactmomentNummer via keten-lookup

### DIFF
--- a/InterneTaakAfhandeling.Common/Services/OpenKlantApi/KlantcontactService.cs
+++ b/InterneTaakAfhandeling.Common/Services/OpenKlantApi/KlantcontactService.cs
@@ -1,8 +1,8 @@
 ﻿using InterneTaakAfhandeling.Common.Exceptions;
-using InterneTaakAfhandeling.Common.Services.OpenKlantApi;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
+using Microsoft.Extensions.Logging;
 
-namespace InterneTaakAfhandeling.Web.Server.Services
+namespace InterneTaakAfhandeling.Common.Services.OpenKlantApi
 {
     public interface IKlantcontactService
     {

--- a/InterneTaakAfhandeling.Common/Services/OpenKlantApi/Models/Internetaak.cs
+++ b/InterneTaakAfhandeling.Common/Services/OpenKlantApi/Models/Internetaak.cs
@@ -20,6 +20,8 @@ public class Internetaak
 
     public string? Nummer { get; set; }
 
+    public string? OrigineleContactmomentNummer { get; set; }
+
     public string? GevraagdeHandeling { get; set; }
 
     public Klantcontact AanleidinggevendKlantcontact { get; set; }

--- a/InterneTaakAfhandeling.Poller/Features/InternetakenNotifier.cs
+++ b/InterneTaakAfhandeling.Poller/Features/InternetakenNotifier.cs
@@ -23,6 +23,7 @@ public class InternetakenNotifier : IInternetakenProcessor
     private readonly IEmailContentService _emailContentService;
     private readonly INotifierStateService _notifierStateService;
     private readonly IInterneTaakEmailInputService _emailInputService;
+    private readonly IKlantcontactService _klantcontactService;
 
     public InternetakenNotifier(
         IOpenKlantApiClient openKlantApiClient,
@@ -31,7 +32,8 @@ public class InternetakenNotifier : IInternetakenProcessor
         ILogger<InternetakenNotifier> logger,
         IEmailContentService emailContentService,
         INotifierStateService notifierStateService,
-        IInterneTaakEmailInputService emailInputService)
+        IInterneTaakEmailInputService emailInputService,
+        IKlantcontactService klantcontactService)
     {
         _openKlantApiClient = openKlantApiClient ?? throw new ArgumentNullException(nameof(openKlantApiClient));
         _emailService = emailService ?? throw new ArgumentNullException(nameof(emailService));
@@ -43,6 +45,7 @@ public class InternetakenNotifier : IInternetakenProcessor
         _emailContentService = emailContentService ?? throw new ArgumentNullException(nameof(emailContentService));
         _notifierStateService = notifierStateService ?? throw new ArgumentNullException(nameof(notifierStateService));
         _emailInputService = emailInputService;
+        _klantcontactService = klantcontactService ?? throw new ArgumentNullException(nameof(klantcontactService));
     }
 
     public async Task NotifyAboutNewInternetakenAsync()
@@ -100,6 +103,8 @@ public class InternetakenNotifier : IInternetakenProcessor
         {
             _logger.LogInformation("Processing internetaken: {Number}", internetaak.Nummer);
 
+            await ResolveOrigineleContactmomentNummerAsync(internetaak);
+
             var actors = await GetActorsAsync(internetaak);
             var actorEmailsResult = await _emailInputService.ResolveActorsEmailAsync(actors);
             var actorEmails = actorEmailsResult.FoundEmails;
@@ -144,6 +149,28 @@ public class InternetakenNotifier : IInternetakenProcessor
         }
 
         return actoren;
+    }
+
+    private async Task ResolveOrigineleContactmomentNummerAsync(Internetaak internetaak)
+    {
+        if (internetaak.AanleidinggevendKlantcontact == null)
+            return;
+
+        try
+        {
+            var eersteKlantcontact = await _klantcontactService.GetEersteKlantcontactInKetenAsync(
+                internetaak.AanleidinggevendKlantcontact.Uuid);
+
+            internetaak.OrigineleContactmomentNummer = eersteKlantcontact?.Nummer
+                ?? internetaak.AanleidinggevendKlantcontact.Nummer;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Kon originele contactmoment-nummer niet bepalen voor internetaak {Nummer}, fallback naar aanleidinggevend klantcontact",
+                internetaak.Nummer);
+            internetaak.OrigineleContactmomentNummer = internetaak.AanleidinggevendKlantcontact.Nummer;
+        }
     }
 
 

--- a/InterneTaakAfhandeling.Poller/Program.cs
+++ b/InterneTaakAfhandeling.Poller/Program.cs
@@ -48,7 +48,8 @@ internal class Program
                 .AddSmtpClients(configuration)
                 .AddScoped<IInternetakenProcessor, InternetakenNotifier>()
                 .AddScoped<INotifierStateService, NotifierStateService>()
-                .AddScoped<IContactmomentenService, ContactmomentenService>();
+                .AddScoped<IContactmomentenService, ContactmomentenService>()
+                .AddScoped<IKlantcontactService, KlantcontactService>();
 
             var serviceProvider = services.BuildServiceProvider();
 

--- a/InterneTaakAfhandeling.Web.Server/Config/ServiceCollectionExtensions.cs
+++ b/InterneTaakAfhandeling.Web.Server/Config/ServiceCollectionExtensions.cs
@@ -11,7 +11,6 @@ using InterneTaakAfhandeling.Web.Server.Features.InterneTakenOverzicht;
 using InterneTaakAfhandeling.Web.Server.Features.KlantContact;
 using InterneTaakAfhandeling.Web.Server.Features.MyInterneTakenOverview;
 using InterneTaakAfhandeling.Web.Server.Middleware;
-using InterneTaakAfhandeling.Web.Server.Services;
 using InterneTaakAfhandeling.Web.Server.Services.LogboekService;
 using Microsoft.EntityFrameworkCore;
 

--- a/InterneTaakAfhandeling.Web.Server/Features/InterneTaakDetails/InternetaakDetailsService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/InterneTaakDetails/InternetaakDetailsService.cs
@@ -1,6 +1,7 @@
 ﻿using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi;
 using InterneTaakAfhandeling.Common.Services.ZakenApi;
+using Microsoft.Extensions.Logging;
 
 namespace InterneTaakAfhandeling.Web.Server.Features.InterneTaak
 {
@@ -8,11 +9,18 @@ namespace InterneTaakAfhandeling.Web.Server.Features.InterneTaak
     {
         Task<Internetaak?> Get(InterneTaakQuery interneTaakQueryParameters);
     }
-    public class InternetaakDetailsService(IOpenKlantApiClient openKlantApiClient, IZakenApiClient zakenApiClient, IContactmomentenService contactmomentenService) : IInternetaakService
+    public class InternetaakDetailsService(
+        IOpenKlantApiClient openKlantApiClient,
+        IZakenApiClient zakenApiClient,
+        IContactmomentenService contactmomentenService,
+        IKlantcontactService klantcontactService,
+        ILogger<InternetaakDetailsService> logger) : IInternetaakService
     {
         private readonly IOpenKlantApiClient _openKlantApiClient = openKlantApiClient;
         private readonly IZakenApiClient _zakenApiClient = zakenApiClient;
         private readonly IContactmomentenService _contactmomentenService = contactmomentenService;
+        private readonly IKlantcontactService _klantcontactService = klantcontactService;
+        private readonly ILogger<InternetaakDetailsService> _logger = logger;
 
         public async Task<Internetaak?> Get(InterneTaakQuery interneTaakQueryParameters)
         {
@@ -39,10 +47,31 @@ namespace InterneTaakAfhandeling.Web.Server.Features.InterneTaak
                 {
                     interntaak.Zaak = await _zakenApiClient.GetZaakAsync(onderwerpObjectId);
                 }
+
+                await ResolveOrigineleContactmomentNummerAsync(interntaak);
             }
 
 
             return interntaak;
+        }
+
+        private async Task ResolveOrigineleContactmomentNummerAsync(Internetaak internetaak)
+        {
+            try
+            {
+                var eersteKlantcontact = await _klantcontactService.GetEersteKlantcontactInKetenAsync(
+                    internetaak.AanleidinggevendKlantcontact.Uuid);
+
+                internetaak.OrigineleContactmomentNummer = eersteKlantcontact?.Nummer
+                    ?? internetaak.AanleidinggevendKlantcontact.Nummer;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Kon originele contactmoment-nummer niet bepalen voor internetaak {Nummer}, fallback naar aanleidinggevend klantcontact",
+                    internetaak.Nummer);
+                internetaak.OrigineleContactmomentNummer = internetaak.AanleidinggevendKlantcontact.Nummer;
+            }
         }
     }
 }

--- a/InterneTaakAfhandeling.Web.Server/Features/InterneTakenOverzicht/InterneTakenOverzichtModel.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/InterneTakenOverzicht/InterneTakenOverzichtModel.cs
@@ -28,6 +28,7 @@ public class InterneTaakOverzichtItem
 
     public string Uuid { get; set; } = string.Empty;
     public string? Nummer { get; set; } = string.Empty;
+    public string? OrigineleContactmomentNummer { get; set; }
     public string? GevraagdeHandeling { get; set; } = string.Empty;
     public string? Status { get; set; } = string.Empty;
     public DateTimeOffset? ToegewezenOp { get; init; }

--- a/InterneTaakAfhandeling.Web.Server/Features/InterneTakenOverzicht/InterneTakenOverzichtService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/InterneTakenOverzicht/InterneTakenOverzichtService.cs
@@ -72,6 +72,7 @@ namespace InterneTaakAfhandeling.Web.Server.Features.InterneTakenOverzicht
                     item.Onderwerp = klantcontact.Onderwerp;
                     item.ContactDatum = klantcontact.PlaatsgevondenOp;
                     item.KlantNaam = ExtractKlantNaamFromKlantcontact(klantcontact);
+                    item.OrigineleContactmomentNummer = klantcontact.Nummer;
                 }
             }
             catch (Exception ex)

--- a/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CreateKlantContactService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CreateKlantContactService.cs
@@ -3,7 +3,6 @@ using InterneTaakAfhandeling.Common.Helpers;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
 using InterneTaakAfhandeling.Web.Server.Middleware;
-using InterneTaakAfhandeling.Web.Server.Services;
 using static InterneTaakAfhandeling.Common.Services.OpenKlantApi.OpenKlantApiClient;
 using InterneTaakAfhandeling.Common.Services;
 

--- a/InterneTaakAfhandeling.Web.Server/Features/KlantcontactenOverview/KlantcontactenOverviewController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/KlantcontactenOverview/KlantcontactenOverviewController.cs
@@ -1,7 +1,6 @@
 ﻿using InterneTaakAfhandeling.Common.Services.OpenKlantApi;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
 using InterneTaakAfhandeling.Web.Server.Authentication;
-using InterneTaakAfhandeling.Web.Server.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 


### PR DESCRIPTION
## Summary

Feature #299 wil het nummer van het originele contactmoment tonen in plaats van het interne-taaknummer. Deze taak legt de server-side basis: het `OrigineleContactmomentNummer` wordt opgehaald via de klantcontact-keten en beschikbaar gemaakt in de datamodellen die door de UI, e-mails en routing worden geconsumeerd.

## Changes

- **Model verrijking**: nieuw nullable veld `OrigineleContactmomentNummer` toegevoegd aan `Internetaak` (Common) en `InterneTaakOverzichtItem` (Web.Server). Het bestaande `Nummer`-veld blijft behouden voor backward-compatibility.
- **KlantcontactService verplaatst** van `Web.Server\Services\` naar `Common\Services\OpenKlantApi\` zodat zowel Web.Server als Poller de keten-lookup kunnen hergebruiken (geen logicawijzigingen, alleen namespace).
- **Detail view**: `InternetaakDetailsService` injecteert nu `IKlantcontactService` en roept `GetEersteKlantcontactInKetenAsync()` aan om het originele contactmoment-nummer te bepalen. Bij een API-fout wordt het nummer van het aanleidinggevend klantcontact als fallback gebruikt, met een warning log.
- **Overzicht**: `InterneTakenOverzichtService` gebruikt het `Nummer` van het reeds opgehaalde klantcontact als `OrigineleContactmomentNummer` — geen extra keten-lookup per overzichtitem.
- **Poller**: `InternetakenNotifier` injecteert `IKlantcontactService` en voert de keten-lookup uit vóór e-mailverwerking, zodat taak #374 het nummer kan gebruiken in e-mails.

## Test plan

- [x] Internetaak detail bevat het originele contactmoment-nummer
- [x] OrigineleContactmomentNummer bij meerdere contactmomenten in de keten
- [x] Fallback als keten niet bepaald kan worden
- [x] Overzicht bevat originele contactmoment-nummer per internetaak
- [x] Linting passes (`npm run lint:ci`)
- [x] Formatting passes (`npm run format:ci`)
- [x] Build succeeds (0 errors)

## Related

Closes #372
