### PR TITLE
test(e2e): add E2E tests for readonly contact request guard

### DIFF
--- a/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekScenarioHelpers.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekScenarioHelpers.cs
@@ -134,6 +134,15 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             await Expect(Page.GetContactmomentRegistrerenTab()).ToBeVisibleAsync(new() { Timeout = 10000 });
         }
 
+        private async Task NavigateToVerwerktContactverzoekByNummer(string internetaakNummer)
+        {
+            await Step($"Navigate to verwerkt contactverzoek by nummer: {internetaakNummer}");
+            await SafeGotoAsync($"/contactverzoek/{internetaakNummer}");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            // Verwerkt contactverzoeken hide the action tabs; wait for the afgehandeld message instead.
+            await Expect(Page.GetAfgehandeldMessage()).ToBeVisibleAsync(new() { Timeout = 10000 });
+        }
+
         private async Task NavigateToContactmomentRegistrerenTab()
         {
             await Step("Navigate to Contactmoment Registreren tab");

--- a/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekScenarios.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekScenarios.cs
@@ -258,74 +258,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             Assert.IsNull(internetaak.AfgehandeldOp, "AfgehandeldOp should NOT be set when canceled");
         }
 
-
-        [TestMethod("Validation that closed contactverzoek can still be updated")]
-        public async Task User_UpdateClosedContactverzoek_CanStillAddContactmoment()
-        {
-            var testOnderwerp = $"Test_Update_Closed_{Guid.NewGuid().ToString().Substring(0, 8)}";
-            var contactmomentUuid = await SetupContactverzoek(testOnderwerp, attachZaak: false);
-
-            await NavigateToContactverzoekDetails(testOnderwerp);
-            await NavigateToContactmomentRegistrerenTab();
-
-            await Step("Fill form and close the contactverzoek");
-            await Page.GetKanalenSelect().SelectOptionAsync(new[] { "Telefoon" });
-            await Page.GetInformatieBurgerTextbox().FillAsync("Initial contactmoment before closing");
-
-            await Step("Select 'Ja' for afsluiten to close the contactverzoek");
-            await Page.GetJaLabel().ClickAsync();
-
-            await Step("Click 'Contactmoment opslaan' button to trigger confirmation");
-            await Page.GetContactmomentOpslaanButton().ClickAsync();
-
-            await Step("Verify confirmation dialog is displayed");
-            await Expect(Page.GetByRole(AriaRole.Dialog)).ToBeVisibleAsync();
-
-            await Step("Click 'Opslaan & afronden' on confirmation dialog");
-            await Page.GetOpslaanEnAfrondenButton().ClickAsync();
-
-            await Step("Wait for close confirmation");
-            await Expect(Page.GetContactmomentSuccesvolOpgeslagenEnAfgerondMessage()).ToBeVisibleAsync();
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-
-            await Step("Get internetaak UUID and nummer for navigation");
-            var internetaakUuid = await TestDataHelper.GetInternetaakUuidFromContactmomentAsync(contactmomentUuid);
-            Assert.IsNotNull(internetaakUuid, "Internetaak UUID should be found");
-            
-            var internetaak = await TestDataHelper.GetInternetaakByIdAsync(internetaakUuid.Value);
-            Assert.AreEqual(KnownInternetaakStatussen.Verwerkt, internetaak.Status, "Status should be verwerkt after closing");
-            var internetaakNummer = internetaak.Nummer;
-
-            await Step($"Navigate back to closed contactverzoek using nummer: {internetaakNummer}");
-            await NavigateToContactverzoekByNummer(internetaakNummer!);
-
-            await Step("Verify contactverzoek details page is displayed");
-            await Expect(Page.Locator($"text={testOnderwerp}")).ToBeVisibleAsync();
-            await Expect(Page.GetContactmomentRegistrerenTab()).ToBeVisibleAsync();
-
-            await Step("Navigate to Contactmoment Registreren tab to add another contactmoment");
-            await NavigateToContactmomentRegistrerenTab();
-
-            await Step("Verify 'Contact opnemen gelukt' is selected by default");
-            await Expect(Page.GetContactOpnemenGeluktRadio()).ToBeCheckedAsync();
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-
-            await Step("Fill and save a new contactmoment on the closed contactverzoek");
-            await Page.GetKanalenSelect().SelectOptionAsync(new[] { "E-mail" });
-            await Page.GetInformatieBurgerTextbox().FillAsync("Follow-up contactmoment on closed request");
-            
-            await Step("Select 'Nee' for afsluiten (don't close it again)");
-            await Page.GetNeeLabel().ClickAsync();
-            await Page.GetContactmomentOpslaanButton().ClickAsync();
-
-            await Step("Verify new contactmoment was saved successfully");
-            await Expect(Page.GetContactmomentSuccesvolBijgewerktMessage()).ToBeVisibleAsync();
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-
-            await Step("Verify the new contactmoment appears in Logboek");
-            await Expect(Page.GetByText("Follow-up contactmoment on closed request")).ToBeVisibleAsync();
-        }
-
         [TestMethod("Validation that closed contactverzoek assigned to user appears in Mijn historie")]
         public async Task User_ViewClosedContactverzoekInMijnHistorie()
         {
@@ -689,14 +621,15 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
 
             await Step("Then the detail screen of the contact request is the same as the 'Alle contactverzoeken' page");
             await VerifyBasicContactverzoekFields(testOnderwerp);
-            await VerifyActionTabsArePresent();
             await VerifyMetadataFields();
 
-            await Step("Verify the contactverzoek detail page elements are present");
-            await Expect(Page.Locator($"text={testOnderwerp}")).ToBeVisibleAsync();
-            await Expect(Page.GetContactmomentRegistrerenTab()).ToBeVisibleAsync();
-            await Expect(Page.GetDoorsturenTab()).ToBeVisibleAsync();
-            await Expect(Page.GetAlleenToelichtingTab()).ToBeVisibleAsync();
+            await Step("Verify action controls are hidden for verwerkt contactverzoek (Feature #344)");
+            await Expect(Page.GetContactmomentRegistrerenTab()).Not.ToBeVisibleAsync();
+            await Expect(Page.GetDoorsturenTab()).Not.ToBeVisibleAsync();
+            await Expect(Page.GetAlleenToelichtingTab()).Not.ToBeVisibleAsync();
+
+            await Step("Verify informational message is shown for verwerkt contactverzoek");
+            await Expect(Page.GetAfgehandeldMessage()).ToBeVisibleAsync();
 
             await Step("Verify the contactverzoek shows as verwerkt status");
             await Expect(Page.GetStatusValue()).ToHaveTextAsync("verwerkt");
@@ -1013,6 +946,189 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             await Expect(logbookHeading).ToBeVisibleAsync();
             var logbookSection = logbookHeading.Locator("xpath=ancestor::section");
             await Expect(logbookSection.GetByRole(AriaRole.Paragraph).Filter(new() { HasText = "test logboek" })).ToBeVisibleAsync(new() { Timeout = 10000 });
+        }
+
+        // Feature #344 — Afgehandeld contactverzoek alleen leesbaar
+        // Scenarios from Task #390 (backend guard) and Task #403 (frontend read-only)
+
+        [TestMethod("Assigning to self is rejected for verwerkt contactverzoek")]
+        public async Task AssignToSelf_IsRejected_WhenVerwerkt()
+        {
+            var onderwerp = $"Test_Guard_Assign_{Guid.NewGuid().ToString().Substring(0, 8)}";
+            var (contactmomentUuid, internetaakUuid, _) = await TestDataHelper.CreateVerwerktContactverzoekAsync(onderwerp);
+            RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(contactmomentUuid.ToString()));
+
+            await SafeGotoAsync("/");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+            await Step("Make direct API call to aan-mij-toewijzen on verwerkt contactverzoek");
+            var response = await Page.Context.APIRequest.PostAsync($"/api/internetaken/{internetaakUuid}/aan-mij-toewijzen");
+
+            Assert.AreEqual(409, response.Status, "Expected HTTP 409 when assigning verwerkt contactverzoek");
+            var body = await response.TextAsync();
+            Assert.IsTrue(body.Contains("verwerkt"), "Response body should reference 'verwerkt' status");
+        }
+
+        [TestMethod("Adding a notitie is rejected for verwerkt contactverzoek")]
+        public async Task AddNotitie_IsRejected_WhenVerwerkt()
+        {
+            var onderwerp = $"Test_Guard_Notitie_{Guid.NewGuid().ToString().Substring(0, 8)}";
+            var (contactmomentUuid, internetaakUuid, _) = await TestDataHelper.CreateVerwerktContactverzoekAsync(onderwerp);
+            RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(contactmomentUuid.ToString()));
+
+            await SafeGotoAsync("/");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+            await Step("Make direct API call to notitie endpoint on verwerkt contactverzoek");
+            var response = await Page.Context.APIRequest.PostAsync(
+                $"/api/internetaken/{internetaakUuid}/notitie",
+                new() { DataObject = new { Notitie = "test notitie" } });
+
+            Assert.AreEqual(409, response.Status, "Expected HTTP 409 when adding notitie to verwerkt contactverzoek");
+            var body = await response.TextAsync();
+            Assert.IsTrue(body.Contains("verwerkt"), "Response body should reference 'verwerkt' status");
+        }
+
+        [TestMethod("Forwarding is rejected for verwerkt contactverzoek")]
+        public async Task Forward_IsRejected_WhenVerwerkt()
+        {
+            var onderwerp = $"Test_Guard_Forward_{Guid.NewGuid().ToString().Substring(0, 8)}";
+            var (contactmomentUuid, internetaakUuid, _) = await TestDataHelper.CreateVerwerktContactverzoekAsync(onderwerp);
+            RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(contactmomentUuid.ToString()));
+
+            await SafeGotoAsync("/");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+            await Step("Make direct API call to forward endpoint on verwerkt contactverzoek");
+            var response = await Page.Context.APIRequest.PostAsync(
+                $"/api/internetaken/{internetaakUuid}/forward",
+                new() { DataObject = new { ActorType = "Medewerker", ActorIdentifier = "test@test.nl" } });
+
+            Assert.AreEqual(409, response.Status, "Expected HTTP 409 when forwarding verwerkt contactverzoek");
+            var body = await response.TextAsync();
+            Assert.IsTrue(body.Contains("verwerkt"), "Response body should reference 'verwerkt' status");
+        }
+
+        [TestMethod("Linking a zaak is rejected for verwerkt contactverzoek")]
+        public async Task LinkZaak_IsRejected_WhenVerwerkt()
+        {
+            var onderwerp = $"Test_Guard_Zaak_{Guid.NewGuid().ToString().Substring(0, 8)}";
+            var (contactmomentUuid, internetaakUuid, _) = await TestDataHelper.CreateVerwerktContactverzoekAsync(onderwerp);
+            RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(contactmomentUuid.ToString()));
+
+            await SafeGotoAsync("/");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+            await Step("Make direct API call to koppel-zaak endpoint on verwerkt contactverzoek");
+            var response = await Page.Context.APIRequest.PostAsync(
+                "/api/internetaken/koppel-zaak",
+                new() { DataObject = new { InternetaakId = internetaakUuid.ToString() } });
+
+            Assert.AreEqual(409, response.Status, "Expected HTTP 409 when linking zaak to verwerkt contactverzoek");
+            var body = await response.TextAsync();
+            Assert.IsTrue(body.Contains("verwerkt"), "Response body should reference 'verwerkt' status");
+        }
+
+        [TestMethod("Registering a contactmoment is rejected for verwerkt contactverzoek")]
+        public async Task RegisterContactmoment_IsRejected_WhenVerwerkt()
+        {
+            var onderwerp = $"Test_Guard_Close_{Guid.NewGuid().ToString().Substring(0, 8)}";
+            var (contactmomentUuid, internetaakUuid, _) = await TestDataHelper.CreateVerwerktContactverzoekAsync(onderwerp);
+            RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(contactmomentUuid.ToString()));
+
+            await SafeGotoAsync("/");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+            await Step("Make direct API call to close-with-klantcontact on verwerkt contactverzoek");
+            var response = await Page.Context.APIRequest.PostAsync(
+                "/api/internetaken/close-with-klantcontact",
+                new() { DataObject = new { InterneTaakId = internetaakUuid } });
+
+            Assert.AreEqual(409, response.Status, "Expected HTTP 409 when registering contactmoment on verwerkt contactverzoek");
+            var body = await response.TextAsync();
+            Assert.IsTrue(body.Contains("verwerkt"), "Response body should reference 'verwerkt' status");
+        }
+
+        [TestMethod("Mutation is allowed for te_verwerken contactverzoek")]
+        public async Task AssignToSelf_IsAllowed_WhenTeVerwerken()
+        {
+            var onderwerp = $"Test_Guard_Allow_{Guid.NewGuid().ToString().Substring(0, 8)}";
+            var contactmomentUuid = await TestDataHelper.CreateContactverzoek(onderwerp, attachZaak: false);
+            RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(contactmomentUuid.ToString()));
+
+            var internetaakUuid = await TestDataHelper.GetInternetaakUuidFromContactmomentAsync(contactmomentUuid);
+            Assert.IsNotNull(internetaakUuid, "Internetaak UUID should be found");
+
+            await SafeGotoAsync("/");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+            await Step("Make direct API call to aan-mij-toewijzen on te_verwerken contactverzoek");
+            var response = await Page.Context.APIRequest.PostAsync($"/api/internetaken/{internetaakUuid}/aan-mij-toewijzen");
+
+            Assert.IsTrue(response.Status is >= 200 and < 300,
+                $"Expected success response for te_verwerken contactverzoek, got HTTP {response.Status}");
+        }
+
+        [TestMethod("Action controls are hidden and informational message is shown for verwerkt contactverzoek")]
+        public async Task ActionControls_AreHidden_WithMessage_WhenVerwerkt()
+        {
+            var onderwerp = $"Test_Readonly_UI_{Guid.NewGuid().ToString().Substring(0, 8)}";
+            var (contactmomentUuid, _, internetaakNummer) = await TestDataHelper.CreateVerwerktContactverzoekAsync(onderwerp);
+            RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(contactmomentUuid.ToString()));
+
+            await NavigateToVerwerktContactverzoekByNummer(internetaakNummer);
+
+            await Step("Verify action controls are not visible");
+            await Expect(Page.GetToewijzenAanMezelfButton()).Not.ToBeVisibleAsync();
+            await Expect(Page.GetContactmomentRegistrerenTab()).Not.ToBeVisibleAsync();
+            await Expect(Page.GetDoorsturenTab()).Not.ToBeVisibleAsync();
+            await Expect(Page.GetAlleenToelichtingTab()).Not.ToBeVisibleAsync();
+            await Expect(Page.GetGekoppeldeZaakKoppelenButton()).Not.ToBeVisibleAsync();
+
+            await Step("Verify informational message is shown");
+            await Expect(Page.GetAfgehandeldMessage()).ToBeVisibleAsync();
+        }
+
+        [TestMethod("Action controls are available for open (te_verwerken) contactverzoek")]
+        public async Task ActionControls_AreAvailable_WhenTeVerwerken()
+        {
+            var onderwerp = $"Test_Open_Controls_{Guid.NewGuid().ToString().Substring(0, 8)}";
+            await SetupContactverzoek(onderwerp, attachZaak: false);
+
+            await NavigateToContactverzoekDetails(onderwerp);
+
+            await Step("Verify action controls are visible for te_verwerken contactverzoek");
+            await Expect(Page.GetToewijzenAanMezelfButton()).ToBeVisibleAsync();
+            await Expect(Page.GetContactmomentRegistrerenTab()).ToBeVisibleAsync();
+            await Expect(Page.GetDoorsturenTab()).ToBeVisibleAsync();
+            await Expect(Page.GetAlleenToelichtingTab()).ToBeVisibleAsync();
+
+            await Step("Verify informational message is not shown");
+            await Expect(Page.GetAfgehandeldMessage()).Not.ToBeVisibleAsync();
+        }
+
+        [TestMethod("Access via Mijn historie also shows read-only mode for verwerkt contactverzoek")]
+        public async Task ActionControls_AreHidden_WhenAccessedViaHistorie()
+        {
+            var onderwerp = $"Test_Historie_Readonly_{Guid.NewGuid().ToString().Substring(0, 8)}";
+            await CreateAssignAndCloseContactverzoek(onderwerp, "Closing for Mijn historie readonly test");
+
+            await Step("Navigate to Mijn historie");
+            await SafeGotoAsync("/historie");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+            await Step("Find the closed contactverzoek in the history list and click through");
+            await Expect(Page.Locator($"text={onderwerp}")).ToBeVisibleAsync(new() { Timeout = 15000 });
+            var contactverzoekRow = Page.Locator("table tbody tr").Filter(new() { HasText = onderwerp });
+            await contactverzoekRow.GetByRole(AriaRole.Link).Filter(new() { HasText = "Klik hier" }).ClickAsync();
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+            await Step("Verify all action controls are hidden");
+            await Expect(Page.GetAfgehandeldMessage()).ToBeVisibleAsync(new() { Timeout = 10000 });
+            await Expect(Page.GetContactmomentRegistrerenTab()).Not.ToBeVisibleAsync();
+            await Expect(Page.GetDoorsturenTab()).Not.ToBeVisibleAsync();
+            await Expect(Page.GetAlleenToelichtingTab()).Not.ToBeVisibleAsync();
+            await Expect(Page.GetToewijzenAanMezelfButton()).Not.ToBeVisibleAsync();
         }
     }
 }

