### PR TITLE
fix(assign-to-me): check all three medewerker identificator types in isAlreadyAssigned

### DIFF
--- a/InterneTaakAfhandeling.Web.Client/src/constants/medewerkerIdentificators.ts
+++ b/InterneTaakAfhandeling.Web.Client/src/constants/medewerkerIdentificators.ts
@@ -13,3 +13,22 @@ export const KnownMedewerkerIdentificators = {
     codeSoortObjectId: "idf"
   }
 } as const;
+
+type MedewerkerIdentificator = (typeof KnownMedewerkerIdentificators)[Exclude<
+  keyof typeof KnownMedewerkerIdentificators,
+  "codeObjecttype"
+>];
+
+export const matchesIdentificator = (
+  actoridentificator:
+    | { codeRegister?: string; codeSoortObjectId?: string; objectId?: string }
+    | undefined,
+  known: MedewerkerIdentificator,
+  objectId: string,
+  options?: { caseInsensitive?: boolean }
+) =>
+  actoridentificator?.codeRegister === known.codeRegister &&
+  actoridentificator?.codeSoortObjectId === known.codeSoortObjectId &&
+  (options?.caseInsensitive
+    ? actoridentificator?.objectId?.toLowerCase() === objectId.toLowerCase()
+    : actoridentificator?.objectId === objectId);

--- a/InterneTaakAfhandeling.Web.Client/src/constants/medewerkerIdentificators.ts
+++ b/InterneTaakAfhandeling.Web.Client/src/constants/medewerkerIdentificators.ts
@@ -1,0 +1,15 @@
+export const KnownMedewerkerIdentificators = {
+  codeObjecttype: "mdw",
+  emailFromEntraId: {
+    codeRegister: "msei",
+    codeSoortObjectId: "email"
+  },
+  emailHandmatig: {
+    codeRegister: "handmatig",
+    codeSoortObjectId: "email"
+  },
+  objectRegisterId: {
+    codeRegister: "obj",
+    codeSoortObjectId: "idf"
+  }
+} as const;

--- a/InterneTaakAfhandeling.Web.Client/src/features/assign-contactverzoek-to-me/AssignContactverzoekToMe.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/features/assign-contactverzoek-to-me/AssignContactverzoekToMe.vue
@@ -23,25 +23,40 @@
 import { toast } from "@/components/toast/toast";
 import { ref, computed } from "vue";
 import { userService } from "@/services/userService";
+import { KnownMedewerkerIdentificators } from "@/constants/medewerkerIdentificators";
 import type { Actor } from "@/types/internetaken";
 const props = withDefaults(
   defineProps<{
     id: string;
     userEmail: string;
+    objectregisterMedewerkerId: string;
     actoren: Actor[];
   }>(),
-  { actoren: () => [] }
+  { objectregisterMedewerkerId: "", actoren: () => [] }
 );
 
 const emit = defineEmits(["assignmentSuccess"]);
 
+const isMedewerkerActor = (actor: Actor) =>
+  actor.soortActor === "medewerker" &&
+  actor.actoridentificator?.codeObjecttype === KnownMedewerkerIdentificators.codeObjecttype;
+
+const matchesEmail = (actor: Actor) =>
+  (actor.actoridentificator?.codeSoortObjectId ===
+    KnownMedewerkerIdentificators.emailFromEntraId.codeSoortObjectId ||
+    actor.actoridentificator?.codeSoortObjectId ===
+      KnownMedewerkerIdentificators.emailHandmatig.codeSoortObjectId) &&
+  actor.actoridentificator?.objectId?.toLowerCase() === props.userEmail.toLowerCase();
+
+const matchesObjectRegisterId = (actor: Actor) =>
+  !!props.objectregisterMedewerkerId &&
+  actor.actoridentificator?.codeSoortObjectId ===
+    KnownMedewerkerIdentificators.objectRegisterId.codeSoortObjectId &&
+  actor.actoridentificator?.objectId === props.objectregisterMedewerkerId;
+
 const isAlreadyAssigned = computed(() =>
   props.actoren.some(
-    (actor) =>
-      actor.soortActor === "medewerker" &&
-      actor.actoridentificator?.codeObjecttype === "mdw" &&
-      actor.actoridentificator?.codeSoortObjectId === "email" &&
-      actor.actoridentificator?.objectId?.toLowerCase() === props.userEmail.toLowerCase()
+    (actor) => isMedewerkerActor(actor) && (matchesEmail(actor) || matchesObjectRegisterId(actor))
   )
 );
 

--- a/InterneTaakAfhandeling.Web.Client/src/features/assign-contactverzoek-to-me/AssignContactverzoekToMe.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/features/assign-contactverzoek-to-me/AssignContactverzoekToMe.vue
@@ -23,7 +23,10 @@
 import { toast } from "@/components/toast/toast";
 import { ref, computed } from "vue";
 import { userService } from "@/services/userService";
