### PR TITLE
feat(guards): block mutations on verwerkte contactverzoeken

### DIFF
--- a/InterneTaakAfhandeling.Web.Server/Config/ServiceCollectionExtensions.cs
+++ b/InterneTaakAfhandeling.Web.Server/Config/ServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ using InterneTaakAfhandeling.Web.Server.Features.KlantContact;
 using InterneTaakAfhandeling.Web.Server.Features.MyInterneTakenOverview;
 using InterneTaakAfhandeling.Web.Server.Middleware;
 using InterneTaakAfhandeling.Web.Server.Services;
+using InterneTaakAfhandeling.Web.Server.Guards;
 using InterneTaakAfhandeling.Web.Server.Services.LogboekService;
 using Microsoft.EntityFrameworkCore;
 
@@ -58,6 +59,7 @@ namespace InterneTaakAfhandeling.Web.Server.Config
             services.AddScoped<IAssignInternetaakToMeService, AssignInternetaakToMeService>();
             services.AddScoped<IForwardContactRequestService, ForwardContactRequestService>();
             services.AddScoped<ILogboekService, LogboekService>();
+            services.AddScoped<IInternetaakGuardService, InternetaakGuardService>();
             services.AddScoped<IMyInterneTakenOverviewService, MyInterneTakenOverviewService>();
             services.AddSmtpClients(configuration);
             

--- a/InterneTaakAfhandeling.Web.Server/Features/AddNotitieToInternetaak/AddNotitieToInternetaakController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/AddNotitieToInternetaak/AddNotitieToInternetaakController.cs
@@ -1,4 +1,5 @@
 using InterneTaakAfhandeling.Web.Server.Authentication;
