### PR TITLE
feat(contactverzoek): hide mutation controls for verwerkte contactverzoeken

### DIFF
--- a/InterneTaakAfhandeling.Web.Client/src/components/ContactverzoekDetails.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/ContactverzoekDetails.vue
@@ -21,7 +21,7 @@
         Gekoppelde zaak
 
         <koppel-zaak-modal
-          v-if="taak?.aanleidinggevendKlantcontact?.uuid"
+          v-if="taak?.aanleidinggevendKlantcontact?.uuid && !isAfgehandeld"
           :aanleidinggevendKlantcontactUuid="taak.aanleidinggevendKlantcontact.uuid"
           :zaakIdentificatie="taak?.zaak?.identificatie"
           :internetaak-id="taak.uuid"
@@ -50,7 +50,7 @@ import InterneToelichtingSection from "./InterneToelichtingSection.vue";
 import type { Internetaken, Zaak } from "@/types/internetaken";
 import KoppelZaakModal from "@/components/KoppelZaakModal.vue";
 
-defineProps<{ taak: Internetaken; zaak: Zaak | undefined }>();
+defineProps<{ taak: Internetaken; zaak: Zaak | undefined; isAfgehandeld?: boolean }>();
 
 const labelId = useId();
 </script>

--- a/InterneTaakAfhandeling.Web.Client/src/views/ContactverzoekDetailView.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/views/ContactverzoekDetailView.vue
@@ -7,7 +7,7 @@
       <utrecht-heading :level="1"
         >Contactverzoek {{ taak.aanleidinggevendKlantcontact?.nummer }}</utrecht-heading
       >
-      <utrecht-button-group>
+      <utrecht-button-group v-if="!isAfgehandeld">
         <assign-contactverzoek-to-me
           :id="taak.uuid"
           :user-email="userEmail"
@@ -29,6 +29,7 @@
       <contactverzoek-details
         :taak="taak"
         :zaak="taak.zaak"
+        :is-afgehandeld="isAfgehandeld"
         @zaak-gekoppeld="handleZaakGekoppeld"
       />
     </detail-section>
@@ -46,7 +47,11 @@
     </detail-section>
 
     <detail-section title="Acties">
-      <contactverzoek-acties :taak="taak" @success="fetchInternetaken" />
+      <contactverzoek-acties v-if="!isAfgehandeld" :taak="taak" @success="fetchInternetaken" />
+
+      <utrecht-paragraph v-else class="same-margin-as-datalist" role="alert">
+        Dit contactverzoek is afgehandeld en kan niet meer worden gewijzigd.
+      </utrecht-paragraph>
     </detail-section>
 
     <detail-section title="Logboek contactverzoek" class="ita-detail-section--compact">
@@ -88,6 +93,7 @@ const errorMessage = ref<string | null>(null);
 const isContactmomentRoute = computed(() => !!props.contactmomentNumber);
 const routeNummer = computed(() => props.contactmomentNumber ?? props.contactverzoekId ?? "");
 const userEmail = computed(() => authStore.user?.email ?? "");
+const isAfgehandeld = computed(() => taak.value?.status === "verwerkt");
 
 const handleZaakGekoppeld = () => {
   fetchInternetaken();

--- a/InterneTaakAfhandeling.Web.Client/src/views/ContactverzoekDetailView.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/views/ContactverzoekDetailView.vue
@@ -49,7 +49,7 @@
     <detail-section title="Acties">
       <contactverzoek-acties v-if="!isAfgehandeld" :taak="taak" @success="fetchInternetaken" />
 
-      <utrecht-paragraph v-else class="same-margin-as-datalist" role="alert">
+      <utrecht-paragraph v-else class="same-margin-as-datalist">
         Dit contactverzoek is afgehandeld en kan niet meer worden gewijzigd.
       </utrecht-paragraph>
     </detail-section>


### PR DESCRIPTION
## Summary

Prevents medewerkers from accidentally modifying a completed contactverzoek by hiding all action controls in the UI when the status is `verwerkt`. This ensures the afhandelingshistorie remains integer and provides clear visual feedback that the dossier is closed.

Part of Feature #344 — Afgehandeld contactverzoek alleen leesbaar.

## Changes

- Added a computed `isAfgehandeld` check in `ContactverzoekDetailView.vue` that evaluates `status === "verwerkt"`
- Conditionally hides the full Acties section and shows an informational message when the contactverzoek is afgehandeld
- Hides the "Zaak koppelen" pen icon in `ContactverzoekDetails.vue` for verwerkte contactverzoeken

## Test plan

- [ ] Action controls are hidden for a verwerkt contactverzoek and informational message is shown
- [ ] Action controls are available for an open (te_verwerken) contactverzoek
- [ ] Access via "Mijn historie" also shows read-only mode

## Related

Closes #403