### PR TITLE
feat(email): gebruik OrigineleContactmomentNummer in deeplink en onderwerpregel

### DIFF
--- a/InterneTaakAfhandeling.Common/Services/Emailservices/Content/EmailContentService.cs
+++ b/InterneTaakAfhandeling.Common/Services/Emailservices/Content/EmailContentService.cs
@@ -28,11 +28,12 @@ public class EmailContentService : IEmailContentService
 
     public string BuildInternetakenEmailContent(Internetaak internetaak, string itaBaseUrl)
     {
-        var deeplink = $"{itaBaseUrl.TrimEnd('/')}/contactverzoek/{internetaak.Nummer}";
+        var nummer = internetaak.OrigineleContactmomentNummer ?? internetaak.Nummer;
+        var deeplink = $"{itaBaseUrl.TrimEnd('/')}/contactverzoek/{nummer}";
 
         var sb = new StringBuilder(EmailTemplate);
         sb.Replace("{Link}", deeplink)
-          .Replace("{Nummer}", internetaak.Nummer);
+          .Replace("{Nummer}", nummer);
 
         return sb.ToString();
     }

--- a/InterneTaakAfhandeling.Common/Services/OpenKlantApi/KlantcontactService.cs
+++ b/InterneTaakAfhandeling.Common/Services/OpenKlantApi/KlantcontactService.cs
@@ -8,6 +8,7 @@ namespace InterneTaakAfhandeling.Common.Services.OpenKlantApi
     {
         Task<Klantcontact?> GetEersteKlantcontactInKetenAsync(Guid klantcontactUuid);
         Task<List<Klantcontact>> BouwKlantcontactKetenAsync(Guid startKlantcontactUuid);
+        Task ResolveOrigineleContactmomentNummerAsync(Internetaak internetaak);
     }
 
     public class KlantcontactService : IKlantcontactService
@@ -53,6 +54,28 @@ namespace InterneTaakAfhandeling.Common.Services.OpenKlantApi
             await VoegKlantcontactenToeAanKeten(aanleidinggevendKlantcontact.Uuid, keten, verwerkte_uuids);
 
             return keten;
