### PR TITLE
feat(email): gebruik AanleidinggevendKlantcontact.Nummer in deeplink en onderwerp

### DIFF
--- a/InterneTaakAfhandeling.Common/Services/Emailservices/Content/EmailContentService.cs
+++ b/InterneTaakAfhandeling.Common/Services/Emailservices/Content/EmailContentService.cs
@@ -28,11 +28,14 @@ public class EmailContentService : IEmailContentService
 
     public string BuildInternetakenEmailContent(Internetaak internetaak, string itaBaseUrl)
     {
-        var deeplink = $"{itaBaseUrl.TrimEnd('/')}/contactverzoek/{internetaak.Nummer}";
+        var contactmomentNummer = internetaak.AanleidinggevendKlantcontact?.Nummer
+            ?? throw new InvalidOperationException($"AanleidinggevendKlantcontact.Nummer ontbreekt voor internetaak {internetaak.Nummer}");
+
+        var deeplink = $"{itaBaseUrl.TrimEnd('/')}/contactmoment/{contactmomentNummer}";
 
         var sb = new StringBuilder(EmailTemplate);
         sb.Replace("{Link}", deeplink)
-          .Replace("{Nummer}", internetaak.Nummer);
+          .Replace("{Nummer}", contactmomentNummer);
 
         return sb.ToString();
     }

--- a/InterneTaakAfhandeling.Poller/Features/InternetakenNotifier.cs
+++ b/InterneTaakAfhandeling.Poller/Features/InternetakenNotifier.cs
@@ -111,9 +111,16 @@ public class InternetakenNotifier : IInternetakenProcessor
 
             if (actorEmails.Count > 0)
             {
+                var contactmomentNummer = internetaak.AanleidinggevendKlantcontact?.Nummer;
+                if (string.IsNullOrEmpty(contactmomentNummer))
+                {
+                    _logger.LogError("AanleidinggevendKlantcontact.Nummer ontbreekt voor internetaak {Number}", internetaak.Nummer);
+                    return new ProcessingResult(false, Guid.Parse(internetaak.Uuid), internetaak.ToegewezenOp ?? DateTimeOffset.MinValue, "AanleidinggevendKlantcontact.Nummer ontbreekt");
+                }
+
                 var emailContent = _emailContentService.BuildInternetakenEmailContent(internetaak, _itaBaseUrl);
 
-                await Task.WhenAll(actorEmails.Select(email => _emailService.SendEmailAsync(email, $"Nieuw contactverzoek - {internetaak.Nummer}", emailContent)));
+                await Task.WhenAll(actorEmails.Select(email => _emailService.SendEmailAsync(email, $"Nieuw contactverzoek - {contactmomentNummer}", emailContent)));
 
                 _logger.LogInformation("Successfully processed internetaken: {Number}", internetaak.Nummer);
             }

--- a/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestService.cs
@@ -63,7 +63,9 @@ public class ForwardContactRequestService(
                 return GetResultMessageWhenNoEmails(actorEmailResult);
 
             var emailContent = emailContentService.BuildInternetakenEmailContent(internetaken, _itaBaseUrl);
-            var subject = $"Contactverzoek Doorgestuurd - {internetaken.Nummer}";
+            var contactmomentNummer = internetaken.AanleidinggevendKlantcontact?.Nummer
+                ?? throw new InvalidOperationException($"AanleidinggevendKlantcontact.Nummer ontbreekt voor internetaak {internetaken.Nummer}");
+            var subject = $"Contactverzoek Doorgestuurd - {contactmomentNummer}";
 
             var sendResults = await SendEmailsAsync(actorEmailResult.FoundEmails, subject, emailContent);
 


### PR DESCRIPTION
## Summary

E-mails naar afdelingen en medewerkers bevatten nu `AanleidinggevendKlantcontact.Nummer` (het originele contactmoment-nummer) in zowel de onderwerpregel als de deeplink-URL. Dit zorgt ervoor dat ontvangers hetzelfde referentienummer zien als de inwoner in het Portaal, in plaats van het interne-taaknummer.

Onderdeel van Feature #299: Gebruik het nummer van het "contactmoment" in plaats van het nummer van de "interne taak".

## Changes

- **E-mail deeplink**: deeplink-URL opgebouwd met `AanleidinggevendKlantcontact.Nummer` via het pad `/contactmoment/{nummer}` (was `/contactverzoek/{internetaakNummer}`). Gooit `InvalidOperationException` als het nummer ontbreekt.
- **E-mail onderwerp (notificatie)**: onderwerpregel "Nieuw contactverzoek - {nummer}" gebruikt nu het contactmoment-nummer. Logt een error en retourneert een failure als het nummer ontbreekt.
- **E-mail onderwerp (doorsturen)**: onderwerpregel "Contactverzoek Doorgestuurd - {nummer}" gebruikt nu het contactmoment-nummer. Gooit `InvalidOperationException` bij ontbreken.

## Test plan

- [ ] E-mailonderwerp bevat het contactmoment-nummer
- [ ] Deeplink in e-mail bevat het contactmoment-nummer
- [ ] Doorgestuurd contactverzoek e-mail bevat het contactmoment-nummer
- [ ] Fout als contactmoment-nummer ontbreekt

## Related

Closes #374