### PR TITLE
chart: add nodeSelector/tolerations/affinity for ITA poller + web

### DIFF
--- a/charts/internetaakafhandeling/templates/poller-cronjob.yaml
+++ b/charts/internetaakafhandeling/templates/poller-cronjob.yaml
@@ -27,3 +27,15 @@ spec:
                 - secretRef:
                     name: {{ include "internetaakafhandeling.fullname" . }}-secrets
           restartPolicy: OnFailure
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/charts/internetaakafhandeling/templates/web-deployment.yaml
+++ b/charts/internetaakafhandeling/templates/web-deployment.yaml
@@ -52,3 +52,15 @@ spec:
         - name: appsettings-volume
           configMap:
             name: {{ include "internetaakafhandeling.web.name" . }}-appsettings
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/internetaakafhandeling/values.yaml
+++ b/charts/internetaakafhandeling/values.yaml
@@ -2,6 +2,14 @@
 nameOverride: ""
 fullnameOverride: ""
 
+# Pod scheduling controls applied to both poller-cronjob and web-deployment.
+# Defaults are empty so behavior is unchanged on single-nodepool clusters.
+# Useful for multi-nodepool clusters (e.g. AKS system/user pool separation)
+# where workloads must be pinned to specific nodes.
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
 # Global PostgreSQL configuration
 postgresql:
   enabled: true

--- a/docs/changelog/changelog.md
+++ b/docs/changelog/changelog.md
@@ -1,6 +1,15 @@
 # Changelog
 
 ## Latest version
+
+### Helm chart additions
+- `nodeSelector`, `tolerations` en `affinity` toegevoegd op chart root (geldt voor zowel `poller-cronjob` als `web-deployment`). Backwards compatible: defaults zijn leeg, bestaand gedrag op single-nodepool clusters ongewijzigd. Voor multi-nodepool clusters (bv AKS systempool/userpool) kan een operator nu workloads pinnen op specifieke nodes, bv:
+  ```yaml
+  ita:
+    nodeSelector:
+      agentpool: userpool
+  ```
+
 - beheerder kan exclusief alle contactverzoeken raadplegen
 
 ## v3.0.0


### PR DESCRIPTION
Nodepool instelbaar maken voor de ITA poller en web. Standaard niks veranderd, maar SSC kan nu via values aangeven dat pods op de userpool moeten landen (niet op systempool).
Backwards compatible