-import { KnownMedewerkerIdentificators } from "@/constants/medewerkerIdentificators";
+import {
+  KnownMedewerkerIdentificators,
+  matchesIdentificator
+} from "@/constants/medewerkerIdentificators";
 import type { Actor } from "@/types/internetaken";
 const props = withDefaults(
   defineProps<{
@@ -41,22 +44,28 @@ const isMedewerkerActor = (actor: Actor) =>
   actor.soortActor === "medewerker" &&
   actor.actoridentificator?.codeObjecttype === KnownMedewerkerIdentificators.codeObjecttype;
 
-const matchesEmail = (actor: Actor) =>
-  (actor.actoridentificator?.codeSoortObjectId ===
-    KnownMedewerkerIdentificators.emailFromEntraId.codeSoortObjectId ||
-    actor.actoridentificator?.codeSoortObjectId ===
-      KnownMedewerkerIdentificators.emailHandmatig.codeSoortObjectId) &&
-  actor.actoridentificator?.objectId?.toLowerCase() === props.userEmail.toLowerCase();
-
-const matchesObjectRegisterId = (actor: Actor) =>
-  !!props.objectregisterMedewerkerId &&
-  actor.actoridentificator?.codeSoortObjectId ===
-    KnownMedewerkerIdentificators.objectRegisterId.codeSoortObjectId &&
-  actor.actoridentificator?.objectId === props.objectregisterMedewerkerId;
-
 const isAlreadyAssigned = computed(() =>
   props.actoren.some(
-    (actor) => isMedewerkerActor(actor) && (matchesEmail(actor) || matchesObjectRegisterId(actor))
+    (actor) =>
+      isMedewerkerActor(actor) &&
+      (matchesIdentificator(
+        actor.actoridentificator,
+        KnownMedewerkerIdentificators.emailFromEntraId,
+        props.userEmail,
+        { caseInsensitive: true }
+      ) ||
+        matchesIdentificator(
+          actor.actoridentificator,
+          KnownMedewerkerIdentificators.emailHandmatig,
+          props.userEmail,
+          { caseInsensitive: true }
+        ) ||
+        (!!props.objectregisterMedewerkerId &&
+          matchesIdentificator(
+            actor.actoridentificator,
+            KnownMedewerkerIdentificators.objectRegisterId,
+            props.objectregisterMedewerkerId
+          )))
   )
 );
 

--- a/InterneTaakAfhandeling.Web.Client/src/services/authService.ts
+++ b/InterneTaakAfhandeling.Web.Client/src/services/authService.ts
@@ -11,6 +11,7 @@ class AuthService {
           isLoggedIn: data.isLoggedIn,
           email: data.email || "",
           name: data.name || "",
+          objectregisterMedewerkerId: data.objectregisterMedewerkerId || "",
           roles: data.roles || [],
           hasITASystemAccess: data.hasITASystemAccess || false,
           hasFunctioneelBeheerderAccess: data.hasFunctioneelBeheerderAccess || false

--- a/InterneTaakAfhandeling.Web.Client/src/types/user.ts
+++ b/InterneTaakAfhandeling.Web.Client/src/types/user.ts
@@ -2,6 +2,7 @@ export type User = {
   isLoggedIn: boolean;
   email: string;
   name: string;
+  objectregisterMedewerkerId: string;
   roles: string[];
   hasITASystemAccess: boolean;
   hasFunctioneelBeheerderAccess: boolean;

--- a/InterneTaakAfhandeling.Web.Client/src/views/ContactverzoekDetailView.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/views/ContactverzoekDetailView.vue
@@ -11,6 +11,7 @@
         <assign-contactverzoek-to-me
           :id="taak.uuid"
           :user-email="userEmail"
+          :objectregister-medewerker-id="objectregisterMedewerkerId"
           :actoren="taak.toegewezenAanActoren ?? []"
           @assignmentSuccess="fetchInternetaken"
         />
@@ -93,6 +94,7 @@ const errorMessage = ref<string | null>(null);
 const isContactmomentRoute = computed(() => !!props.contactmomentNumber);
 const routeNummer = computed(() => props.contactmomentNumber ?? props.contactverzoekId ?? "");
 const userEmail = computed(() => authStore.user?.email ?? "");
+const objectregisterMedewerkerId = computed(() => authStore.user?.objectregisterMedewerkerId ?? "");
 const isAfgehandeld = computed(() => taak.value?.status === "verwerkt");
 
 const handleZaakGekoppeld = () => {


### PR DESCRIPTION
## Summary

The "Toewijzen aan jezelf" button visibility check (`isAlreadyAssigned`) only matched users assigned via email (`codeSoortObjectId: "email"`), missing the `ObjectRegisterId` type (`codeSoortObjectId: "idf"`). This caused the button to remain visible even when the user was already assigned via their objectregister medewerker ID — inconsistent with the backend `MyInterneTakenOverviewService` which checks all three types.

This fix aligns the frontend check with the backend by introducing shared constants and matching on email (EntraId + handmatig) OR objectregister ID.

## Changes

- **New constants module** — `KnownMedewerkerIdentificators` mirrors the backend C# class, eliminating magic strings
- **Extended assignment check** — `isAlreadyAssigned` now uses named predicates (`matchesEmail`, `matchesObjectRegisterId`) covering all three identificator types
- **User type & service update** — `objectregisterMedewerkerId` is added to the frontend `User` type and mapped from `/api/me`
- **Prop wiring** — parent view passes the new ID to the component

## Test plan

- [ ] Button is hidden when user is assigned via EntraId email
- [ ] Button is hidden when user is assigned via handmatig email
- [ ] Button is hidden when user is assigned via objectregister medewerker ID
- [ ] Button is visible when user is not individually assigned (team assignment doesn't count)
- [ ] Existing E2E tests still pass

## Related

Closes #425