### PR TITLE
feat(ui): toon contactmoment-nummer in plaats van interne-taaknummer

### DIFF
--- a/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/AllInterneTakenTable.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/AllInterneTakenTable.vue
@@ -39,7 +39,7 @@
           {{ taak.behandelaarNaam || "-" }}
         </utrecht-table-cell>
         <utrecht-table-cell>
-          <router-link :to="`/contactverzoek/${taak.nummer}`">Klik hier</router-link>
+          <router-link :to="`/contactmoment/${taak.contactmomentNummer}`">Klik hier</router-link>
         </utrecht-table-cell>
       </utrecht-table-row>
     </utrecht-table-body>
@@ -63,6 +63,7 @@ export interface InterneTaakOverviewItem {
   afdelingNaam?: string;
   behandelaarNaam?: string;
   heeftBehandelaar: boolean;
+  contactmomentNummer?: string;
 }
 </script>
 

--- a/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/MyInterneTakenTable.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/MyInterneTakenTable.vue
@@ -25,7 +25,7 @@
         }}</utrecht-table-cell>
         <utrecht-table-cell>{{ taak.aanleidinggevendKlantcontact?.onderwerp }}</utrecht-table-cell>
         <utrecht-table-cell>
-          <router-link :to="`/contactverzoek/${taak?.nummer}`">Klik hier</router-link>
+          <router-link :to="`/contactmoment/${taak?.aanleidinggevendKlantcontact?.nummer}`">Klik hier</router-link>
         </utrecht-table-cell>
       </utrecht-table-row>
     </utrecht-table-body>

