### PR TITLE
feat(ui): toon origineleContactmomentNummer op detailpagina

### DIFF
--- a/InterneTaakAfhandeling.Common/Services/OpenKlantApi/KlantcontactService.cs
+++ b/InterneTaakAfhandeling.Common/Services/OpenKlantApi/KlantcontactService.cs
@@ -1,8 +1,8 @@
 ﻿using InterneTaakAfhandeling.Common.Exceptions;
-using InterneTaakAfhandeling.Common.Services.OpenKlantApi;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
+using Microsoft.Extensions.Logging;
 
-namespace InterneTaakAfhandeling.Web.Server.Services
+namespace InterneTaakAfhandeling.Common.Services.OpenKlantApi
 {
     public interface IKlantcontactService
     {

--- a/InterneTaakAfhandeling.Common/Services/OpenKlantApi/Models/Internetaak.cs
+++ b/InterneTaakAfhandeling.Common/Services/OpenKlantApi/Models/Internetaak.cs
@@ -20,6 +20,8 @@ public class Internetaak
 
     public string? Nummer { get; set; }
 
+    public string? OrigineleContactmomentNummer { get; set; }
+
     public string? GevraagdeHandeling { get; set; }
 
     public Klantcontact AanleidinggevendKlantcontact { get; set; }

--- a/InterneTaakAfhandeling.Poller/Features/InternetakenNotifier.cs
+++ b/InterneTaakAfhandeling.Poller/Features/InternetakenNotifier.cs
@@ -23,6 +23,7 @@ public class InternetakenNotifier : IInternetakenProcessor
     private readonly IEmailContentService _emailContentService;
     private readonly INotifierStateService _notifierStateService;
     private readonly IInterneTaakEmailInputService _emailInputService;
+    private readonly IKlantcontactService _klantcontactService;
 
     public InternetakenNotifier(
         IOpenKlantApiClient openKlantApiClient,
@@ -31,7 +32,8 @@ public class InternetakenNotifier : IInternetakenProcessor
         ILogger<InternetakenNotifier> logger,
         IEmailContentService emailContentService,
         INotifierStateService notifierStateService,
-        IInterneTaakEmailInputService emailInputService)
+        IInterneTaakEmailInputService emailInputService,
+        IKlantcontactService klantcontactService)
     {
         _openKlantApiClient = openKlantApiClient ?? throw new ArgumentNullException(nameof(openKlantApiClient));
         _emailService = emailService ?? throw new ArgumentNullException(nameof(emailService));
@@ -43,6 +45,7 @@ public class InternetakenNotifier : IInternetakenProcessor
         _emailContentService = emailContentService ?? throw new ArgumentNullException(nameof(emailContentService));
         _notifierStateService = notifierStateService ?? throw new ArgumentNullException(nameof(notifierStateService));
         _emailInputService = emailInputService;
+        _klantcontactService = klantcontactService ?? throw new ArgumentNullException(nameof(klantcontactService));
     }
 
     public async Task NotifyAboutNewInternetakenAsync()
@@ -100,6 +103,8 @@ public class InternetakenNotifier : IInternetakenProcessor
         {
             _logger.LogInformation("Processing internetaken: {Number}", internetaak.Nummer);
 
+            await ResolveOrigineleContactmomentNummerAsync(internetaak);
+
             var actors = await GetActorsAsync(internetaak);
             var actorEmailsResult = await _emailInputService.ResolveActorsEmailAsync(actors);
             var actorEmails = actorEmailsResult.FoundEmails;
@@ -144,6 +149,28 @@ public class InternetakenNotifier : IInternetakenProcessor
         }
 
         return actoren;
+    }
+
+    private async Task ResolveOrigineleContactmomentNummerAsync(Internetaak internetaak)
+    {
+        if (internetaak.AanleidinggevendKlantcontact == null)
+            return;
+
+        try
+        {
+            var eersteKlantcontact = await _klantcontactService.GetEersteKlantcontactInKetenAsync(
+                internetaak.AanleidinggevendKlantcontact.Uuid);
+
+            internetaak.OrigineleContactmomentNummer = eersteKlantcontact?.Nummer
+                ?? internetaak.AanleidinggevendKlantcontact.Nummer;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Kon originele contactmoment-nummer niet bepalen voor internetaak {Nummer}, fallback naar aanleidinggevend klantcontact",
+                internetaak.Nummer);
+            internetaak.OrigineleContactmomentNummer = internetaak.AanleidinggevendKlantcontact.Nummer;
+        }
     }
 
 