--- a/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekScenarios.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekScenarios.cs
@@ -1000,9 +1000,10 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Make direct API call to forward endpoint on verwerkt contactverzoek");
+            // ActorType must be "Afdeling" or "Groep" to pass ForwardContactRequestModel.Validate()
             var response = await Page.Context.APIRequest.PostAsync(
                 $"/api/internetaken/{internetaakUuid}/forward",
-                new() { DataObject = new { ActorType = "Medewerker", ActorIdentifier = "test@test.nl" } });
+                new() { DataObject = new { ActorType = "Afdeling", ActorIdentifier = "Burgerzaken_ibz" } });
 
             Assert.AreEqual(409, response.Status, "Expected HTTP 409 when forwarding verwerkt contactverzoek");
             var body = await response.TextAsync();
@@ -1020,9 +1021,18 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Make direct API call to koppel-zaak endpoint on verwerkt contactverzoek");
+            // All required fields must be present for the body to deserialize before the guard can run
             var response = await Page.Context.APIRequest.PostAsync(
                 "/api/internetaken/koppel-zaak",
-                new() { DataObject = new { InternetaakId = internetaakUuid.ToString() } });
+                new()
+                {
+                    DataObject = new
+                    {
+                        InternetaakId = internetaakUuid.ToString(),
+                        ZaakIdentificatie = "ZAAK-GUARD-TEST",
+                        AanleidinggevendKlantcontactUuid = contactmomentUuid
+                    }
+                });
 
             Assert.AreEqual(409, response.Status, "Expected HTTP 409 when linking zaak to verwerkt contactverzoek");
             var body = await response.TextAsync();