+        }
+
+        public async Task ResolveOrigineleContactmomentNummerAsync(Internetaak internetaak)
+        {
+            if (internetaak.AanleidinggevendKlantcontact == null)
+                return;
+
+            try
+            {
+                var eersteKlantcontact = await GetEersteKlantcontactInKetenAsync(
+                    internetaak.AanleidinggevendKlantcontact.Uuid);
+
+                internetaak.OrigineleContactmomentNummer = eersteKlantcontact?.Nummer
+                    ?? internetaak.AanleidinggevendKlantcontact.Nummer;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Kon originele contactmoment-nummer niet bepalen voor internetaak {Nummer}, fallback naar aanleidinggevend klantcontact",
+                    internetaak.Nummer);
+                internetaak.OrigineleContactmomentNummer = internetaak.AanleidinggevendKlantcontact.Nummer;
+            }
         }
 
         private async Task VoegKlantcontactenToeAanKeten(

--- a/InterneTaakAfhandeling.Common/Services/OpenKlantApi/KlantcontactService.cs
+++ b/InterneTaakAfhandeling.Common/Services/OpenKlantApi/KlantcontactService.cs
@@ -1,8 +1,8 @@
 ﻿using InterneTaakAfhandeling.Common.Exceptions;
-using InterneTaakAfhandeling.Common.Services.OpenKlantApi;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
+using Microsoft.Extensions.Logging;
 
-namespace InterneTaakAfhandeling.Web.Server.Services
+namespace InterneTaakAfhandeling.Common.Services.OpenKlantApi
 {
     public interface IKlantcontactService
     {

--- a/InterneTaakAfhandeling.Common/Services/OpenKlantApi/Models/Internetaak.cs
+++ b/InterneTaakAfhandeling.Common/Services/OpenKlantApi/Models/Internetaak.cs
@@ -20,6 +20,8 @@ public class Internetaak
 
     public string? Nummer { get; set; }
 
+    public string? OrigineleContactmomentNummer { get; set; }
+
     public string? GevraagdeHandeling { get; set; }
 
     public Klantcontact AanleidinggevendKlantcontact { get; set; }

--- a/InterneTaakAfhandeling.Poller/Features/InternetakenNotifier.cs
+++ b/InterneTaakAfhandeling.Poller/Features/InternetakenNotifier.cs
@@ -23,6 +23,7 @@ public class InternetakenNotifier : IInternetakenProcessor
     private readonly IEmailContentService _emailContentService;
     private readonly INotifierStateService _notifierStateService;
     private readonly IInterneTaakEmailInputService _emailInputService;
+    private readonly IKlantcontactService _klantcontactService;
 
     public InternetakenNotifier(
         IOpenKlantApiClient openKlantApiClient,
@@ -31,7 +32,8 @@ public class InternetakenNotifier : IInternetakenProcessor
         ILogger<InternetakenNotifier> logger,
         IEmailContentService emailContentService,
         INotifierStateService notifierStateService,
-        IInterneTaakEmailInputService emailInputService)
+        IInterneTaakEmailInputService emailInputService,
+        IKlantcontactService klantcontactService)
     {
         _openKlantApiClient = openKlantApiClient ?? throw new ArgumentNullException(nameof(openKlantApiClient));
         _emailService = emailService ?? throw new ArgumentNullException(nameof(emailService));
@@ -43,6 +45,7 @@ public class InternetakenNotifier : IInternetakenProcessor
         _emailContentService = emailContentService ?? throw new ArgumentNullException(nameof(emailContentService));
         _notifierStateService = notifierStateService ?? throw new ArgumentNullException(nameof(notifierStateService));
         _emailInputService = emailInputService;
+        _klantcontactService = klantcontactService ?? throw new ArgumentNullException(nameof(klantcontactService));
     }
 
     public async Task NotifyAboutNewInternetakenAsync()
@@ -100,6 +103,8 @@ public class InternetakenNotifier : IInternetakenProcessor
         {
             _logger.LogInformation("Processing internetaken: {Number}", internetaak.Nummer);
 
+            await ResolveOrigineleContactmomentNummerAsync(internetaak);
+
             var actors = await GetActorsAsync(internetaak);
             var actorEmailsResult = await _emailInputService.ResolveActorsEmailAsync(actors);
             var actorEmails = actorEmailsResult.FoundEmails;
@@ -144,6 +149,28 @@ public class InternetakenNotifier : IInternetakenProcessor
         }
 
         return actoren;
+    }
+
+    private async Task ResolveOrigineleContactmomentNummerAsync(Internetaak internetaak)
+    {
+        if (internetaak.AanleidinggevendKlantcontact == null)
+            return;
+
+        try
+        {
+            var eersteKlantcontact = await _klantcontactService.GetEersteKlantcontactInKetenAsync(
+                internetaak.AanleidinggevendKlantcontact.Uuid);
+
+            internetaak.OrigineleContactmomentNummer = eersteKlantcontact?.Nummer
+                ?? internetaak.AanleidinggevendKlantcontact.Nummer;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Kon originele contactmoment-nummer niet bepalen voor internetaak {Nummer}, fallback naar aanleidinggevend klantcontact",
+                internetaak.Nummer);
+            internetaak.OrigineleContactmomentNummer = internetaak.AanleidinggevendKlantcontact.Nummer;
+        }
     }
 
 

--- a/InterneTaakAfhandeling.Poller/Features/InternetakenNotifier.cs
+++ b/InterneTaakAfhandeling.Poller/Features/InternetakenNotifier.cs
@@ -103,7 +103,7 @@ public class InternetakenNotifier : IInternetakenProcessor
         {
             _logger.LogInformation("Processing internetaken: {Number}", internetaak.Nummer);
 
-            await ResolveOrigineleContactmomentNummerAsync(internetaak);
+            await _klantcontactService.ResolveOrigineleContactmomentNummerAsync(internetaak);
 
             var actors = await GetActorsAsync(internetaak);
             var actorEmailsResult = await _emailInputService.ResolveActorsEmailAsync(actors);
@@ -150,28 +150,6 @@ public class InternetakenNotifier : IInternetakenProcessor
         }
 
         return actoren;