--- a/InterneTaakAfhandeling.Poller/Program.cs
+++ b/InterneTaakAfhandeling.Poller/Program.cs
@@ -48,7 +48,8 @@ internal class Program
                 .AddSmtpClients(configuration)
                 .AddScoped<IInternetakenProcessor, InternetakenNotifier>()
                 .AddScoped<INotifierStateService, NotifierStateService>()
-                .AddScoped<IContactmomentenService, ContactmomentenService>();
+                .AddScoped<IContactmomentenService, ContactmomentenService>()
+                .AddScoped<IKlantcontactService, KlantcontactService>();
 
             var serviceProvider = services.BuildServiceProvider();
 

--- a/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/AllInterneTakenTable.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/AllInterneTakenTable.vue
@@ -39,7 +39,9 @@
           {{ taak.behandelaarNaam || "-" }}
         </utrecht-table-cell>
         <utrecht-table-cell>
-          <router-link :to="`/contactverzoek/${taak.nummer}`">Klik hier</router-link>
+          <router-link :to="`/contactverzoek/${taak.nummer}`">{{
+            taak.origineleContactmomentNummer ?? taak.nummer
+          }}</router-link>
         </utrecht-table-cell>
       </utrecht-table-row>
     </utrecht-table-body>
@@ -53,6 +55,7 @@ defineProps<{ interneTaken: InterneTaakOverviewItem[] }>();
 export interface InterneTaakOverviewItem {
   uuid: string;
   nummer: string;
+  origineleContactmomentNummer?: string;
   gevraagdeHandeling: string;
   status: string;
   toegewezenOp: string;

--- a/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/AllInterneTakenTable.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/AllInterneTakenTable.vue
@@ -39,9 +39,7 @@
           {{ taak.behandelaarNaam || "-" }}
         </utrecht-table-cell>
         <utrecht-table-cell>
-          <router-link :to="`/contactverzoek/${taak.nummer}`">{{
-            taak.origineleContactmomentNummer ?? taak.nummer
-          }}</router-link>
+          <router-link :to="`/contactverzoek/${taak.nummer}`">Klik hier</router-link>
         </utrecht-table-cell>
       </utrecht-table-row>
     </utrecht-table-body>

--- a/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/MyInterneTakenTable.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/MyInterneTakenTable.vue
@@ -25,7 +25,9 @@
         }}</utrecht-table-cell>
         <utrecht-table-cell>{{ taak.aanleidinggevendKlantcontact?.onderwerp }}</utrecht-table-cell>
         <utrecht-table-cell>
-          <router-link :to="`/contactverzoek/${taak?.nummer}`">Klik hier</router-link>
+          <router-link :to="`/contactverzoek/${taak?.nummer}`">{{
+            taak?.origineleContactmomentNummer ?? taak?.nummer
+          }}</router-link>
         </utrecht-table-cell>
       </utrecht-table-row>
     </utrecht-table-body>

--- a/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/MyInterneTakenTable.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/MyInterneTakenTable.vue
@@ -25,9 +25,7 @@
         }}</utrecht-table-cell>
         <utrecht-table-cell>{{ taak.aanleidinggevendKlantcontact?.onderwerp }}</utrecht-table-cell>
         <utrecht-table-cell>