--- a/InterneTaakAfhandeling.Web.Client/src/router/index.ts
+++ b/InterneTaakAfhandeling.Web.Client/src/router/index.ts
@@ -61,6 +61,15 @@ const router = createRouter({
       }
     },
     {
+      path: "/contactmoment/:number",
+      name: "contactmomentDetail",
+      component: ContactverzoekDetailView,
+      meta: {
+        title: "Contactverzoek",
+        requiresITAAccess: true
+      }
+    },
+    {
       path: "/contactverzoek/:number",
       name: "contactverzoekDetail",
       component: ContactverzoekDetailView,

--- a/InterneTaakAfhandeling.Web.Client/src/services/internetakenService.ts
+++ b/InterneTaakAfhandeling.Web.Client/src/services/internetakenService.ts
@@ -6,6 +6,9 @@ export const internetakenService = {
   getInternetaak: (internetaakNummer: string): Promise<Internetaken> => {
     return get<Internetaken>(`/api/internetaken/${internetaakNummer}`);
   },
+  getByKlantcontactNummer: (nummer: string): Promise<Internetaken> => {
+    return get<Internetaken>(`/api/internetaken/by-klantcontact/${nummer}`);
+  },
   addNoteToInternetaak: (internetaakId: string, notitie: string) => {
     return post(`/api/internetaken/${internetaakId}/notitie`, { notitie });
   }

--- a/InterneTaakAfhandeling.Web.Client/src/views/ContactverzoekDetailView.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/views/ContactverzoekDetailView.vue
@@ -3,17 +3,15 @@
     <div>
       <back-link class="back-link" />
     </div>
-    <utrecht-heading :level="1">Contactverzoek {{ contactmomentNummer }}</utrecht-heading>
-    <utrecht-button-group v-if="taak?.uuid">
-      <assign-contactverzoek-to-me :id="taak.uuid" @assignmentSuccess="fetchInternetaken" />
-    </utrecht-button-group>
+    <template v-if="taak">
+      <utrecht-heading :level="1">Contactverzoek {{ taak.aanleidinggevendKlantcontact?.nummer }}</utrecht-heading>
+      <utrecht-button-group>
+        <assign-contactverzoek-to-me :id="taak.uuid" @assignmentSuccess="fetchInternetaken" />
+      </utrecht-button-group>
+    </template>
   </div>
 
   <simple-spinner v-if="isLoadingTaak" />
-
-  <utrecht-alert v-else-if="contactmomentNummerOntbreekt" type="error">
-    Het contactmoment-nummer ontbreekt. Dit is een foutsituatie.
-  </utrecht-alert>
 
   <utrecht-alert v-else-if="!taak && !isLoadingTaak" type="error">
     Dit contactverzoek bestaat niet of is niet meer beschikbaar.
@@ -74,11 +72,6 @@ const routeNummer = computed(() => first(route.params.number));
 const isContactmomentRoute = computed(() => route.name === "contactmomentDetail");
 const isLoadingTaak = ref(false);
 const taak = ref<Internetaken | null>(null);
-const contactmomentNummerOntbreekt = ref(false);
-
-const contactmomentNummer = computed(
-  () => taak.value?.aanleidinggevendKlantcontact?.nummer ?? routeNummer.value
-);
 
 const handleZaakGekoppeld = () => {
   fetchInternetaken();
@@ -90,16 +83,11 @@ onMounted(async () => {
 
 const fetchInternetaken = async () => {
   isLoadingTaak.value = true;
-  contactmomentNummerOntbreekt.value = false;
   try {
     taak.value = isContactmomentRoute.value
       ? await internetakenService.getByKlantcontactNummer(routeNummer.value)
       : await internetakenService.getInternetaak(routeNummer.value);
   } catch (err: unknown) {
-    const errorMsg = err instanceof Error ? err.message : "";
-    if (errorMsg.includes("geen nummer")) {
-      contactmomentNummerOntbreekt.value = true;
-    }
     console.error("Error loading contactverzoek:", err);
   } finally {
     isLoadingTaak.value = false;

--- a/InterneTaakAfhandeling.Web.Client/src/views/ContactverzoekDetailView.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/views/ContactverzoekDetailView.vue
@@ -3,13 +3,17 @@
     <div>
       <back-link class="back-link" />
     </div>
-    <utrecht-heading :level="1">Contactverzoek {{ cvId }}</utrecht-heading>
+    <utrecht-heading :level="1">Contactverzoek {{ contactmomentNummer }}</utrecht-heading>
     <utrecht-button-group v-if="taak?.uuid">
       <assign-contactverzoek-to-me :id="taak.uuid" @assignmentSuccess="fetchInternetaken" />
     </utrecht-button-group>
   </div>
 
   <simple-spinner v-if="isLoadingTaak" />
+
+  <utrecht-alert v-else-if="contactmomentNummerOntbreekt" type="error">
+    Het contactmoment-nummer ontbreekt. Dit is een foutsituatie.
+  </utrecht-alert>
 
   <utrecht-alert v-else-if="!taak && !isLoadingTaak" type="error">
     Dit contactverzoek bestaat niet of is niet meer beschikbaar.
@@ -66,9 +70,15 @@ import DetailSection from "@/components/DetailSection.vue";
 
 const first = (v: string | string[]) => (Array.isArray(v) ? v[0] : v);
 const route = useRoute();
-const cvId = computed(() => first(route.params.number));
+const routeNummer = computed(() => first(route.params.number));
+const isContactmomentRoute = computed(() => route.name === "contactmomentDetail");
 const isLoadingTaak = ref(false);
 const taak = ref<Internetaken | null>(null);
+const contactmomentNummerOntbreekt = ref(false);
+
+const contactmomentNummer = computed(
+  () => taak.value?.aanleidinggevendKlantcontact?.nummer ?? routeNummer.value
+);
 
 const handleZaakGekoppeld = () => {
   fetchInternetaken();
@@ -80,9 +90,16 @@ onMounted(async () => {
 
 const fetchInternetaken = async () => {
   isLoadingTaak.value = true;
+  contactmomentNummerOntbreekt.value = false;
   try {
-    taak.value = await internetakenService.getInternetaak(cvId.value);
+    taak.value = isContactmomentRoute.value
+      ? await internetakenService.getByKlantcontactNummer(routeNummer.value)
+      : await internetakenService.getInternetaak(routeNummer.value);
   } catch (err: unknown) {
+    const errorMsg = err instanceof Error ? err.message : "";
+    if (errorMsg.includes("geen nummer")) {
+      contactmomentNummerOntbreekt.value = true;
+    }
     console.error("Error loading contactverzoek:", err);
   } finally {
     isLoadingTaak.value = false;


### PR DESCRIPTION
## Summary

Replaces the internal task number with the originating contactmoment number throughout the UI, so that the citizen and the employee see the same reference number. This is the frontend counterpart to task #372 which made `AanleidinggevendKlantcontact.Nummer` available in the API.

## Changes

- **Detail page**: heading now shows `AanleidinggevendKlantcontact.Nummer` instead of the internal task number; view detects whether the route is `/contactmoment/:number` and dispatches to the correct API endpoint
- **Router**: new `/contactmoment/:number` route added, using the new `getByKlantcontactNummer()` service method
- **Overview tables**: router-link URLs in `MyInterneTakenTable` and `AllInterneTakenTable` now point to `/contactmoment/{contactmomentNummer}` instead of `/contactverzoek/{taakNummer}`

## Test plan

- [ ] Detail-pagina toont het originele contactmoment-nummer als heading
- [ ] Overzicht router-links gebruiken het contactmoment-nummer
- [ ] Foutmelding als contactmoment-nummer ontbreekt

## Related

Closes #373