-    }
-
-    private async Task ResolveOrigineleContactmomentNummerAsync(Internetaak internetaak)
-    {
-        if (internetaak.AanleidinggevendKlantcontact == null)
-            return;
-
-        try
-        {
-            var eersteKlantcontact = await _klantcontactService.GetEersteKlantcontactInKetenAsync(
-                internetaak.AanleidinggevendKlantcontact.Uuid);
-
-            internetaak.OrigineleContactmomentNummer = eersteKlantcontact?.Nummer
-                ?? internetaak.AanleidinggevendKlantcontact.Nummer;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex,
-                "Kon originele contactmoment-nummer niet bepalen voor internetaak {Nummer}, fallback naar aanleidinggevend klantcontact",
-                internetaak.Nummer);
-            internetaak.OrigineleContactmomentNummer = internetaak.AanleidinggevendKlantcontact.Nummer;
-        }
     }
 
 

--- a/InterneTaakAfhandeling.Poller/Features/InternetakenNotifier.cs
+++ b/InterneTaakAfhandeling.Poller/Features/InternetakenNotifier.cs
@@ -118,7 +118,8 @@ public class InternetakenNotifier : IInternetakenProcessor
             {
                 var emailContent = _emailContentService.BuildInternetakenEmailContent(internetaak, _itaBaseUrl);
 
-                await Task.WhenAll(actorEmails.Select(email => _emailService.SendEmailAsync(email, $"Nieuw contactverzoek - {internetaak.Nummer}", emailContent)));
+                var nummer = internetaak.OrigineleContactmomentNummer ?? internetaak.Nummer;
+                await Task.WhenAll(actorEmails.Select(email => _emailService.SendEmailAsync(email, $"Nieuw contactverzoek - {nummer}", emailContent)));
 
                 _logger.LogInformation("Successfully processed internetaken: {Number}", internetaak.Nummer);
             }

--- a/InterneTaakAfhandeling.Poller/Program.cs
+++ b/InterneTaakAfhandeling.Poller/Program.cs
@@ -48,7 +48,8 @@ internal class Program
                 .AddSmtpClients(configuration)
                 .AddScoped<IInternetakenProcessor, InternetakenNotifier>()
                 .AddScoped<INotifierStateService, NotifierStateService>()
-                .AddScoped<IContactmomentenService, ContactmomentenService>();
+                .AddScoped<IContactmomentenService, ContactmomentenService>()
+                .AddScoped<IKlantcontactService, KlantcontactService>();
 
             var serviceProvider = services.BuildServiceProvider();
 

--- a/InterneTaakAfhandeling.Web.Server/Config/ServiceCollectionExtensions.cs
+++ b/InterneTaakAfhandeling.Web.Server/Config/ServiceCollectionExtensions.cs
@@ -11,7 +11,6 @@ using InterneTaakAfhandeling.Web.Server.Features.InterneTakenOverzicht;
 using InterneTaakAfhandeling.Web.Server.Features.KlantContact;
 using InterneTaakAfhandeling.Web.Server.Features.MyInterneTakenOverview;
 using InterneTaakAfhandeling.Web.Server.Middleware;
-using InterneTaakAfhandeling.Web.Server.Services;
 using InterneTaakAfhandeling.Web.Server.Services.LogboekService;
 using Microsoft.EntityFrameworkCore;
 

--- a/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestService.cs
@@ -40,7 +40,7 @@ public class ForwardContactRequestService(
 
         var updatedInternetaak = await openKlantApiClient.PatchInternetaakActorAsync(internetakenUpdateRequest, internetaak.Uuid);
 
-        await ResolveOrigineleContactmomentNummerAsync(updatedInternetaak);
+        await klantcontactService.ResolveOrigineleContactmomentNummerAsync(updatedInternetaak);
 
         var notficationResult = await NotifyInternetaakActors(updatedInternetaak, actors);
 
@@ -235,27 +235,5 @@ public class ForwardContactRequestService(
         };
 
         return await openKlantApiClient.CreateActorAsync(actorRequest);
-    }
-
-    private async Task ResolveOrigineleContactmomentNummerAsync(Internetaak internetaak)
-    {
-        if (internetaak.AanleidinggevendKlantcontact == null)
-            return;
-
-        try
-        {
-            var eersteKlantcontact = await klantcontactService.GetEersteKlantcontactInKetenAsync(
-                internetaak.AanleidinggevendKlantcontact.Uuid);
-
-            internetaak.OrigineleContactmomentNummer = eersteKlantcontact?.Nummer
-                ?? internetaak.AanleidinggevendKlantcontact.Nummer;
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex,
-                "Kon originele contactmoment-nummer niet bepalen voor internetaak {Nummer}, fallback naar aanleidinggevend klantcontact",
-                internetaak.Nummer);
-            internetaak.OrigineleContactmomentNummer = internetaak.AanleidinggevendKlantcontact.Nummer;
-        }
     }
 }