+using InterneTaakAfhandeling.Web.Server.Guards;
 using InterneTaakAfhandeling.Web.Server.Services.LogboekService;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -11,19 +12,27 @@ namespace InterneTaakAfhandeling.Web.Server.Features.AddNotitieToInternetaak;
 [ProducesResponseType(StatusCodes.Status401Unauthorized)]
 public class AddNotitieToInternetaakController(
     ITAUser user,
-    ILogboekService logboekService) : Controller
+    ILogboekService logboekService,
+    IInternetaakGuardService internetaakGuardService) : Controller
 {
     private readonly ILogboekService _logboekService =
         logboekService ?? throw new ArgumentNullException(nameof(logboekService));
 
     private readonly ITAUser _user = user ?? throw new ArgumentNullException(nameof(user));
 
+    private readonly IInternetaakGuardService _internetaakGuardService =
+        internetaakGuardService ?? throw new ArgumentNullException(nameof(internetaakGuardService));
+
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
     [HttpPost("{internetaakId}/notitie")]
     public async Task<IActionResult> AddNote([FromRoute] Guid internetaakId, [FromBody] AddNotitieRequest request)
     {
+        var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(internetaakId);
+        if (blocked != null) return blocked;
+
         var notitieAction = KnownContactAction.Note(request.Notitie, _user);
         await _logboekService.LogContactRequestAction(notitieAction, internetaakId);
 

--- a/InterneTaakAfhandeling.Web.Server/Features/AddNotitieToInternetaak/AddNotitieToInternetaakController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/AddNotitieToInternetaak/AddNotitieToInternetaakController.cs
@@ -30,7 +30,7 @@ public class AddNotitieToInternetaakController(
     [HttpPost("{internetaakId}/notitie")]
     public async Task<IActionResult> AddNote([FromRoute] Guid internetaakId, [FromBody] AddNotitieRequest request)
     {
-        var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(internetaakId);
+        var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(internetaakId, "notitie");
         if (blocked != null) return blocked;
 
         var notitieAction = KnownContactAction.Note(request.Notitie, _user);

--- a/InterneTaakAfhandeling.Web.Server/Features/AssignInternetaakToMe/AssignInternetaakToMeController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/AssignInternetaakToMe/AssignInternetaakToMeController.cs
@@ -1,5 +1,6 @@
 ﻿using InterneTaakAfhandeling.Common.Helpers;
 using InterneTaakAfhandeling.Web.Server.Authentication;
+using InterneTaakAfhandeling.Web.Server.Guards;
 using InterneTaakAfhandeling.Web.Server.Services.LogboekService;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -14,16 +15,22 @@ namespace InterneTaakAfhandeling.Web.Server.Features.AssignInternetaakToMe
         IAssignInternetaakToMeService AssignInternetakenService,
         ITAUser user,
         ILogboekService logboekService,
+        IInternetaakGuardService internetaakGuardService,
         ILogger<AssignInternetaakToMeController> logger) : Controller
     {
         private readonly IAssignInternetaakToMeService _AssignInternetakenService = AssignInternetakenService;
         private readonly ITAUser _user = user;
         private readonly ILogboekService _logboekService = logboekService ?? throw new ArgumentNullException(nameof(logboekService));
+        private readonly IInternetaakGuardService _internetaakGuardService = internetaakGuardService ?? throw new ArgumentNullException(nameof(internetaakGuardService));
         private readonly ILogger<AssignInternetaakToMeController> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
         [HttpPost("{internetaakId}/aan-mij-toewijzen")]
         public async Task<IActionResult> AssignInternetakenAsync([FromRoute] Guid internetaakId)
         {
+            var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(internetaakId);
+            if (blocked != null) return blocked;
+
             try
             {
                 var (updatedInterneTaak, currentUserActor) = await _AssignInternetakenService.ToSelfAsync(internetaakId, user);
@@ -44,6 +51,3 @@ namespace InterneTaakAfhandeling.Web.Server.Features.AssignInternetaakToMe
         }
     }
 }
-
-
-

--- a/InterneTaakAfhandeling.Web.Server/Features/AssignInternetaakToMe/AssignInternetaakToMeController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/AssignInternetaakToMe/AssignInternetaakToMeController.cs
@@ -28,11 +28,11 @@ namespace InterneTaakAfhandeling.Web.Server.Features.AssignInternetaakToMe
         [HttpPost("{internetaakId}/aan-mij-toewijzen")]
         public async Task<IActionResult> AssignInternetakenAsync([FromRoute] Guid internetaakId)
         {
-            var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(internetaakId, "aan-mij-toewijzen");
-            if (blocked != null) return blocked;
-
             try
             {
+                var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(internetaakId, "aan-mij-toewijzen");
+                if (blocked != null) return blocked;
+
                 var (updatedInterneTaak, currentUserActor) = await _AssignInternetakenService.ToSelfAsync(internetaakId, user);
 
                 var assignedAction = KnownContactAction.AssignedToSelf(currentUserActor.Uuid, _user);

--- a/InterneTaakAfhandeling.Web.Server/Features/AssignInternetaakToMe/AssignInternetaakToMeController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/AssignInternetaakToMe/AssignInternetaakToMeController.cs
@@ -28,7 +28,7 @@ namespace InterneTaakAfhandeling.Web.Server.Features.AssignInternetaakToMe
         [HttpPost("{internetaakId}/aan-mij-toewijzen")]
         public async Task<IActionResult> AssignInternetakenAsync([FromRoute] Guid internetaakId)
         {
-            var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(internetaakId);
+            var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(internetaakId, "aan-mij-toewijzen");
             if (blocked != null) return blocked;
 
             try

--- a/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestController.cs
@@ -1,4 +1,5 @@
 using InterneTaakAfhandeling.Web.Server.Authentication;
+using InterneTaakAfhandeling.Web.Server.Guards;
 using InterneTaakAfhandeling.Web.Server.Services.LogboekService;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -12,6 +13,7 @@ namespace InterneTaakAfhandeling.Web.Server.Features.ForwardContactRequest;
 public class ForwardContactRequestController(
     IForwardContactRequestService forwardContactRequestService,
     ILogboekService logboekService,
+    IInternetaakGuardService internetaakGuardService,
     ITAUser user) : Controller
 {
     private readonly ITAUser _user = user ?? throw new ArgumentNullException(nameof(user));
@@ -19,10 +21,14 @@ public class ForwardContactRequestController(
     [ProducesResponseType(typeof(ForwardContactRequestResponse),StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
     [HttpPost("{id:guid}/forward")]
     public async Task<IActionResult> ForwardContactRequestAsync([FromRoute] Guid id,
         [FromBody] ForwardContactRequestModel request)
     {
+        var blocked = await internetaakGuardService.EnsureNotVerwerktAsync(id);
+        if (blocked != null) return blocked;
+
         var response = await forwardContactRequestService.ForwardAsync(id, request);
         await logboekService.LogContactRequestAction(KnownContactAction.ForwardKlantContact(request, _user), id);
 

--- a/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestController.cs
@@ -26,7 +26,7 @@ public class ForwardContactRequestController(
     public async Task<IActionResult> ForwardContactRequestAsync([FromRoute] Guid id,
         [FromBody] ForwardContactRequestModel request)
     {
-        var blocked = await internetaakGuardService.EnsureNotVerwerktAsync(id);
+        var blocked = await internetaakGuardService.EnsureNotVerwerktAsync(id, "forward");
         if (blocked != null) return blocked;
 
         var response = await forwardContactRequestService.ForwardAsync(id, request);

--- a/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CloseInterneTaakWithKlantContact/CloseInterneTaakWithKlantContactController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CloseInterneTaakWithKlantContact/CloseInterneTaakWithKlantContactController.cs
@@ -41,14 +41,15 @@ public class CloseInterneTaakWithKlantContactController(
 
     [ProducesResponseType(typeof(RelatedKlantcontactResult), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ITAException), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
     [HttpPost("close-with-klantcontact")] //todo: refactor to "HttpPost("[internetaakUuid]/close-with-klantcontact)" and consider making it a PUT
     public async Task<IActionResult> CreateRelatedKlantcontact([FromBody] RequestModel request)
     {
-        var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(request.InterneTaakId, "close-with-klantcontact");
-        if (blocked != null) return blocked;
-
         try
         {
+            var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(request.InterneTaakId, "close-with-klantcontact");
+            if (blocked != null) return blocked;
+
             _logger.LogInformation(
                 "Closing Interne taak and creating related klantcontact with aanleidinggevendKlantcontact UUID: {AanleidinggevendKlantcontactUuid}",
                 request.AanleidinggevendKlantcontactUuid);

--- a/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CloseInterneTaakWithKlantContact/CloseInterneTaakWithKlantContactController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CloseInterneTaakWithKlantContact/CloseInterneTaakWithKlantContactController.cs
@@ -3,6 +3,7 @@ using InterneTaakAfhandeling.Common.Services.OpenKlantApi;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
 using InterneTaakAfhandeling.Web.Server.Authentication;
 using InterneTaakAfhandeling.Web.Server.Exceptions;
+using InterneTaakAfhandeling.Web.Server.Guards;
 using InterneTaakAfhandeling.Web.Server.Services.LogboekService;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -18,6 +19,7 @@ public class CloseInterneTaakWithKlantContactController(
     ICreateKlantContactService createKlantContactService,
     ILogger<CloseInterneTaakWithKlantContactController> logger,
     IOpenKlantApiClient openKlantApiClient,
+    IInternetaakGuardService internetaakGuardService,
     ILogboekService logboekService) : Controller
 {
     private readonly ICreateKlantContactService _createKlantContactService =
@@ -34,11 +36,17 @@ public class CloseInterneTaakWithKlantContactController(
     private readonly IOpenKlantApiClient openKlantApiClient =
         openKlantApiClient ?? throw new ArgumentNullException(nameof(openKlantApiClient));
 
+    private readonly IInternetaakGuardService _internetaakGuardService =
+        internetaakGuardService ?? throw new ArgumentNullException(nameof(internetaakGuardService));
+
     [ProducesResponseType(typeof(RelatedKlantcontactResult), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ITAException), StatusCodes.Status409Conflict)]
     [HttpPost("close-with-klantcontact")] //todo: refactor to "HttpPost("[internetaakUuid]/close-with-klantcontact)" and consider making it a PUT
     public async Task<IActionResult> CreateRelatedKlantcontact([FromBody] RequestModel request)
     {
+        var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(request.InterneTaakId);
+        if (blocked != null) return blocked;
+
         try
         {
             _logger.LogInformation(

--- a/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CloseInterneTaakWithKlantContact/CloseInterneTaakWithKlantContactController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CloseInterneTaakWithKlantContact/CloseInterneTaakWithKlantContactController.cs
@@ -44,7 +44,7 @@ public class CloseInterneTaakWithKlantContactController(
     [HttpPost("close-with-klantcontact")] //todo: refactor to "HttpPost("[internetaakUuid]/close-with-klantcontact)" and consider making it a PUT
     public async Task<IActionResult> CreateRelatedKlantcontact([FromBody] RequestModel request)
     {
-        var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(request.InterneTaakId);
+        var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(request.InterneTaakId, "close-with-klantcontact");
         if (blocked != null) return blocked;
 
         try

--- a/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CreateKlantContact/CreateKlantContactController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CreateKlantContact/CreateKlantContactController.cs
@@ -1,6 +1,7 @@
 ﻿using InterneTaakAfhandeling.Common.Exceptions;
 using InterneTaakAfhandeling.Web.Server.Authentication;
 using InterneTaakAfhandeling.Web.Server.Exceptions;
+using InterneTaakAfhandeling.Web.Server.Guards;
 using InterneTaakAfhandeling.Web.Server.Services.LogboekService;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -19,24 +20,32 @@ public class CreateKlantContactController : Controller
     private readonly ITAUser _user;
 
 
+    private readonly IInternetaakGuardService _internetaakGuardService;
+
     public CreateKlantContactController(
         ITAUser user,
         ICreateKlantContactService createKlantContactService,
         ILogger<CreateKlantContactController> logger,
-        ILogboekService logboekService)
+        ILogboekService logboekService,
+        IInternetaakGuardService internetaakGuardService)
     {
         _user = user ?? throw new ArgumentNullException(nameof(user));
         _createKlantContactService = createKlantContactService ??
                                      throw new ArgumentNullException(nameof(createKlantContactService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _logboekService = logboekService ?? throw new ArgumentNullException(nameof(logboekService));
+        _internetaakGuardService = internetaakGuardService ?? throw new ArgumentNullException(nameof(internetaakGuardService));
     }
 
     [ProducesResponseType(typeof(RelatedKlantcontactResult), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ITAException), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
     [HttpPost("add-klantcontact")] //todo refactor, route should be api/klantcontacten/[klantcontactUuid]/klantcontacten
     public async Task<IActionResult> CreateRelatedKlantcontact([FromBody] CreateRelatedKlantcontactRequestModel request)
     {
+        var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(request.InterneTaakId, "add-klantcontact");
+        if (blocked != null) return blocked;
+
         try
         {
             _logger.LogInformation(

--- a/InterneTaakAfhandeling.Web.Server/Features/KoppelZaakAanKlantcontact/KoppelZaakAanKlantcontactController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/KoppelZaakAanKlantcontact/KoppelZaakAanKlantcontactController.cs
@@ -6,6 +6,7 @@ using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
 using InterneTaakAfhandeling.Common.Services.ZakenApi;
 using InterneTaakAfhandeling.Common.Services.ZakenApi.Models;
 using InterneTaakAfhandeling.Web.Server.Authentication;
+using InterneTaakAfhandeling.Web.Server.Guards;
 using InterneTaakAfhandeling.Web.Server.Services.LogboekService;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -23,12 +24,14 @@ public class KoppelZaakAanKlantcontactController : Controller
     private readonly IOpenKlantApiClient _openKlantApiClient;
     private readonly IZakenApiClient _zakenApiClient;
     private readonly ITAUser _user;
+    private readonly IInternetaakGuardService _internetaakGuardService;
 
     public KoppelZaakAanKlantcontactController(
         IZakenApiClient zakenApiClient,
         IOpenKlantApiClient openKlantApiClient,
         ILogger<KoppelZaakAanKlantcontactController> logger,
         ILogboekService logboekService,
+        IInternetaakGuardService internetaakGuardService,
         ITAUser user
         )
     {
@@ -36,6 +39,7 @@ public class KoppelZaakAanKlantcontactController : Controller
         _openKlantApiClient = openKlantApiClient ?? throw new ArgumentNullException(nameof(openKlantApiClient));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _logboekService = logboekService ?? throw new ArgumentNullException(nameof(logboekService));
+        _internetaakGuardService = internetaakGuardService ?? throw new ArgumentNullException(nameof(internetaakGuardService));
         _user = user;
     }
 
@@ -48,6 +52,17 @@ public class KoppelZaakAanKlantcontactController : Controller
     {
         try
         {
+            if (!Guid.TryParse(request.InternetaakId, out var internetaakGuid))
+                return BadRequest(new ProblemDetails
+                {
+                    Title = "Ongeldige aanvraag",
+                    Detail = "InternetaakId is geen geldig UUID",
+                    Status = StatusCodes.Status400BadRequest
+                });
+
+            var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(internetaakGuid);
+            if (blocked != null) return blocked;
+
             if (string.IsNullOrWhiteSpace(request.ZaakIdentificatie))
                 return BadRequest(new ProblemDetails
                 {

--- a/InterneTaakAfhandeling.Web.Server/Features/KoppelZaakAanKlantcontact/KoppelZaakAanKlantcontactController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/KoppelZaakAanKlantcontact/KoppelZaakAanKlantcontactController.cs
@@ -60,7 +60,7 @@ public class KoppelZaakAanKlantcontactController : Controller
                     Status = StatusCodes.Status400BadRequest
                 });
 
-            var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(internetaakGuid);
+            var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(internetaakGuid, "koppel-zaak");
             if (blocked != null) return blocked;
 
             if (string.IsNullOrWhiteSpace(request.ZaakIdentificatie))

--- a/InterneTaakAfhandeling.Web.Server/Guards/IInternetaakGuardService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Guards/IInternetaakGuardService.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace InterneTaakAfhandeling.Web.Server.Guards;
+
+public interface IInternetaakGuardService
+{
+    /// <summary>
+    /// Checks whether the interne taak has status 'verwerkt'.
+    /// Returns a 409 Conflict ObjectResult if blocked, or null if the mutation is allowed.
+    /// </summary>
+    Task<ObjectResult?> EnsureNotVerwerktAsync(Guid internetaakId);
+}

--- a/InterneTaakAfhandeling.Web.Server/Guards/IInternetaakGuardService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Guards/IInternetaakGuardService.cs
@@ -8,5 +8,5 @@ public interface IInternetaakGuardService
     /// Checks whether the interne taak has status 'verwerkt'.
     /// Returns a 409 Conflict ObjectResult if blocked, or null if the mutation is allowed.
     /// </summary>
-    Task<ObjectResult?> EnsureNotVerwerktAsync(Guid internetaakId);
+    Task<ObjectResult?> EnsureNotVerwerktAsync(Guid internetaakId, string actionType);
 }

--- a/InterneTaakAfhandeling.Web.Server/Guards/InternetaakGuardService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Guards/InternetaakGuardService.cs
@@ -7,7 +7,7 @@ public class InternetaakGuardService(
     IOpenKlantApiClient openKlantApiClient,
     ILogger<InternetaakGuardService> logger) : IInternetaakGuardService
 {
-    public async Task<ObjectResult?> EnsureNotVerwerktAsync(Guid internetaakId)
+    public async Task<ObjectResult?> EnsureNotVerwerktAsync(Guid internetaakId, string actionType)
     {
         var internetaak = await openKlantApiClient.GetInternetaakByIdAsync(internetaakId);
 
@@ -17,7 +17,8 @@ public class InternetaakGuardService(
         }
 
         logger.LogWarning(
-            "Mutation blocked: interne taak {InternetaakId} has status 'verwerkt'",
+            "Mutation blocked: action {ActionType} on interne taak {InternetaakId} has status 'verwerkt'",
+            actionType,
             internetaakId);
 
         var problemDetails = new ProblemDetails

--- a/InterneTaakAfhandeling.Web.Server/Guards/InternetaakGuardService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Guards/InternetaakGuardService.cs
@@ -1,0 +1,36 @@
+using InterneTaakAfhandeling.Common.Services.OpenKlantApi;
+using Microsoft.AspNetCore.Mvc;
+
+namespace InterneTaakAfhandeling.Web.Server.Guards;
+
+public class InternetaakGuardService(
+    IOpenKlantApiClient openKlantApiClient,
+    ILogger<InternetaakGuardService> logger) : IInternetaakGuardService
+{
+    public async Task<ObjectResult?> EnsureNotVerwerktAsync(Guid internetaakId)
+    {
+        var internetaak = await openKlantApiClient.GetInternetaakByIdAsync(internetaakId);
+
+        if (internetaak.Status != KnownInternetaakStatussen.Verwerkt)
+        {
+            return null;
+        }
+
+        logger.LogWarning(
+            "Mutation blocked: interne taak {InternetaakId} has status 'verwerkt'",
+            internetaakId);
+
+        var problemDetails = new ProblemDetails
+        {
+            Type = "https://tools.ietf.org/html/rfc9110#section-15.5.10",
+            Title = "Contactverzoek is afgehandeld",
+            Detail = "Dit contactverzoek heeft status 'verwerkt' en kan niet meer worden gewijzigd.",
+            Status = StatusCodes.Status409Conflict
+        };
+
+        return new ObjectResult(problemDetails)
+        {
+            StatusCode = StatusCodes.Status409Conflict
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Protects the integrity of completed contactverzoeken by blocking all mutation endpoints when the interne taak has status `verwerkt`. This prevents medewerkers from accidentally modifying closed dossiers — whether from the UI or via direct API calls. Serves Feature #344 (Afgehandeld contactverzoek alleen leesbaar) acceptance criterion: "Een directe API-aanroep die probeert een afgehandeld contactverzoek te muteren wordt geweigerd met een duidelijke foutmelding."

## Changes

- **Guard service**: New `IInternetaakGuardService` / `InternetaakGuardService` that fetches the interne taak status and throws a 409 ProblemDetails response when status is `verwerkt`
- **Mutation controllers**: Integrated the guard into all five mutation endpoints (assign, notitie, forward, koppel-zaak, close-with-klantcontact)
- **DI registration**: Registered the guard service in `ServiceCollectionExtensions`

## Test plan

- [ ] Assigning to self is rejected for verwerkt contactverzoek (HTTP 409)
- [ ] Adding a notitie is rejected for verwerkt contactverzoek (HTTP 409)
- [ ] Forwarding is rejected for verwerkt contactverzoek (HTTP 409)
- [ ] Linking a zaak is rejected for verwerkt contactverzoek (HTTP 409)
- [ ] Registering a contactmoment is rejected for verwerkt contactverzoek (HTTP 409)
- [ ] Mutation is allowed for te_verwerken contactverzoek

## Related

Closes #390