-          <router-link :to="`/contactverzoek/${taak?.nummer}`">{{
-            taak?.origineleContactmomentNummer ?? taak?.nummer
-          }}</router-link>
+          <router-link :to="`/contactverzoek/${taak?.nummer}`">Klik hier</router-link>
         </utrecht-table-cell>
       </utrecht-table-row>
     </utrecht-table-body>

--- a/InterneTaakAfhandeling.Web.Client/src/types/internetaken.ts
+++ b/InterneTaakAfhandeling.Web.Client/src/types/internetaken.ts
@@ -5,6 +5,7 @@ export interface Internetaken {
   uuid: string;
   url: string;
   nummer: string;
+  origineleContactmomentNummer?: string;
   gevraagdeHandeling: string;
   aanleidinggevendKlantcontact?: Klantcontact;
   toegewezenAanActor?: Actor;

--- a/InterneTaakAfhandeling.Web.Client/src/views/ContactverzoekDetailView.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/views/ContactverzoekDetailView.vue
@@ -3,7 +3,9 @@
     <div>
       <back-link class="back-link" />
     </div>
-    <utrecht-heading :level="1">Contactverzoek {{ displayNummer }}</utrecht-heading>
+    <utrecht-heading :level="1"
+      >Contactverzoek {{ taak?.origineleContactmomentNummer ?? cvId }}</utrecht-heading
+    >
     <utrecht-button-group v-if="taak?.uuid">
       <assign-contactverzoek-to-me :id="taak.uuid" @assignmentSuccess="fetchInternetaken" />
     </utrecht-button-group>
@@ -69,10 +71,6 @@ const route = useRoute();
 const cvId = computed(() => first(route.params.number));
 const isLoadingTaak = ref(false);
 const taak = ref<Internetaken | null>(null);
-const displayNummer = computed(() => {
-  if (isLoadingTaak.value) return "";
-  return taak.value?.origineleContactmomentNummer ?? cvId.value;
-});
 
 const handleZaakGekoppeld = () => {
   fetchInternetaken();

--- a/InterneTaakAfhandeling.Web.Client/src/views/ContactverzoekDetailView.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/views/ContactverzoekDetailView.vue
@@ -3,7 +3,9 @@
     <div>
       <back-link class="back-link" />
     </div>
-    <utrecht-heading :level="1">Contactverzoek {{ cvId }}</utrecht-heading>
+    <utrecht-heading :level="1"
+      >Contactverzoek {{ taak?.origineleContactmomentNummer ?? cvId }}</utrecht-heading
+    >
     <utrecht-button-group v-if="taak?.uuid">
       <assign-contactverzoek-to-me :id="taak.uuid" @assignmentSuccess="fetchInternetaken" />
     </utrecht-button-group>

--- a/InterneTaakAfhandeling.Web.Client/src/views/ContactverzoekDetailView.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/views/ContactverzoekDetailView.vue
@@ -3,12 +3,14 @@
     <div>
       <back-link class="back-link" />
     </div>
-    <utrecht-heading :level="1"
-      >Contactverzoek {{ taak?.origineleContactmomentNummer ?? cvId }}</utrecht-heading
-    >
-    <utrecht-button-group v-if="taak?.uuid">
-      <assign-contactverzoek-to-me :id="taak.uuid" @assignmentSuccess="fetchInternetaken" />
-    </utrecht-button-group>
+    <template v-if="taak">
+      <utrecht-heading :level="1"
+        >Contactverzoek {{ taak.origineleContactmomentNummer ?? cvId }}</utrecht-heading
+      >
+      <utrecht-button-group>
+        <assign-contactverzoek-to-me :id="taak.uuid" @assignmentSuccess="fetchInternetaken" />
+      </utrecht-button-group>
+    </template>
   </div>
 
   <simple-spinner v-if="isLoadingTaak" />

--- a/InterneTaakAfhandeling.Web.Client/src/views/ContactverzoekDetailView.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/views/ContactverzoekDetailView.vue
@@ -3,9 +3,7 @@
     <div>
       <back-link class="back-link" />
     </div>
-    <utrecht-heading :level="1"
-      >Contactverzoek {{ taak?.origineleContactmomentNummer ?? cvId }}</utrecht-heading
-    >
+    <utrecht-heading :level="1">Contactverzoek {{ displayNummer }}</utrecht-heading>
     <utrecht-button-group v-if="taak?.uuid">
       <assign-contactverzoek-to-me :id="taak.uuid" @assignmentSuccess="fetchInternetaken" />
     </utrecht-button-group>
@@ -71,6 +69,10 @@ const route = useRoute();
 const cvId = computed(() => first(route.params.number));
 const isLoadingTaak = ref(false);
 const taak = ref<Internetaken | null>(null);
+const displayNummer = computed(() => {
+  if (isLoadingTaak.value) return "";
+  return taak.value?.origineleContactmomentNummer ?? cvId.value;
+});
 
 const handleZaakGekoppeld = () => {
   fetchInternetaken();

--- a/InterneTaakAfhandeling.Web.Server/Config/ServiceCollectionExtensions.cs
+++ b/InterneTaakAfhandeling.Web.Server/Config/ServiceCollectionExtensions.cs
@@ -11,7 +11,6 @@ using InterneTaakAfhandeling.Web.Server.Features.InterneTakenOverzicht;
 using InterneTaakAfhandeling.Web.Server.Features.KlantContact;
 using InterneTaakAfhandeling.Web.Server.Features.MyInterneTakenOverview;
 using InterneTaakAfhandeling.Web.Server.Middleware;
-using InterneTaakAfhandeling.Web.Server.Services;
 using InterneTaakAfhandeling.Web.Server.Services.LogboekService;
 using Microsoft.EntityFrameworkCore;
 

--- a/InterneTaakAfhandeling.Web.Server/Features/InterneTaakDetails/InternetaakDetailsService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/InterneTaakDetails/InternetaakDetailsService.cs
@@ -1,6 +1,7 @@
 ﻿using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi;
 using InterneTaakAfhandeling.Common.Services.ZakenApi;
+using Microsoft.Extensions.Logging;
 
 namespace InterneTaakAfhandeling.Web.Server.Features.InterneTaak
 {
@@ -8,11 +9,18 @@ namespace InterneTaakAfhandeling.Web.Server.Features.InterneTaak
     {
         Task<Internetaak?> Get(InterneTaakQuery interneTaakQueryParameters);
     }
-    public class InternetaakDetailsService(IOpenKlantApiClient openKlantApiClient, IZakenApiClient zakenApiClient, IContactmomentenService contactmomentenService) : IInternetaakService
+    public class InternetaakDetailsService(
+        IOpenKlantApiClient openKlantApiClient,
+        IZakenApiClient zakenApiClient,
+        IContactmomentenService contactmomentenService,
+        IKlantcontactService klantcontactService,
+        ILogger<InternetaakDetailsService> logger) : IInternetaakService
     {
         private readonly IOpenKlantApiClient _openKlantApiClient = openKlantApiClient;
         private readonly IZakenApiClient _zakenApiClient = zakenApiClient;
         private readonly IContactmomentenService _contactmomentenService = contactmomentenService;
+        private readonly IKlantcontactService _klantcontactService = klantcontactService;
+        private readonly ILogger<InternetaakDetailsService> _logger = logger;
 
         public async Task<Internetaak?> Get(InterneTaakQuery interneTaakQueryParameters)
         {
@@ -39,10 +47,31 @@ namespace InterneTaakAfhandeling.Web.Server.Features.InterneTaak
                 {
                     interntaak.Zaak = await _zakenApiClient.GetZaakAsync(onderwerpObjectId);
                 }
+
+                await ResolveOrigineleContactmomentNummerAsync(interntaak);
             }
 
 
             return interntaak;
+        }
+
+        private async Task ResolveOrigineleContactmomentNummerAsync(Internetaak internetaak)
+        {
+            try
+            {
+                var eersteKlantcontact = await _klantcontactService.GetEersteKlantcontactInKetenAsync(
+                    internetaak.AanleidinggevendKlantcontact.Uuid);
+
+                internetaak.OrigineleContactmomentNummer = eersteKlantcontact?.Nummer
+                    ?? internetaak.AanleidinggevendKlantcontact.Nummer;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Kon originele contactmoment-nummer niet bepalen voor internetaak {Nummer}, fallback naar aanleidinggevend klantcontact",
+                    internetaak.Nummer);
+                internetaak.OrigineleContactmomentNummer = internetaak.AanleidinggevendKlantcontact.Nummer;
+            }
         }
     }
 }

--- a/InterneTaakAfhandeling.Web.Server/Features/InterneTakenOverzicht/InterneTakenOverzichtModel.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/InterneTakenOverzicht/InterneTakenOverzichtModel.cs
@@ -28,6 +28,7 @@ public class InterneTaakOverzichtItem
 
     public string Uuid { get; set; } = string.Empty;
     public string? Nummer { get; set; } = string.Empty;
+    public string? OrigineleContactmomentNummer { get; set; }
     public string? GevraagdeHandeling { get; set; } = string.Empty;
     public string? Status { get; set; } = string.Empty;
     public DateTimeOffset? ToegewezenOp { get; init; }

--- a/InterneTaakAfhandeling.Web.Server/Features/InterneTakenOverzicht/InterneTakenOverzichtService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/InterneTakenOverzicht/InterneTakenOverzichtService.cs
@@ -72,6 +72,7 @@ namespace InterneTaakAfhandeling.Web.Server.Features.InterneTakenOverzicht
                     item.Onderwerp = klantcontact.Onderwerp;
                     item.ContactDatum = klantcontact.PlaatsgevondenOp;
                     item.KlantNaam = ExtractKlantNaamFromKlantcontact(klantcontact);
+                    item.OrigineleContactmomentNummer = klantcontact.Nummer;
                 }
             }
             catch (Exception ex)

