### PR TITLE
feat(assign-to-me): hide button when user is already individually assigned

### DIFF
--- a/InterneTaakAfhandeling.Web.Client/src/features/assign-contactverzoek-to-me/AssignContactverzoekToMe.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/features/assign-contactverzoek-to-me/AssignContactverzoekToMe.vue
@@ -1,28 +1,43 @@
 <template>
-  <utrecht-alert-dialog ref="toewijzenAlertRef">
-    <form method="dialog" @submit.prevent="toewijzen">
-      <utrecht-paragraph> Wil je dit contactverzoek toewijzen aan jezelf? </utrecht-paragraph>
-      <utrecht-button-group>
-        <utrecht-button appearance="primary-action-button" type="submit"
-          >Toewijzen aan mezelf</utrecht-button
-        >
-        <utrecht-button appearance="secondary-action-button" type="button" @click="close"
-          >Annuleren</utrecht-button
-        >
-      </utrecht-button-group>
-    </form>
-  </utrecht-alert-dialog>
-  <utrecht-button type="button" appearance="primary-action-button" @click="show"
-    >Toewijzen aan mezelf</utrecht-button
-  >
+  <template v-if="!isAlreadyAssigned">
+    <utrecht-alert-dialog ref="toewijzenAlertRef">
+      <form method="dialog" @submit.prevent="toewijzen">
+        <utrecht-paragraph> Wil je dit contactverzoek toewijzen aan jezelf? </utrecht-paragraph>
+        <utrecht-button-group>
+          <utrecht-button appearance="primary-action-button" type="submit"
+            >Toewijzen aan mezelf</utrecht-button
+          >
+          <utrecht-button appearance="secondary-action-button" type="button" @click="close"
+            >Annuleren</utrecht-button
+          >
+        </utrecht-button-group>
+      </form>
+    </utrecht-alert-dialog>
+    <utrecht-button type="button" appearance="primary-action-button" @click="show"
+      >Toewijzen aan mezelf</utrecht-button
+    >
+  </template>
 </template>
 
 <script setup lang="ts">
 import { toast } from "@/components/toast/toast";
-import { ref, defineEmits } from "vue";
+import { ref, computed, defineEmits } from "vue";
 import { userService } from "@/services/userService";
-const props = defineProps<{ id: string }>();
+import type { Actor } from "@/types/internetaken";
+const props = defineProps<{
+  id: string;
+  userEmail: string;
+  actoren: Actor[];
+}>();
 const emit = defineEmits(["assignmentSuccess"]);
+
+const isAlreadyAssigned = computed(() =>
+  props.actoren.some(
+    (actor) =>
+      actor.soortActor === "medewerker" &&
+      actor.actoridentificator?.objectId?.toLowerCase() === props.userEmail.toLowerCase(),
+  ),
+);
 
 const toewijzenAlertRef = ref<{ dialogRef?: HTMLDialogElement }>();
 const show = () => toewijzenAlertRef.value?.dialogRef?.showModal();

--- a/InterneTaakAfhandeling.Web.Client/src/features/assign-contactverzoek-to-me/AssignContactverzoekToMe.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/features/assign-contactverzoek-to-me/AssignContactverzoekToMe.vue
@@ -24,17 +24,22 @@ import { toast } from "@/components/toast/toast";
 import { ref, computed, defineEmits } from "vue";
 import { userService } from "@/services/userService";
 import type { Actor } from "@/types/internetaken";
-const props = defineProps<{
-  id: string;
-  userEmail: string;
-  actoren: Actor[];
-}>();
+const props = withDefaults(
+  defineProps<{
+    id: string;
+    userEmail: string;
+    actoren: Actor[];
+  }>(),
+  { actoren: () => [] },
+);
 const emit = defineEmits(["assignmentSuccess"]);
 
 const isAlreadyAssigned = computed(() =>
   props.actoren.some(
     (actor) =>
       actor.soortActor === "medewerker" &&
+      actor.actoridentificator?.codeObjecttype === "mdw" &&
+      actor.actoridentificator?.codeSoortObjectId === "email" &&
       actor.actoridentificator?.objectId?.toLowerCase() === props.userEmail.toLowerCase(),
   ),
 );

--- a/InterneTaakAfhandeling.Web.Client/src/views/ContactverzoekDetailView.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/views/ContactverzoekDetailView.vue
@@ -6,7 +6,12 @@
     <template v-if="taak">
       <utrecht-heading :level="1">Contactverzoek {{ taak.aanleidinggevendKlantcontact?.nummer }}</utrecht-heading>
       <utrecht-button-group>
-        <assign-contactverzoek-to-me :id="taak.uuid" @assignmentSuccess="fetchInternetaken" />
+        <assign-contactverzoek-to-me
+        :id="taak.uuid"
+        :user-email="userEmail"
+        :actoren="taak.toegewezenAanActoren ?? []"
+        @assignmentSuccess="fetchInternetaken"
+      />
       </utrecht-button-group>
     </template>
   </div>
@@ -65,9 +70,12 @@ import ContactverzoekDetails from "@/components/ContactverzoekDetails.vue";
 import ContactmomentDetails from "@/components/ContactmomentDetails.vue";
 import ContactverzoekActies from "@/components/ContactverzoekActies.vue";
 import DetailSection from "@/components/DetailSection.vue";
+import { useAuthStore } from "@/stores/auth";
 
 const first = (v: string | string[]) => (Array.isArray(v) ? v[0] : v);
 const route = useRoute();
+const authStore = useAuthStore();
+const userEmail = computed(() => authStore.user?.email ?? "");
 const routeNummer = computed(() => first(route.params.number));
 const isContactmomentRoute = computed(() => route.name === "contactmomentDetail");
 const isLoadingTaak = ref(false);


### PR DESCRIPTION
## Summary

Hides the "Toewijzen aan mezelf" button on the contactverzoek detail page when the logged-in employee is already individually assigned. This prevents confusion about whether the user still needs to self-assign when they are already listed as an assigned actor. Part of the UX improvements epic (#346) and feature #347.

## Changes

- **AssignContactverzoekToMe.vue**: Added props for the assigned actors list and the current user's email. The component now compares the logged-in user's email (case-insensitive) against individually assigned actors (`soortActor === 'medewerker'`) and hides the button when a match is found. Team assignments (`organisatorische_eenheid`) are excluded from this check.
- **ContactverzoekDetailView.vue**: Imported `useAuthStore` and passes the user email and the `toegewezenAanActoren` list as props to `AssignContactverzoekToMe`.

## Test plan

- [ ] Knop verborgen bij individuele toewijzing
- [ ] Knop zichtbaar zonder individuele toewijzing
- [ ] Teamtoewijzing telt niet als individuele toewijzing
- [ ] Geen toewijzingen — knop is zichtbaar

## Related

Closes #384