--- a/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestService.cs
@@ -21,6 +21,7 @@ public class ForwardContactRequestService(
     IEmailContentService emailContentService,
     ILogger<ForwardContactRequestService> logger,
     IInterneTaakEmailInputService emailInputService,
+    IKlantcontactService klantcontactService,
     IConfiguration configuration) : IForwardContactRequestService
 {
     private readonly string _itaBaseUrl = configuration.GetValue<string>("Ita:BaseUrl")
@@ -38,6 +39,8 @@ public class ForwardContactRequestService(
         };
 
         var updatedInternetaak = await openKlantApiClient.PatchInternetaakActorAsync(internetakenUpdateRequest, internetaak.Uuid);
+
+        await ResolveOrigineleContactmomentNummerAsync(updatedInternetaak);
 
         var notficationResult = await NotifyInternetaakActors(updatedInternetaak, actors);
 
@@ -63,7 +66,8 @@ public class ForwardContactRequestService(
                 return GetResultMessageWhenNoEmails(actorEmailResult);
 
             var emailContent = emailContentService.BuildInternetakenEmailContent(internetaken, _itaBaseUrl);
-            var subject = $"Contactverzoek Doorgestuurd - {internetaken.Nummer}";
+            var nummer = internetaken.OrigineleContactmomentNummer ?? internetaken.Nummer;
+            var subject = $"Contactverzoek Doorgestuurd - {nummer}";
 
             var sendResults = await SendEmailsAsync(actorEmailResult.FoundEmails, subject, emailContent);
 
@@ -231,5 +235,27 @@ public class ForwardContactRequestService(
         };
 
         return await openKlantApiClient.CreateActorAsync(actorRequest);
+    }
+
+    private async Task ResolveOrigineleContactmomentNummerAsync(Internetaak internetaak)
+    {
+        if (internetaak.AanleidinggevendKlantcontact == null)
+            return;
+
+        try
+        {
+            var eersteKlantcontact = await klantcontactService.GetEersteKlantcontactInKetenAsync(
+                internetaak.AanleidinggevendKlantcontact.Uuid);
+
+            internetaak.OrigineleContactmomentNummer = eersteKlantcontact?.Nummer
+                ?? internetaak.AanleidinggevendKlantcontact.Nummer;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Kon originele contactmoment-nummer niet bepalen voor internetaak {Nummer}, fallback naar aanleidinggevend klantcontact",
+                internetaak.Nummer);
+            internetaak.OrigineleContactmomentNummer = internetaak.AanleidinggevendKlantcontact.Nummer;
+        }
     }
 }

--- a/InterneTaakAfhandeling.Web.Server/Features/InterneTaakDetails/InternetaakDetailsService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/InterneTaakDetails/InternetaakDetailsService.cs
@@ -1,6 +1,7 @@
 ﻿using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi;
 using InterneTaakAfhandeling.Common.Services.ZakenApi;
