### PR TITLE
feat(internetaak): expose AanleidinggevendKlantcontact.Nummer in all code paths

### DIFF
--- a/InterneTaakAfhandeling.Poller/Features/InternetakenNotifier.cs
+++ b/InterneTaakAfhandeling.Poller/Features/InternetakenNotifier.cs
@@ -100,6 +100,11 @@ public class InternetakenNotifier : IInternetakenProcessor
         {
             _logger.LogInformation("Processing internetaken: {Number}", internetaak.Nummer);
 
+            if (internetaak.AanleidinggevendKlantcontact?.Uuid != null)
+            {
+                internetaak.AanleidinggevendKlantcontact = await _openKlantApiClient.GetKlantcontactAsync(internetaak.AanleidinggevendKlantcontact.Uuid);
+            }
+
             var actors = await GetActorsAsync(internetaak);
             var actorEmailsResult = await _emailInputService.ResolveActorsEmailAsync(actors);
             var actorEmails = actorEmailsResult.FoundEmails;

--- a/InterneTaakAfhandeling.Web.Server/Features/InterneTaakDetails/InternetaakDetailsController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/InterneTaakDetails/InternetaakDetailsController.cs
@@ -14,24 +14,62 @@ namespace InterneTaakAfhandeling.Web.Server.Features.Internetaken
         private readonly IInternetaakService _internetakenService = internetakenService;
 
         [ProducesResponseType(typeof(Internetaak), StatusCodes.Status200OK)]
-        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
         [HttpGet("{internetaakNummer}")]
-
-        //todo: refactor to use Id instead of nummer
         public async Task<IActionResult> Get([FromRoute] string internetaakNummer)
         {
             var interneTaakQueryParameters = new InterneTaakQuery { Nummer = internetaakNummer };
             var internetaak = await _internetakenService.Get(interneTaakQueryParameters);
 
-            if (internetaak == null) {
-                NotFound(new ProblemDetails
+            if (internetaak == null)
+            {
+                return NotFound(new ProblemDetails
                 {
                     Title = "Interne taak niet gevonden",
                     Detail = $"Geen interne taak gevonden met identificatie: {interneTaakQueryParameters.Nummer}",
                     Status = StatusCodes.Status404NotFound
                 });
-            };
+            }
 
+            if (internetaak.AanleidinggevendKlantcontact?.Nummer == null)
+            {
+                return Conflict(new ProblemDetails
+                {
+                    Title = "Contactmoment-nummer ontbreekt",
+                    Detail = "Het aanleidinggevend klantcontact heeft geen nummer. Dit is een foutsituatie.",
+                    Status = StatusCodes.Status409Conflict
+                });
+            }
+
+            return Ok(internetaak);
+        }
+
+        [ProducesResponseType(typeof(Internetaak), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [HttpGet("by-klantcontact/{nummer}")]
+        public async Task<IActionResult> GetByKlantcontactNummer([FromRoute] string nummer)
+        {
+            var internetaak = await _internetakenService.GetByKlantcontactNummer(nummer);
+
+            if (internetaak == null)
+            {
+                return NotFound(new ProblemDetails
+                {
+                    Title = "Interne taak niet gevonden",
+                    Detail = $"Geen interne taak gevonden voor klantcontact met nummer: {nummer}",
+                    Status = StatusCodes.Status404NotFound
+                });
+            }
+
+            if (internetaak.AanleidinggevendKlantcontact?.Nummer == null)
+            {
+                return Conflict(new ProblemDetails
+                {
+                    Title = "Contactmoment-nummer ontbreekt",
+                    Detail = "Het aanleidinggevend klantcontact heeft geen nummer. Dit is een foutsituatie.",
+                    Status = StatusCodes.Status409Conflict
+                });
+            }
 
             return Ok(internetaak);
         }

--- a/InterneTaakAfhandeling.Web.Server/Features/InterneTaakDetails/InternetaakDetailsController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/InterneTaakDetails/InternetaakDetailsController.cs
@@ -15,6 +15,7 @@ namespace InterneTaakAfhandeling.Web.Server.Features.Internetaken
 
         [ProducesResponseType(typeof(Internetaak), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
         [HttpGet("{internetaakNummer}")]
         public async Task<IActionResult> Get([FromRoute] string internetaakNummer)
         {
@@ -46,6 +47,7 @@ namespace InterneTaakAfhandeling.Web.Server.Features.Internetaken
 
         [ProducesResponseType(typeof(Internetaak), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
         [HttpGet("by-klantcontact/{nummer}")]
         public async Task<IActionResult> GetByKlantcontactNummer([FromRoute] string nummer)
         {

--- a/InterneTaakAfhandeling.Web.Server/Features/InterneTaakDetails/InternetaakDetailsService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/InterneTaakDetails/InternetaakDetailsService.cs
@@ -7,6 +7,7 @@ namespace InterneTaakAfhandeling.Web.Server.Features.InterneTaak
     public interface IInternetaakService
     {
         Task<Internetaak?> Get(InterneTaakQuery interneTaakQueryParameters);
+        Task<Internetaak?> GetByKlantcontactNummer(string klantcontactNummer);
     }
     public class InternetaakDetailsService(IOpenKlantApiClient openKlantApiClient, IZakenApiClient zakenApiClient, IContactmomentenService contactmomentenService) : IInternetaakService
     {
@@ -31,6 +32,34 @@ namespace InterneTaakAfhandeling.Web.Server.Features.InterneTaak
 
             var interntaak = internetaken.Single();
 
+            await EnrichWithZaakAsync(interntaak);
+
+            return interntaak;
+        }
+
+        public async Task<Internetaak?> GetByKlantcontactNummer(string klantcontactNummer)
+        {
+            var query = new InterneTaakQuery
+            {
+                Klantcontact__Nummer = klantcontactNummer
+            };
+
+            var internetaken = await _openKlantApiClient.QueryInterneTakenAsync(query);
+
+            if (internetaken == null || internetaken.Count == 0)
+            {
+                return null;
+            }
+
+            var interntaak = internetaken.First();
+
+            await EnrichWithZaakAsync(interntaak);
+
+            return interntaak;
+        }
+
+        private async Task EnrichWithZaakAsync(Internetaak? interntaak)
+        {
             if (interntaak?.AanleidinggevendKlantcontact != null)
             {
                 var onderwerpObjectId = _contactmomentenService.GetZaakOnderwerpObject(interntaak.AanleidinggevendKlantcontact);
@@ -40,9 +69,6 @@ namespace InterneTaakAfhandeling.Web.Server.Features.InterneTaak
                     interntaak.Zaak = await _zakenApiClient.GetZaakAsync(onderwerpObjectId);
                 }
             }
-
-
-            return interntaak;
         }
     }
 }

--- a/InterneTaakAfhandeling.Web.Server/Features/InterneTakenOverzicht/InterneTakenOverzichtModel.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/InterneTakenOverzicht/InterneTakenOverzichtModel.cs
@@ -40,4 +40,6 @@ public class InterneTaakOverzichtItem
 
     public string? AfdelingNaam { get; set; }
     public string? BehandelaarNaam { get; set; }
+
+    public string? ContactmomentNummer { get; set; }
 }

--- a/InterneTaakAfhandeling.Web.Server/Features/InterneTakenOverzicht/InterneTakenOverzichtService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/InterneTakenOverzicht/InterneTakenOverzichtService.cs
@@ -72,6 +72,7 @@ namespace InterneTaakAfhandeling.Web.Server.Features.InterneTakenOverzicht
                     item.Onderwerp = klantcontact.Onderwerp;
                     item.ContactDatum = klantcontact.PlaatsgevondenOp;
                     item.KlantNaam = ExtractKlantNaamFromKlantcontact(klantcontact);
+                    item.ContactmomentNummer = klantcontact.Nummer;
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary

Lays the server-side foundation for Feature #299 — using the contactmoment number instead of the internal task number. This task ensures `AanleidinggevendKlantcontact.Nummer` is available in all code paths consumed by the UI, e-mails, and routing, without adding new fields — the number is already present on the existing `Internetaak.AanleidinggevendKlantcontact` relation.

Adds a new lookup endpoint `GET /api/internetaken/by-klantcontact/{nummer}` for finding an internetaak by its originating klantcontact number.

## Changes

- **Internetaak detail endpoint**: expand `AanleidinggevendKlantcontact` to include `Nummer` in the response; add new `by-klantcontact/{nummer}` route for lookup by klantcontact number
- **Detail service**: add `GetByKlantcontactNummer()` method querying on `Klantcontact__Nummer` with full enrichment (zaak, actoren, klantcontact)
- **Overzicht model & service**: add `ContactmomentNummer` field to `InterneTaakOverzichtItem`, populated from the already-fetched klantcontact — for router-link URL construction

## Test plan

- [ ] Internetaak detail bevat het klantcontact-nummer
- [ ] Fout als klantcontact-nummer null is
- [ ] Overzicht bevat contactmoment-nummer per internetaak
- [ ] Lookup by klantcontact-nummer returns the correct internetaak

## Related

Closes #372