### PR TITLE
feat(contactverzoek): enforce read-only mode for afgehandelde contactverzoeken

### DIFF
--- a/InterneTaakAfhandeling.Web.Client/src/components/ContactverzoekDetails.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/ContactverzoekDetails.vue
@@ -21,7 +21,7 @@
         Gekoppelde zaak
 
         <koppel-zaak-modal
-          v-if="taak?.aanleidinggevendKlantcontact?.uuid"
+          v-if="taak?.aanleidinggevendKlantcontact?.uuid && !isAfgehandeld"
           :aanleidinggevendKlantcontactUuid="taak.aanleidinggevendKlantcontact.uuid"
           :zaakIdentificatie="taak?.zaak?.identificatie"
           :internetaak-id="taak.uuid"
@@ -50,7 +50,7 @@ import InterneToelichtingSection from "./InterneToelichtingSection.vue";
 import type { Internetaken, Zaak } from "@/types/internetaken";
 import KoppelZaakModal from "@/components/KoppelZaakModal.vue";
 
-defineProps<{ taak: Internetaken; zaak: Zaak | undefined }>();
+defineProps<{ taak: Internetaken; zaak: Zaak | undefined; isAfgehandeld?: boolean }>();
 
 const labelId = useId();
 </script>

--- a/InterneTaakAfhandeling.Web.Client/src/views/ContactverzoekDetailView.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/views/ContactverzoekDetailView.vue
@@ -7,7 +7,7 @@
       <utrecht-heading :level="1"
         >Contactverzoek {{ taak.aanleidinggevendKlantcontact?.nummer }}</utrecht-heading
       >
-      <utrecht-button-group>
+      <utrecht-button-group v-if="!isAfgehandeld">
         <assign-contactverzoek-to-me
           :id="taak.uuid"
           :user-email="userEmail"
@@ -29,6 +29,7 @@
       <contactverzoek-details
         :taak="taak"
         :zaak="taak.zaak"
+        :is-afgehandeld="isAfgehandeld"
         @zaak-gekoppeld="handleZaakGekoppeld"
       />
     </detail-section>
@@ -46,7 +47,11 @@
     </detail-section>
 
     <detail-section title="Acties">
-      <contactverzoek-acties :taak="taak" @success="fetchInternetaken" />
+      <contactverzoek-acties v-if="!isAfgehandeld" :taak="taak" @success="fetchInternetaken" />
+
+      <utrecht-paragraph v-else class="same-margin-as-datalist" role="alert">
+        Dit contactverzoek is afgehandeld en kan niet meer worden gewijzigd.
+      </utrecht-paragraph>
     </detail-section>
 
     <detail-section title="Logboek contactverzoek" class="ita-detail-section--compact">
@@ -88,6 +93,7 @@ const errorMessage = ref<string | null>(null);
 const isContactmomentRoute = computed(() => !!props.contactmomentNumber);
 const routeNummer = computed(() => props.contactmomentNumber ?? props.contactverzoekId ?? "");
 const userEmail = computed(() => authStore.user?.email ?? "");