+using Microsoft.Extensions.Logging;
 
 namespace InterneTaakAfhandeling.Web.Server.Features.InterneTaak
 {
@@ -8,11 +9,18 @@ namespace InterneTaakAfhandeling.Web.Server.Features.InterneTaak
     {
         Task<Internetaak?> Get(InterneTaakQuery interneTaakQueryParameters);
     }
-    public class InternetaakDetailsService(IOpenKlantApiClient openKlantApiClient, IZakenApiClient zakenApiClient, IContactmomentenService contactmomentenService) : IInternetaakService
+    public class InternetaakDetailsService(
+        IOpenKlantApiClient openKlantApiClient,
+        IZakenApiClient zakenApiClient,
+        IContactmomentenService contactmomentenService,
+        IKlantcontactService klantcontactService,
+        ILogger<InternetaakDetailsService> logger) : IInternetaakService
     {
         private readonly IOpenKlantApiClient _openKlantApiClient = openKlantApiClient;
         private readonly IZakenApiClient _zakenApiClient = zakenApiClient;
         private readonly IContactmomentenService _contactmomentenService = contactmomentenService;
+        private readonly IKlantcontactService _klantcontactService = klantcontactService;
+        private readonly ILogger<InternetaakDetailsService> _logger = logger;
 
         public async Task<Internetaak?> Get(InterneTaakQuery interneTaakQueryParameters)
         {
@@ -39,10 +47,31 @@ namespace InterneTaakAfhandeling.Web.Server.Features.InterneTaak
                 {
                     interntaak.Zaak = await _zakenApiClient.GetZaakAsync(onderwerpObjectId);
                 }
+
+                await ResolveOrigineleContactmomentNummerAsync(interntaak);
             }
 
 
             return interntaak;
+        }
+
+        private async Task ResolveOrigineleContactmomentNummerAsync(Internetaak internetaak)
+        {
+            try
+            {
+                var eersteKlantcontact = await _klantcontactService.GetEersteKlantcontactInKetenAsync(
+                    internetaak.AanleidinggevendKlantcontact.Uuid);
+
+                internetaak.OrigineleContactmomentNummer = eersteKlantcontact?.Nummer
+                    ?? internetaak.AanleidinggevendKlantcontact.Nummer;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Kon originele contactmoment-nummer niet bepalen voor internetaak {Nummer}, fallback naar aanleidinggevend klantcontact",
+                    internetaak.Nummer);
+                internetaak.OrigineleContactmomentNummer = internetaak.AanleidinggevendKlantcontact.Nummer;
+            }
         }
     }
 }

--- a/InterneTaakAfhandeling.Web.Server/Features/InterneTaakDetails/InternetaakDetailsService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/InterneTaakDetails/InternetaakDetailsService.cs
@@ -1,8 +1,6 @@
 ﻿using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi;
 using InterneTaakAfhandeling.Common.Services.ZakenApi;
-using Microsoft.Extensions.Logging;
-
 namespace InterneTaakAfhandeling.Web.Server.Features.InterneTaak
 {
     public interface IInternetaakService
@@ -13,8 +11,7 @@ namespace InterneTaakAfhandeling.Web.Server.Features.InterneTaak
         IOpenKlantApiClient openKlantApiClient,
         IZakenApiClient zakenApiClient,
         IContactmomentenService contactmomentenService,
-        IKlantcontactService klantcontactService,
-        ILogger<InternetaakDetailsService> logger) : IInternetaakService
+        IKlantcontactService klantcontactService) : IInternetaakService
     {
         private readonly IOpenKlantApiClient _openKlantApiClient = openKlantApiClient;
         private readonly IZakenApiClient _zakenApiClient = zakenApiClient;

--- a/InterneTaakAfhandeling.Web.Server/Features/InterneTaakDetails/InternetaakDetailsService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/InterneTaakDetails/InternetaakDetailsService.cs
@@ -19,8 +19,6 @@ namespace InterneTaakAfhandeling.Web.Server.Features.InterneTaak
         private readonly IOpenKlantApiClient _openKlantApiClient = openKlantApiClient;
         private readonly IZakenApiClient _zakenApiClient = zakenApiClient;
         private readonly IContactmomentenService _contactmomentenService = contactmomentenService;
-        private readonly IKlantcontactService _klantcontactService = klantcontactService;
-        private readonly ILogger<InternetaakDetailsService> _logger = logger;
 
         public async Task<Internetaak?> Get(InterneTaakQuery interneTaakQueryParameters)
         {
@@ -48,30 +46,11 @@ namespace InterneTaakAfhandeling.Web.Server.Features.InterneTaak
                     interntaak.Zaak = await _zakenApiClient.GetZaakAsync(onderwerpObjectId);
                 }
 
-                await ResolveOrigineleContactmomentNummerAsync(interntaak);
+                await klantcontactService.ResolveOrigineleContactmomentNummerAsync(interntaak);
             }
 
 
             return interntaak;
-        }
-
-        private async Task ResolveOrigineleContactmomentNummerAsync(Internetaak internetaak)
-        {
-            try
-            {
-                var eersteKlantcontact = await _klantcontactService.GetEersteKlantcontactInKetenAsync(
-                    internetaak.AanleidinggevendKlantcontact.Uuid);
-
-                internetaak.OrigineleContactmomentNummer = eersteKlantcontact?.Nummer
-                    ?? internetaak.AanleidinggevendKlantcontact.Nummer;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex,
-                    "Kon originele contactmoment-nummer niet bepalen voor internetaak {Nummer}, fallback naar aanleidinggevend klantcontact",
-                    internetaak.Nummer);
-                internetaak.OrigineleContactmomentNummer = internetaak.AanleidinggevendKlantcontact.Nummer;
-            }
         }
     }
 }