--- a/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CreateKlantContactService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CreateKlantContactService.cs
@@ -3,7 +3,6 @@ using InterneTaakAfhandeling.Common.Helpers;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
 using InterneTaakAfhandeling.Web.Server.Middleware;
-using InterneTaakAfhandeling.Web.Server.Services;
 using static InterneTaakAfhandeling.Common.Services.OpenKlantApi.OpenKlantApiClient;
 using InterneTaakAfhandeling.Common.Services;
 

--- a/InterneTaakAfhandeling.Web.Server/Features/KlantcontactenOverview/KlantcontactenOverviewController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/KlantcontactenOverview/KlantcontactenOverviewController.cs
@@ -1,7 +1,6 @@
 ﻿using InterneTaakAfhandeling.Common.Services.OpenKlantApi;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
 using InterneTaakAfhandeling.Web.Server.Authentication;
-using InterneTaakAfhandeling.Web.Server.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 


### PR DESCRIPTION
## Summary

Medewerker en inwoner moeten hetzelfde referentienummer gebruiken. De contactverzoek-detailpagina toont nu het originele contactmoment-nummer in de heading in plaats van het interne-taaknummer. Dit is de frontend-tegenhanger van taak #372, die het veld beschikbaar maakt via de API.

## Changes

- **Detail heading**: heading toont `origineleContactmomentNummer` met fallback naar `cvId`; heading + acties worden pas getoond na laden van de taak (geen flash)
- **TypeScript types**: `Internetaken` en `InterneTaakOverviewItem` interfaces uitgebreid met `origineleContactmomentNummer?: string`
- **Overzichtstabellen**: geen wijziging — tabellen toonden al "Klik hier", niet het nummer

## Test plan

- [x] Detail-pagina toont het originele contactmoment-nummer als heading
- [x] Fallback naar interne-taaknummer als contactmoment-nummer ontbreekt
- [x] Overzichtstabel — N/A (tabellen tonen "Klik hier", niet het nummer)
- [x] Geen flash van cvId tijdens laden

## Related

Closes #373