+const isAfgehandeld = computed(() => taak.value?.status === "verwerkt");
 
 const handleZaakGekoppeld = () => {
   fetchInternetaken();

--- a/InterneTaakAfhandeling.Web.Client/src/views/ContactverzoekDetailView.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/views/ContactverzoekDetailView.vue
@@ -49,7 +49,7 @@
     <detail-section title="Acties">
       <contactverzoek-acties v-if="!isAfgehandeld" :taak="taak" @success="fetchInternetaken" />
 
-      <utrecht-paragraph v-else class="same-margin-as-datalist" role="alert">
+      <utrecht-paragraph v-else class="same-margin-as-datalist">
         Dit contactverzoek is afgehandeld en kan niet meer worden gewijzigd.
       </utrecht-paragraph>
     </detail-section>

--- a/InterneTaakAfhandeling.Web.Server/Config/ServiceCollectionExtensions.cs
+++ b/InterneTaakAfhandeling.Web.Server/Config/ServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ using InterneTaakAfhandeling.Web.Server.Features.KlantContact;
 using InterneTaakAfhandeling.Web.Server.Features.MyInterneTakenOverview;
 using InterneTaakAfhandeling.Web.Server.Middleware;
 using InterneTaakAfhandeling.Web.Server.Services;
+using InterneTaakAfhandeling.Web.Server.Guards;
 using InterneTaakAfhandeling.Web.Server.Services.LogboekService;
 using Microsoft.EntityFrameworkCore;
 
@@ -58,6 +59,7 @@ namespace InterneTaakAfhandeling.Web.Server.Config
             services.AddScoped<IAssignInternetaakToMeService, AssignInternetaakToMeService>();
             services.AddScoped<IForwardContactRequestService, ForwardContactRequestService>();
             services.AddScoped<ILogboekService, LogboekService>();
+            services.AddScoped<IInternetaakGuardService, InternetaakGuardService>();
             services.AddScoped<IMyInterneTakenOverviewService, MyInterneTakenOverviewService>();
             services.AddSmtpClients(configuration);
             

--- a/InterneTaakAfhandeling.Web.Server/Features/AddNotitieToInternetaak/AddNotitieToInternetaakController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/AddNotitieToInternetaak/AddNotitieToInternetaakController.cs
@@ -1,4 +1,5 @@
 using InterneTaakAfhandeling.Web.Server.Authentication;
+using InterneTaakAfhandeling.Web.Server.Guards;
 using InterneTaakAfhandeling.Web.Server.Services.LogboekService;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -11,19 +12,27 @@ namespace InterneTaakAfhandeling.Web.Server.Features.AddNotitieToInternetaak;
 [ProducesResponseType(StatusCodes.Status401Unauthorized)]
 public class AddNotitieToInternetaakController(
     ITAUser user,
-    ILogboekService logboekService) : Controller
+    ILogboekService logboekService,
+    IInternetaakGuardService internetaakGuardService) : Controller
 {
     private readonly ILogboekService _logboekService =
         logboekService ?? throw new ArgumentNullException(nameof(logboekService));
 
     private readonly ITAUser _user = user ?? throw new ArgumentNullException(nameof(user));
 
+    private readonly IInternetaakGuardService _internetaakGuardService =
+        internetaakGuardService ?? throw new ArgumentNullException(nameof(internetaakGuardService));
+
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
     [HttpPost("{internetaakId}/notitie")]
     public async Task<IActionResult> AddNote([FromRoute] Guid internetaakId, [FromBody] AddNotitieRequest request)
     {
+        var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(internetaakId);
+        if (blocked != null) return blocked;
+
         var notitieAction = KnownContactAction.Note(request.Notitie, _user);
         await _logboekService.LogContactRequestAction(notitieAction, internetaakId);
 

--- a/InterneTaakAfhandeling.Web.Server/Features/AddNotitieToInternetaak/AddNotitieToInternetaakController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/AddNotitieToInternetaak/AddNotitieToInternetaakController.cs
@@ -30,7 +30,7 @@ public class AddNotitieToInternetaakController(
     [HttpPost("{internetaakId}/notitie")]
     public async Task<IActionResult> AddNote([FromRoute] Guid internetaakId, [FromBody] AddNotitieRequest request)
     {
-        var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(internetaakId);
+        var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(internetaakId, "notitie");
         if (blocked != null) return blocked;
 
         var notitieAction = KnownContactAction.Note(request.Notitie, _user);

--- a/InterneTaakAfhandeling.Web.Server/Features/AddNotitieToInternetaak/AddNotitieToInternetaakController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/AddNotitieToInternetaak/AddNotitieToInternetaakController.cs
@@ -13,7 +13,8 @@ namespace InterneTaakAfhandeling.Web.Server.Features.AddNotitieToInternetaak;
 public class AddNotitieToInternetaakController(
     ITAUser user,
     ILogboekService logboekService,
-    IInternetaakGuardService internetaakGuardService) : Controller
+    IInternetaakGuardService internetaakGuardService,
+    ILogger<AddNotitieToInternetaakController> logger) : Controller
 {
     private readonly ILogboekService _logboekService =
         logboekService ?? throw new ArgumentNullException(nameof(logboekService));
@@ -23,6 +24,9 @@ public class AddNotitieToInternetaakController(
     private readonly IInternetaakGuardService _internetaakGuardService =
         internetaakGuardService ?? throw new ArgumentNullException(nameof(internetaakGuardService));
 
+    private readonly ILogger<AddNotitieToInternetaakController> _logger =
+        logger ?? throw new ArgumentNullException(nameof(logger));
+
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
@@ -30,13 +34,21 @@ public class AddNotitieToInternetaakController(
     [HttpPost("{internetaakId}/notitie")]
     public async Task<IActionResult> AddNote([FromRoute] Guid internetaakId, [FromBody] AddNotitieRequest request)
     {
-        var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(internetaakId, "notitie");
-        if (blocked != null) return blocked;
+        try
+        {
+            var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(internetaakId, "notitie");
+            if (blocked != null) return blocked;
 
-        var notitieAction = KnownContactAction.Note(request.Notitie, _user);
-        await _logboekService.LogContactRequestAction(notitieAction, internetaakId);
+            var notitieAction = KnownContactAction.Note(request.Notitie, _user);
+            await _logboekService.LogContactRequestAction(notitieAction, internetaakId);
 
-        return Ok(new { Message = "Notitie succesvol toegevoegd" });
+            return Ok(new { Message = "Notitie succesvol toegevoegd" });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error adding notitie to internetaak {InternetaakId}", internetaakId);
+            throw;
+        }
     }
 }
 

--- a/InterneTaakAfhandeling.Web.Server/Features/AssignInternetaakToMe/AssignInternetaakToMeController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/AssignInternetaakToMe/AssignInternetaakToMeController.cs
@@ -1,5 +1,6 @@
 ﻿using InterneTaakAfhandeling.Common.Helpers;
 using InterneTaakAfhandeling.Web.Server.Authentication;
+using InterneTaakAfhandeling.Web.Server.Guards;
 using InterneTaakAfhandeling.Web.Server.Services.LogboekService;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -14,16 +15,22 @@ namespace InterneTaakAfhandeling.Web.Server.Features.AssignInternetaakToMe
         IAssignInternetaakToMeService AssignInternetakenService,
         ITAUser user,
         ILogboekService logboekService,
+        IInternetaakGuardService internetaakGuardService,
         ILogger<AssignInternetaakToMeController> logger) : Controller
     {
         private readonly IAssignInternetaakToMeService _AssignInternetakenService = AssignInternetakenService;
         private readonly ITAUser _user = user;
         private readonly ILogboekService _logboekService = logboekService ?? throw new ArgumentNullException(nameof(logboekService));
+        private readonly IInternetaakGuardService _internetaakGuardService = internetaakGuardService ?? throw new ArgumentNullException(nameof(internetaakGuardService));
         private readonly ILogger<AssignInternetaakToMeController> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
         [HttpPost("{internetaakId}/aan-mij-toewijzen")]
         public async Task<IActionResult> AssignInternetakenAsync([FromRoute] Guid internetaakId)
         {
+            var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(internetaakId);
+            if (blocked != null) return blocked;
+
             try
             {
                 var (updatedInterneTaak, currentUserActor) = await _AssignInternetakenService.ToSelfAsync(internetaakId, user);
@@ -44,6 +51,3 @@ namespace InterneTaakAfhandeling.Web.Server.Features.AssignInternetaakToMe
         }
     }
 }
-
-
-

--- a/InterneTaakAfhandeling.Web.Server/Features/AssignInternetaakToMe/AssignInternetaakToMeController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/AssignInternetaakToMe/AssignInternetaakToMeController.cs
@@ -28,11 +28,11 @@ namespace InterneTaakAfhandeling.Web.Server.Features.AssignInternetaakToMe
         [HttpPost("{internetaakId}/aan-mij-toewijzen")]
         public async Task<IActionResult> AssignInternetakenAsync([FromRoute] Guid internetaakId)
         {
-            var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(internetaakId, "aan-mij-toewijzen");
-            if (blocked != null) return blocked;
-
             try
             {
+                var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(internetaakId, "aan-mij-toewijzen");
+                if (blocked != null) return blocked;
+
                 var (updatedInterneTaak, currentUserActor) = await _AssignInternetakenService.ToSelfAsync(internetaakId, user);
 
                 var assignedAction = KnownContactAction.AssignedToSelf(currentUserActor.Uuid, _user);

--- a/InterneTaakAfhandeling.Web.Server/Features/AssignInternetaakToMe/AssignInternetaakToMeController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/AssignInternetaakToMe/AssignInternetaakToMeController.cs
@@ -28,7 +28,7 @@ namespace InterneTaakAfhandeling.Web.Server.Features.AssignInternetaakToMe
         [HttpPost("{internetaakId}/aan-mij-toewijzen")]
         public async Task<IActionResult> AssignInternetakenAsync([FromRoute] Guid internetaakId)
         {
-            var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(internetaakId);
+            var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(internetaakId, "aan-mij-toewijzen");
             if (blocked != null) return blocked;
 
             try

--- a/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestController.cs
@@ -1,4 +1,5 @@
 using InterneTaakAfhandeling.Web.Server.Authentication;
+using InterneTaakAfhandeling.Web.Server.Guards;
 using InterneTaakAfhandeling.Web.Server.Services.LogboekService;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -12,6 +13,7 @@ namespace InterneTaakAfhandeling.Web.Server.Features.ForwardContactRequest;
 public class ForwardContactRequestController(
     IForwardContactRequestService forwardContactRequestService,
     ILogboekService logboekService,
+    IInternetaakGuardService internetaakGuardService,
     ITAUser user) : Controller
 {
     private readonly ITAUser _user = user ?? throw new ArgumentNullException(nameof(user));
@@ -19,10 +21,14 @@ public class ForwardContactRequestController(
     [ProducesResponseType(typeof(ForwardContactRequestResponse),StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
     [HttpPost("{id:guid}/forward")]
     public async Task<IActionResult> ForwardContactRequestAsync([FromRoute] Guid id,
         [FromBody] ForwardContactRequestModel request)
     {
+        var blocked = await internetaakGuardService.EnsureNotVerwerktAsync(id);
+        if (blocked != null) return blocked;
+
         var response = await forwardContactRequestService.ForwardAsync(id, request);
         await logboekService.LogContactRequestAction(KnownContactAction.ForwardKlantContact(request, _user), id);
 

--- a/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestController.cs
@@ -14,7 +14,8 @@ public class ForwardContactRequestController(
     IForwardContactRequestService forwardContactRequestService,
     ILogboekService logboekService,
     IInternetaakGuardService internetaakGuardService,
-    ITAUser user) : Controller
+    ITAUser user,
+    ILogger<ForwardContactRequestController> logger) : Controller
 {
     private readonly ITAUser _user = user ?? throw new ArgumentNullException(nameof(user));
 
@@ -26,12 +27,20 @@ public class ForwardContactRequestController(
     public async Task<IActionResult> ForwardContactRequestAsync([FromRoute] Guid id,
         [FromBody] ForwardContactRequestModel request)
     {
-        var blocked = await internetaakGuardService.EnsureNotVerwerktAsync(id, "forward");
-        if (blocked != null) return blocked;
+        try
+        {
+            var blocked = await internetaakGuardService.EnsureNotVerwerktAsync(id, "forward");
+            if (blocked != null) return blocked;
 
-        var response = await forwardContactRequestService.ForwardAsync(id, request);
-        await logboekService.LogContactRequestAction(KnownContactAction.ForwardKlantContact(request, _user), id);
+            var response = await forwardContactRequestService.ForwardAsync(id, request);
+            await logboekService.LogContactRequestAction(KnownContactAction.ForwardKlantContact(request, _user), id);
 
-        return Ok(response);
+            return Ok(response);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error forwarding internetaak {InternetaakId}", id);
+            throw;
+        }
     }
 }

--- a/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestController.cs
@@ -26,7 +26,7 @@ public class ForwardContactRequestController(
     public async Task<IActionResult> ForwardContactRequestAsync([FromRoute] Guid id,
         [FromBody] ForwardContactRequestModel request)
     {
-        var blocked = await internetaakGuardService.EnsureNotVerwerktAsync(id);
+        var blocked = await internetaakGuardService.EnsureNotVerwerktAsync(id, "forward");
         if (blocked != null) return blocked;
 
         var response = await forwardContactRequestService.ForwardAsync(id, request);

--- a/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CloseInterneTaakWithKlantContact/CloseInterneTaakWithKlantContactController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CloseInterneTaakWithKlantContact/CloseInterneTaakWithKlantContactController.cs
@@ -41,14 +41,15 @@ public class CloseInterneTaakWithKlantContactController(
 
     [ProducesResponseType(typeof(RelatedKlantcontactResult), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ITAException), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
     [HttpPost("close-with-klantcontact")] //todo: refactor to "HttpPost("[internetaakUuid]/close-with-klantcontact)" and consider making it a PUT
     public async Task<IActionResult> CreateRelatedKlantcontact([FromBody] RequestModel request)
     {
-        var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(request.InterneTaakId, "close-with-klantcontact");
-        if (blocked != null) return blocked;
-
         try
         {
+            var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(request.InterneTaakId, "close-with-klantcontact");
+            if (blocked != null) return blocked;
+
             _logger.LogInformation(
                 "Closing Interne taak and creating related klantcontact with aanleidinggevendKlantcontact UUID: {AanleidinggevendKlantcontactUuid}",
                 request.AanleidinggevendKlantcontactUuid);

--- a/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CloseInterneTaakWithKlantContact/CloseInterneTaakWithKlantContactController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CloseInterneTaakWithKlantContact/CloseInterneTaakWithKlantContactController.cs
@@ -3,6 +3,7 @@ using InterneTaakAfhandeling.Common.Services.OpenKlantApi;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
 using InterneTaakAfhandeling.Web.Server.Authentication;
 using InterneTaakAfhandeling.Web.Server.Exceptions;
+using InterneTaakAfhandeling.Web.Server.Guards;
 using InterneTaakAfhandeling.Web.Server.Services.LogboekService;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -18,6 +19,7 @@ public class CloseInterneTaakWithKlantContactController(
     ICreateKlantContactService createKlantContactService,
     ILogger<CloseInterneTaakWithKlantContactController> logger,
     IOpenKlantApiClient openKlantApiClient,
+    IInternetaakGuardService internetaakGuardService,
     ILogboekService logboekService) : Controller
 {
     private readonly ICreateKlantContactService _createKlantContactService =
@@ -34,11 +36,17 @@ public class CloseInterneTaakWithKlantContactController(
     private readonly IOpenKlantApiClient openKlantApiClient =
         openKlantApiClient ?? throw new ArgumentNullException(nameof(openKlantApiClient));
 
+    private readonly IInternetaakGuardService _internetaakGuardService =
+        internetaakGuardService ?? throw new ArgumentNullException(nameof(internetaakGuardService));
+
     [ProducesResponseType(typeof(RelatedKlantcontactResult), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ITAException), StatusCodes.Status409Conflict)]
     [HttpPost("close-with-klantcontact")] //todo: refactor to "HttpPost("[internetaakUuid]/close-with-klantcontact)" and consider making it a PUT
     public async Task<IActionResult> CreateRelatedKlantcontact([FromBody] RequestModel request)
     {
+        var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(request.InterneTaakId);
+        if (blocked != null) return blocked;
+
         try
         {
             _logger.LogInformation(

--- a/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CloseInterneTaakWithKlantContact/CloseInterneTaakWithKlantContactController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CloseInterneTaakWithKlantContact/CloseInterneTaakWithKlantContactController.cs
@@ -44,7 +44,7 @@ public class CloseInterneTaakWithKlantContactController(
     [HttpPost("close-with-klantcontact")] //todo: refactor to "HttpPost("[internetaakUuid]/close-with-klantcontact)" and consider making it a PUT
     public async Task<IActionResult> CreateRelatedKlantcontact([FromBody] RequestModel request)
     {
-        var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(request.InterneTaakId);
+        var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(request.InterneTaakId, "close-with-klantcontact");
         if (blocked != null) return blocked;
 
         try

--- a/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CreateKlantContact/CreateKlantContactController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CreateKlantContact/CreateKlantContactController.cs
@@ -1,6 +1,7 @@
 ﻿using InterneTaakAfhandeling.Common.Exceptions;
 using InterneTaakAfhandeling.Web.Server.Authentication;
 using InterneTaakAfhandeling.Web.Server.Exceptions;
+using InterneTaakAfhandeling.Web.Server.Guards;
 using InterneTaakAfhandeling.Web.Server.Services.LogboekService;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -19,24 +20,32 @@ public class CreateKlantContactController : Controller
     private readonly ITAUser _user;
 
 
+    private readonly IInternetaakGuardService _internetaakGuardService;
+
     public CreateKlantContactController(
         ITAUser user,
         ICreateKlantContactService createKlantContactService,
         ILogger<CreateKlantContactController> logger,
-        ILogboekService logboekService)
+        ILogboekService logboekService,
+        IInternetaakGuardService internetaakGuardService)
     {
         _user = user ?? throw new ArgumentNullException(nameof(user));
         _createKlantContactService = createKlantContactService ??
                                      throw new ArgumentNullException(nameof(createKlantContactService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _logboekService = logboekService ?? throw new ArgumentNullException(nameof(logboekService));
+        _internetaakGuardService = internetaakGuardService ?? throw new ArgumentNullException(nameof(internetaakGuardService));
     }
 
     [ProducesResponseType(typeof(RelatedKlantcontactResult), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ITAException), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
     [HttpPost("add-klantcontact")] //todo refactor, route should be api/klantcontacten/[klantcontactUuid]/klantcontacten
     public async Task<IActionResult> CreateRelatedKlantcontact([FromBody] CreateRelatedKlantcontactRequestModel request)
     {
+        var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(request.InterneTaakId, "add-klantcontact");
+        if (blocked != null) return blocked;
+
         try
         {
             _logger.LogInformation(

--- a/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CreateKlantContact/CreateKlantContactController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CreateKlantContact/CreateKlantContactController.cs
@@ -43,11 +43,11 @@ public class CreateKlantContactController : Controller
     [HttpPost("add-klantcontact")] //todo refactor, route should be api/klantcontacten/[klantcontactUuid]/klantcontacten
     public async Task<IActionResult> CreateRelatedKlantcontact([FromBody] CreateRelatedKlantcontactRequestModel request)
     {
-        var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(request.InterneTaakId, "add-klantcontact");
-        if (blocked != null) return blocked;
-
         try
         {
+            var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(request.InterneTaakId, "add-klantcontact");
+            if (blocked != null) return blocked;
+            
             _logger.LogInformation(
                 "Creating related klantcontact with aanleidinggevendKlantcontact UUID: {aanleidinggevendKlantcontactUuid}",
                 request.AanleidinggevendKlantcontactUuid);

--- a/InterneTaakAfhandeling.Web.Server/Features/KoppelZaakAanKlantcontact/KoppelZaakAanKlantcontactController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/KoppelZaakAanKlantcontact/KoppelZaakAanKlantcontactController.cs
@@ -6,6 +6,7 @@ using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
 using InterneTaakAfhandeling.Common.Services.ZakenApi;
 using InterneTaakAfhandeling.Common.Services.ZakenApi.Models;
 using InterneTaakAfhandeling.Web.Server.Authentication;
+using InterneTaakAfhandeling.Web.Server.Guards;
 using InterneTaakAfhandeling.Web.Server.Services.LogboekService;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -23,12 +24,14 @@ public class KoppelZaakAanKlantcontactController : Controller
     private readonly IOpenKlantApiClient _openKlantApiClient;
     private readonly IZakenApiClient _zakenApiClient;
     private readonly ITAUser _user;
+    private readonly IInternetaakGuardService _internetaakGuardService;
 
     public KoppelZaakAanKlantcontactController(
         IZakenApiClient zakenApiClient,
         IOpenKlantApiClient openKlantApiClient,
         ILogger<KoppelZaakAanKlantcontactController> logger,
         ILogboekService logboekService,
+        IInternetaakGuardService internetaakGuardService,
         ITAUser user
         )
     {
@@ -36,6 +39,7 @@ public class KoppelZaakAanKlantcontactController : Controller
         _openKlantApiClient = openKlantApiClient ?? throw new ArgumentNullException(nameof(openKlantApiClient));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _logboekService = logboekService ?? throw new ArgumentNullException(nameof(logboekService));
+        _internetaakGuardService = internetaakGuardService ?? throw new ArgumentNullException(nameof(internetaakGuardService));
         _user = user;
     }
 
@@ -48,6 +52,17 @@ public class KoppelZaakAanKlantcontactController : Controller
     {
         try
         {
+            if (!Guid.TryParse(request.InternetaakId, out var internetaakGuid))
+                return BadRequest(new ProblemDetails
+                {
+                    Title = "Ongeldige aanvraag",
+                    Detail = "InternetaakId is geen geldig UUID",
+                    Status = StatusCodes.Status400BadRequest
+                });
+
+            var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(internetaakGuid);
+            if (blocked != null) return blocked;
+
             if (string.IsNullOrWhiteSpace(request.ZaakIdentificatie))
                 return BadRequest(new ProblemDetails
                 {

--- a/InterneTaakAfhandeling.Web.Server/Features/KoppelZaakAanKlantcontact/KoppelZaakAanKlantcontactController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/KoppelZaakAanKlantcontact/KoppelZaakAanKlantcontactController.cs
@@ -60,7 +60,7 @@ public class KoppelZaakAanKlantcontactController : Controller
                     Status = StatusCodes.Status400BadRequest
                 });
 
-            var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(internetaakGuid);
+            var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(internetaakGuid, "koppel-zaak");
             if (blocked != null) return blocked;
 
             if (string.IsNullOrWhiteSpace(request.ZaakIdentificatie))

--- a/InterneTaakAfhandeling.Web.Server/Guards/IInternetaakGuardService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Guards/IInternetaakGuardService.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace InterneTaakAfhandeling.Web.Server.Guards;
+
+public interface IInternetaakGuardService
+{
+    /// <summary>
+    /// Checks whether the interne taak has status 'verwerkt'.
+    /// Returns a 409 Conflict ObjectResult if blocked, or null if the mutation is allowed.
+    /// </summary>
+    Task<ObjectResult?> EnsureNotVerwerktAsync(Guid internetaakId);
+}

--- a/InterneTaakAfhandeling.Web.Server/Guards/IInternetaakGuardService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Guards/IInternetaakGuardService.cs
@@ -8,5 +8,5 @@ public interface IInternetaakGuardService
     /// Checks whether the interne taak has status 'verwerkt'.
     /// Returns a 409 Conflict ObjectResult if blocked, or null if the mutation is allowed.
     /// </summary>
-    Task<ObjectResult?> EnsureNotVerwerktAsync(Guid internetaakId);
+    Task<ObjectResult?> EnsureNotVerwerktAsync(Guid internetaakId, string actionType);
 }

--- a/InterneTaakAfhandeling.Web.Server/Guards/InternetaakGuardService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Guards/InternetaakGuardService.cs
@@ -7,7 +7,7 @@ public class InternetaakGuardService(
     IOpenKlantApiClient openKlantApiClient,
     ILogger<InternetaakGuardService> logger) : IInternetaakGuardService
 {
-    public async Task<ObjectResult?> EnsureNotVerwerktAsync(Guid internetaakId)
+    public async Task<ObjectResult?> EnsureNotVerwerktAsync(Guid internetaakId, string actionType)
     {
         var internetaak = await openKlantApiClient.GetInternetaakByIdAsync(internetaakId);
 
@@ -17,7 +17,8 @@ public class InternetaakGuardService(
         }
 
         logger.LogWarning(
-            "Mutation blocked: interne taak {InternetaakId} has status 'verwerkt'",
+            "Mutation blocked: action {ActionType} on interne taak {InternetaakId} has status 'verwerkt'",
+            actionType,
             internetaakId);
 
         var problemDetails = new ProblemDetails

--- a/InterneTaakAfhandeling.Web.Server/Guards/InternetaakGuardService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Guards/InternetaakGuardService.cs
@@ -1,0 +1,36 @@
+using InterneTaakAfhandeling.Common.Services.OpenKlantApi;
+using Microsoft.AspNetCore.Mvc;
+
+namespace InterneTaakAfhandeling.Web.Server.Guards;
+
+public class InternetaakGuardService(
+    IOpenKlantApiClient openKlantApiClient,
+    ILogger<InternetaakGuardService> logger) : IInternetaakGuardService
+{
+    public async Task<ObjectResult?> EnsureNotVerwerktAsync(Guid internetaakId)
+    {
+        var internetaak = await openKlantApiClient.GetInternetaakByIdAsync(internetaakId);
+
+        if (internetaak.Status != KnownInternetaakStatussen.Verwerkt)
+        {
+            return null;
+        }
+
+        logger.LogWarning(
+            "Mutation blocked: interne taak {InternetaakId} has status 'verwerkt'",
+            internetaakId);
+
+        var problemDetails = new ProblemDetails
+        {
+            Type = "https://tools.ietf.org/html/rfc9110#section-15.5.10",
+            Title = "Contactverzoek is afgehandeld",
+            Detail = "Dit contactverzoek heeft status 'verwerkt' en kan niet meer worden gewijzigd.",
+            Status = StatusCodes.Status409Conflict
+        };
+
+        return new ObjectResult(problemDetails)
+        {
+            StatusCode = StatusCodes.Status409Conflict
+        };
+    }
+}

--- a/docs/steering/QA.md
+++ b/docs/steering/QA.md
@@ -37,9 +37,62 @@ No coverage thresholds are enforced — only E2E tests exist and no coverage too
 - **Mock boundary:** No mocks — all tests hit real external APIs. Keep it this way.
 - **Database:** Not applicable — ITA uses external APIs as source of truth
 
+## Feature Verification Workflow (Two-Phase)
+
+Features are verified in two phases because E2E tests require a deployed environment that is only available after merging to main.
+
+### Phase 1: Implementation Verification (feature branch, pre-merge)
+
+Triggered by: `wtf.verify-task` at feature level.
+
+Verify that the implementation code matches all Gherkin scenarios and edge cases through **code inspection** — without running E2E tests. This phase gates the feature PR merge to main.
+
+**What is verified:**
+- Each Gherkin scenario's logic is correctly implemented (code walkthrough)
+- Edge cases from the Feature are handled
+- Linting, formatting, and type-checks pass
+- No regressions in existing behavior
+
+**Verdict:** ✅ Implementation Verified / ❌ Needs fixes
+
+**On completion:**
+- Implementation tasks receive the `verified` label
+- Feature PR is approved and merged to main
+- The verify skill offers to create the **E2E Test Task** (see below)
+
+### Phase 2: E2E Verification (post-deploy to test environment)
+
+Triggered by: picking up the E2E Test Task after the feature is deployed to `ita.test.icatt.nl`.
+
+**E2E Test Task:**
+- Created as a sub-issue of the Feature at the end of Phase 1
+- References all Gherkin scenarios from implementation tasks (by issue number, not copied) and edge cases from the Feature
+- Scope: write Playwright E2E tests, run against test env, report pass/fail
+- Label: `e2e-test`
+- Depends on: all implementation tasks `verified` + merged + deployed
+
+**What is verified:**
+- All Gherkin scenarios pass as automated Playwright tests
+- Edge cases pass as automated tests
+- No flaky tests introduced
+
+**Verdict:** ✅ E2E Passed / ❌ Regression found (file bugs)
+
+**On completion:**
+- E2E test task receives the `verified` label
+- Feature is considered fully done
+
+### Feature Completion
+
+A Feature is only considered **fully complete** when both phases are done:
+1. ✅ Phase 1 — implementation verified and merged to main
+2. ✅ Phase 2 — E2E tests written, passing, and committed
+
+---
+
 ## Gherkin → Test Mapping
 
-Every Gherkin scenario from a Task issue must map to at least one Playwright E2E test. E2E tests are written and verified at **feature level** — after all task PRs are merged to the feature branch — so the complete vertical slice can be tested as an integrated whole.
+Every Gherkin scenario from a Task issue must map to at least one Playwright E2E test. E2E tests are written as part of the **Phase 2 E2E Test Task** — after the feature is deployed to the test environment.
 
 - Each Gherkin scenario maps to at least one `[TestMethod]` in the corresponding `{Feature}Scenarios.cs`
 - Test method descriptions must reference the scenario name so failures are traceable
@@ -48,25 +101,35 @@ Every Gherkin scenario from a Task issue must map to at least one Playwright E2E
 - Then steps → assertion (`Expect(...).ToBeVisibleAsync()`, `Expect(...).Not.ToBeVisibleAsync()`)
 - Scenarios describe observable behavior, not implementation details
 - **Role-based scenarios** require separate test methods: one logged in with the role, one without
-- Tests may be committed as part of a task PR or added to the feature branch after all tasks land — as long as full coverage exists before the feature PR merges to main
+- E2E tests are committed in a separate PR (the E2E test task PR) so CI can run them against the deployed environment
 
 ## Definition of Done
 
 ### Task-level DoD (task PR → feature branch)
 
-Tasks are reviewed and merged into the feature branch. Testing happens at feature level.
+Tasks are reviewed and merged into the feature branch. E2E testing happens at feature level in Phase 2.
 
 - [ ] Linting passes (`npm run lint:ci`)
 - [ ] Formatting passes (`npm run format:ci`)
 - [ ] PR approved by at least one reviewer
 - [ ] No unrelated changes or scope creep
 
-### Feature-level DoD (feature PR → main)
+### Feature-level DoD — Phase 1 (feature PR → main)
 
-After all tasks are merged to the feature branch, the complete vertical slice is verified.
+After all tasks are merged to the feature branch, the implementation is verified via code inspection.
+
+- [ ] All Gherkin scenarios are correctly implemented (code inspection)
+- [ ] Edge cases from the Feature are handled in code
+- [ ] Linting and formatting pass
+- [ ] PR approved by at least one reviewer
+- [ ] E2E Test Task created for Phase 2
+
+### Feature-level DoD — Phase 2 (E2E test PR → main)
+
+After the feature is deployed to the test environment, E2E tests are written and executed.
 
 - [ ] All Gherkin scenarios from the Feature's tasks are covered by automated E2E tests
-- [ ] E2E tests pass against the feature branch deployment
+- [ ] E2E tests pass against the test environment
 - [ ] No new flaky tests introduced
 - [ ] Regression test added for any bug fix
 - [ ] Edge cases listed in the Feature are covered by E2E tests


### PR DESCRIPTION
## Summary

Implements Feature #344 — once a contactverzoek reaches status *verwerkt*, it becomes permanently read-only. This protects the integrity of closed dossiers by blocking all mutation actions both at API level (HTTP 409) and in the UI (hiding action controls). Reported via Jira PC-2317 where medewerkers could still modify afgehandelde contactverzoeken via "Mijn historie".

## Changes

- **Backend guard service** — new `InternetaakGuardService` that checks interne taak status before allowing any mutation. Applied to all mutation controllers: assign-to-me, add-notitie, forward, koppel-zaak, and close-with-klantcontact.
- **Frontend read-only mode** — `ContactverzoekDetailView` now computes `isAfgehandeld` and hides all action controls, replacing them with an informational message explaining the contactverzoek is afgehandeld.
- **QA documentation** — added two-phase feature verification workflow to `docs/steering/QA.md`.

## Test plan

- [ ] Assigning to self is rejected for verwerkt contactverzoek (HTTP 409)
- [ ] Adding a notitie is rejected for verwerkt contactverzoek (HTTP 409)
- [ ] Forwarding is rejected for verwerkt contactverzoek (HTTP 409)
- [ ] Linking a zaak is rejected for verwerkt contactverzoek (HTTP 409)
- [ ] Registering a contactmoment is rejected for verwerkt contactverzoek (HTTP 409)
- [ ] Mutation is allowed for te_verwerken contactverzoek
- [ ] Action controls are hidden for a verwerkt contactverzoek + informational message shown
- [ ] Action controls are available for an open contactverzoek
- [ ] Access via "Mijn historie" also shows read-only mode

> **Note:** E2E tests (Task #420) will be written after merge and deploy to the test environment, per the [two-phase verification workflow](docs/steering/QA.md#feature-verification-workflow-two-phase).

## Related

Closes #390
Closes #403
Closes #344