@@ -1040,9 +1050,27 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Make direct API call to close-with-klantcontact on verwerkt contactverzoek");
+            // All required fields must be present for deserialization to succeed before the guard runs
             var response = await Page.Context.APIRequest.PostAsync(
                 "/api/internetaken/close-with-klantcontact",
-                new() { DataObject = new { InterneTaakId = internetaakUuid } });
+                new()
+                {
+                    DataObject = new
+                    {
+                        InterneTaakId = internetaakUuid,
+                        AanleidinggevendKlantcontactUuid = contactmomentUuid,
+                        KlantcontactRequest = new
+                        {
+                            IndicatieContactGelukt = true,
+                            Onderwerp = "guard-test",
+                            Inhoud = "guard-test",
+                            Kanaal = "e-mail",
+                            PlaatsgevondenOp = DateTime.UtcNow,
+                            Taal = "nl",
+                            Vertrouwelijk = false
+                        }
+                    }
+                });
 
             Assert.AreEqual(409, response.Status, "Expected HTTP 409 when registering contactmoment on verwerkt contactverzoek");
             var body = await response.TextAsync();

--- a/InterneTaakAfhandeling.EndToEndTest/Infrastructure/Locators.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Infrastructure/Locators.cs
@@ -172,5 +172,8 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
         // Message locators
         public static ILocator GetContactverzoekToegewezenMessage(this IPage page) =>
             page.GetByText("Contactverzoek toegewezen");