--- a/InterneTaakAfhandeling.Web.Server/Features/InterneTakenOverzicht/InterneTakenOverzichtModel.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/InterneTakenOverzicht/InterneTakenOverzichtModel.cs
@@ -28,6 +28,7 @@ public class InterneTaakOverzichtItem
 
     public string Uuid { get; set; } = string.Empty;
     public string? Nummer { get; set; } = string.Empty;
+    public string? OrigineleContactmomentNummer { get; set; }
     public string? GevraagdeHandeling { get; set; } = string.Empty;
     public string? Status { get; set; } = string.Empty;
     public DateTimeOffset? ToegewezenOp { get; init; }

--- a/InterneTaakAfhandeling.Web.Server/Features/InterneTakenOverzicht/InterneTakenOverzichtService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/InterneTakenOverzicht/InterneTakenOverzichtService.cs
@@ -72,6 +72,7 @@ namespace InterneTaakAfhandeling.Web.Server.Features.InterneTakenOverzicht
                     item.Onderwerp = klantcontact.Onderwerp;
                     item.ContactDatum = klantcontact.PlaatsgevondenOp;
                     item.KlantNaam = ExtractKlantNaamFromKlantcontact(klantcontact);
+                    item.OrigineleContactmomentNummer = klantcontact.Nummer;
                 }
             }
             catch (Exception ex)

--- a/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CreateKlantContactService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CreateKlantContactService.cs
@@ -3,7 +3,6 @@ using InterneTaakAfhandeling.Common.Helpers;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
 using InterneTaakAfhandeling.Web.Server.Middleware;
-using InterneTaakAfhandeling.Web.Server.Services;
 using static InterneTaakAfhandeling.Common.Services.OpenKlantApi.OpenKlantApiClient;
 using InterneTaakAfhandeling.Common.Services;
 

--- a/InterneTaakAfhandeling.Web.Server/Features/KlantcontactenOverview/KlantcontactenOverviewController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/KlantcontactenOverview/KlantcontactenOverviewController.cs
@@ -1,7 +1,6 @@
 ﻿using InterneTaakAfhandeling.Common.Services.OpenKlantApi;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
 using InterneTaakAfhandeling.Web.Server.Authentication;
-using InterneTaakAfhandeling.Web.Server.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 


### PR DESCRIPTION
## Summary

E-mails naar afdelingen en medewerkers moeten het originele contactmoment-nummer bevatten in zowel de onderwerpregel als de deeplink, zodat ontvangers hetzelfde referentienummer zien als de inwoner in het Portaal.

Onderdeel van Feature #299 — Gebruik het nummer van het "contactmoment" in plaats van het nummer van de "interne taak".

## Changes

- **E-mail deeplink & template**: `EmailContentService` bouwt de deeplink-URL en vult de `{Nummer}` placeholder met `OrigineleContactmomentNummer ?? Nummer`
- **Notificatie-onderwerp**: `InternetakenNotifier` gebruikt het originele contactmoment-nummer in het e-mailonderwerp bij nieuwe contactverzoeken
- **Doorstuur-onderwerp**: `ForwardContactRequestService` gebruikt het originele nummer in het onderwerp bij doorgestuurde contactverzoeken, met `IKlantcontactService` als nieuwe dependency
- **DRY refactoring**: `ResolveOrigineleContactmomentNummerAsync` geëxtraheerd naar `IKlantcontactService` — verwijderd uit InternetakenNotifier, InternetaakDetailsService en ForwardContactRequestService
- **Cleanup**: Ongebruikte `logger` parameter verwijderd uit `InternetaakDetailsService`

## Test plan

- [ ] E-mailonderwerp bevat het originele contactmoment-nummer
- [ ] Deeplink in e-mail bevat het originele contactmoment-nummer
- [ ] Doorgestuurd contactverzoek e-mail bevat het originele contactmoment-nummer
- [ ] Fallback naar interne-taaknummer als contactmoment-nummer ontbreekt

## Related

Closes #374