+
+        public static ILocator GetAfgehandeldMessage(this IPage page) =>
+            page.GetByText("Dit contactverzoek is afgehandeld en kan niet meer worden gewijzigd.");
     }
 }

--- a/InterneTaakAfhandeling.EndToEndTest/Infrastructure/TestDataHelper.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Infrastructure/TestDataHelper.cs
@@ -231,6 +231,36 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
             return contactmoment.Uuid;
         }
 
+        public async Task<(Guid ContactmomentUuid, Guid InternetaakUuid, string InternetaakNummer)> CreateVerwerktContactverzoekAsync(string onderwerp)
+        {
+            await CleanupExistingContactmomenten(onderwerp);
+
+            var contactmoment = await CreateContactmoment(
+                onderwerp,
+                "Test contactverzoek for readonly guard verification",
+                klantnaam: null);
+
+            var submitterActor = await GetOrCreateSubmitterActor();
+            await ConnectActorToContactmoment(submitterActor, contactmoment.Uuid);
+
+            await CreateInternetaakIfNotExists(
+                GenerateUniqueInternetaakNummer(),
+                contactmoment.Uuid,
+                new List<Guid>(),
+                isExplicitNummer: false);
+
+            var internetaakUuid = await GetInternetaakUuidFromContactmomentAsync(contactmoment.Uuid)
+                ?? throw new InvalidOperationException($"Internetaak not found after creation for contactmoment {contactmoment.Uuid}");
+
+            await OpenKlantApiClient.PatchInternetaakStatusAsync(
+                new InternetakenPatchStatusRequest { Status = KnownInternetaakStatussen.Verwerkt },
+                internetaakUuid.ToString());
+
+            var internetaak = await GetInternetaakByIdAsync(internetaakUuid);
+            return (contactmoment.Uuid, internetaakUuid, internetaak.Nummer
+                ?? throw new InvalidOperationException("Internetaak nummer is null after creation"));
+        }
+
 
         public async Task<string?> GetZaakIdentificatieFromContactverzoek(Guid klantcontactUuid)
         {


### PR DESCRIPTION
## Summary

Feature #344 makes completed contactverzoeken (status `verwerkt`) fully read-only: backend mutation endpoints return HTTP 409 and the UI hides all action controls. This PR adds the Phase 2 E2E test suite (Task #420) that validates this behavior against the deployed test environment (`ita.test.icatt.nl`), covering all 9 Gherkin scenarios from the implementation tasks #390 (backend guard) and #403 (frontend read-only mode).

All 9 tests pass against `ita.test.icatt.nl`.

## Changes

**New test infrastructure:**
- `TestDataHelper.CreateVerwerktContactverzoekAsync` — creates an internetaak via the OpenKlant API and PATCHes its status to `verwerkt` directly, avoiding a slow UI close flow in test setup
- `Locators.GetAfgehandeldMessage` — locator for the informational message shown on verwerkt contactverzoeken
- `ContactverzoekScenarioHelpers.NavigateToVerwerktContactverzoekByNummer` — navigation helper that waits for the afgehandeld message (action tabs are hidden for verwerkt, so the previous navigation helper would time out)

**9 new E2E test methods:**
- Scenarios 1–6 (backend guard): `Page.Context.APIRequest.PostAsync` makes authenticated HTTP calls directly to `aan-mij-toewijzen`, `notitie`, `forward`, `koppel-zaak`, and `close-with-klantcontact`, asserting HTTP 409 for `verwerkt` contactverzoeken and HTTP 2xx for `te_verwerken`
- Scenarios 7–9 (frontend): Playwright UI assertions verify action controls are hidden and the message "Dit contactverzoek is afgehandeld en kan niet meer worden gewijzigd." is shown

**Removed/fixed existing tests:**
- Removed `User_UpdateClosedContactverzoek_CanStillAddContactmoment` — tested the pre-#344 behavior that mutations on closed contactverzoeken were allowed; Feature #344 explicitly blocks this
- Fixed `User_ClickMijnHistorie_ViewsClosedAssignedContactRequests` — replaced stale assertions (action tabs expected to be visible on `verwerkt` contactverzoeken) with correct read-only assertions

## Test plan

- [x] Assigning to self is rejected for verwerkt contactverzoek (HTTP 409)
- [x] Adding a notitie is rejected for verwerkt contactverzoek (HTTP 409)
- [x] Forwarding is rejected for verwerkt contactverzoek (HTTP 409) — uses `ActorType: Afdeling` per `ForwardContactRequestModel.Validate()` rules
- [x] Linking a zaak is rejected for verwerkt contactverzoek (HTTP 409)
- [x] Registering a contactmoment is rejected for verwerkt contactverzoek (HTTP 409)
- [x] Mutation is allowed for te_verwerken contactverzoek (HTTP 2xx)
- [x] Action controls hidden + informational message shown for verwerkt contactverzoek
- [x] Action controls visible for te_verwerken contactverzoek
- [x] Access via Mijn historie also shows read-only mode for verwerkt contactverzoek

## Related

Closes #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)
