### PR TITLE
refactor(guard): throw ConflictException instead of returning ObjectResult

### DIFF
--- a/InterneTaakAfhandeling.Web.Server/Features/AddNotitieToInternetaak/AddNotitieToInternetaakController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/AddNotitieToInternetaak/AddNotitieToInternetaakController.cs
@@ -34,9 +34,10 @@ public class AddNotitieToInternetaakController(
     [HttpPost("{internetaakId}/notitie")]
     public async Task<IActionResult> AddNote([FromRoute] Guid internetaakId, [FromBody] AddNotitieRequest request)
     {
+        await _internetaakGuardService.GuardAgainstVerwerktAsync(internetaakId);
+
         try
         {
-            await _internetaakGuardService.GuardAgainstVerwerktAsync(internetaakId);
 
             var notitieAction = KnownContactAction.Note(request.Notitie, _user);
             await _logboekService.LogContactRequestAction(notitieAction, internetaakId);

--- a/InterneTaakAfhandeling.Web.Server/Features/AddNotitieToInternetaak/AddNotitieToInternetaakController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/AddNotitieToInternetaak/AddNotitieToInternetaakController.cs
@@ -36,8 +36,7 @@ public class AddNotitieToInternetaakController(
     {
         try
         {
-            var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(internetaakId, "notitie");
-            if (blocked != null) return blocked;
+            await _internetaakGuardService.GuardAgainstVerwerktAsync(internetaakId);
 
             var notitieAction = KnownContactAction.Note(request.Notitie, _user);
             await _logboekService.LogContactRequestAction(notitieAction, internetaakId);

--- a/InterneTaakAfhandeling.Web.Server/Features/AssignInternetaakToMe/AssignInternetaakToMeController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/AssignInternetaakToMe/AssignInternetaakToMeController.cs
@@ -28,10 +28,10 @@ namespace InterneTaakAfhandeling.Web.Server.Features.AssignInternetaakToMe
         [HttpPost("{internetaakId}/aan-mij-toewijzen")]
         public async Task<IActionResult> AssignInternetakenAsync([FromRoute] Guid internetaakId)
         {
+            await _internetaakGuardService.GuardAgainstVerwerktAsync(internetaakId);
+
             try
             {
-                await _internetaakGuardService.GuardAgainstVerwerktAsync(internetaakId);
-
                 var (updatedInterneTaak, currentUserActor) = await _AssignInternetakenService.ToSelfAsync(internetaakId, user);
 
                 var assignedAction = KnownContactAction.AssignedToSelf(currentUserActor.Uuid, _user);

--- a/InterneTaakAfhandeling.Web.Server/Features/AssignInternetaakToMe/AssignInternetaakToMeController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/AssignInternetaakToMe/AssignInternetaakToMeController.cs
@@ -30,8 +30,7 @@ namespace InterneTaakAfhandeling.Web.Server.Features.AssignInternetaakToMe
         {
             try
             {
-                var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(internetaakId, "aan-mij-toewijzen");
-                if (blocked != null) return blocked;
+                await _internetaakGuardService.GuardAgainstVerwerktAsync(internetaakId);
 
                 var (updatedInterneTaak, currentUserActor) = await _AssignInternetakenService.ToSelfAsync(internetaakId, user);
 

--- a/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestController.cs
@@ -29,8 +29,7 @@ public class ForwardContactRequestController(
     {
         try
         {
-            var blocked = await internetaakGuardService.EnsureNotVerwerktAsync(id, "forward");
-            if (blocked != null) return blocked;
+            await internetaakGuardService.GuardAgainstVerwerktAsync(id);
 
             var response = await forwardContactRequestService.ForwardAsync(id, request);
             await logboekService.LogContactRequestAction(KnownContactAction.ForwardKlantContact(request, _user), id);

--- a/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestController.cs
@@ -27,10 +27,10 @@ public class ForwardContactRequestController(
     public async Task<IActionResult> ForwardContactRequestAsync([FromRoute] Guid id,
         [FromBody] ForwardContactRequestModel request)
     {
+        await internetaakGuardService.GuardAgainstVerwerktAsync(id);
+
         try
         {
-            await internetaakGuardService.GuardAgainstVerwerktAsync(id);
-
             var response = await forwardContactRequestService.ForwardAsync(id, request);
             await logboekService.LogContactRequestAction(KnownContactAction.ForwardKlantContact(request, _user), id);
 

--- a/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CloseInterneTaakWithKlantContact/CloseInterneTaakWithKlantContactController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CloseInterneTaakWithKlantContact/CloseInterneTaakWithKlantContactController.cs
@@ -45,10 +45,10 @@ public class CloseInterneTaakWithKlantContactController(
     [HttpPost("close-with-klantcontact")] //todo: refactor to "HttpPost("[internetaakUuid]/close-with-klantcontact)" and consider making it a PUT
     public async Task<IActionResult> CreateRelatedKlantcontact([FromBody] RequestModel request)
     {
+        await _internetaakGuardService.GuardAgainstVerwerktAsync(request.InterneTaakId);
+
         try
         {
-            await _internetaakGuardService.GuardAgainstVerwerktAsync(request.InterneTaakId);
-
             _logger.LogInformation(
                 "Closing Interne taak and creating related klantcontact with aanleidinggevendKlantcontact UUID: {AanleidinggevendKlantcontactUuid}",
                 request.AanleidinggevendKlantcontactUuid);

--- a/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CloseInterneTaakWithKlantContact/CloseInterneTaakWithKlantContactController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CloseInterneTaakWithKlantContact/CloseInterneTaakWithKlantContactController.cs
@@ -47,8 +47,7 @@ public class CloseInterneTaakWithKlantContactController(
     {
         try
         {
-            var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(request.InterneTaakId, "close-with-klantcontact");
-            if (blocked != null) return blocked;
+            await _internetaakGuardService.GuardAgainstVerwerktAsync(request.InterneTaakId);
 
             _logger.LogInformation(
                 "Closing Interne taak and creating related klantcontact with aanleidinggevendKlantcontact UUID: {AanleidinggevendKlantcontactUuid}",

--- a/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CreateKlantContact/CreateKlantContactController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CreateKlantContact/CreateKlantContactController.cs
@@ -45,8 +45,7 @@ public class CreateKlantContactController : Controller
     {
         try
         {
-            var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(request.InterneTaakId, "add-klantcontact");
-            if (blocked != null) return blocked;
+            await _internetaakGuardService.GuardAgainstVerwerktAsync(request.InterneTaakId);
             
             _logger.LogInformation(
                 "Creating related klantcontact with aanleidinggevendKlantcontact UUID: {aanleidinggevendKlantcontactUuid}",

--- a/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CreateKlantContact/CreateKlantContactController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/KlantContact/CreateKlantContact/CreateKlantContactController.cs
@@ -43,10 +43,10 @@ public class CreateKlantContactController : Controller
     [HttpPost("add-klantcontact")] //todo refactor, route should be api/klantcontacten/[klantcontactUuid]/klantcontacten
     public async Task<IActionResult> CreateRelatedKlantcontact([FromBody] CreateRelatedKlantcontactRequestModel request)
     {
+        await _internetaakGuardService.GuardAgainstVerwerktAsync(request.InterneTaakId);
+
         try
         {
-            await _internetaakGuardService.GuardAgainstVerwerktAsync(request.InterneTaakId);
-            
             _logger.LogInformation(
                 "Creating related klantcontact with aanleidinggevendKlantcontact UUID: {aanleidinggevendKlantcontactUuid}",
                 request.AanleidinggevendKlantcontactUuid);

--- a/InterneTaakAfhandeling.Web.Server/Features/KoppelZaakAanKlantcontact/KoppelZaakAanKlantcontactController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/KoppelZaakAanKlantcontact/KoppelZaakAanKlantcontactController.cs
@@ -60,8 +60,7 @@ public class KoppelZaakAanKlantcontactController : Controller
                     Status = StatusCodes.Status400BadRequest
                 });
 
-            var blocked = await _internetaakGuardService.EnsureNotVerwerktAsync(internetaakGuid, "koppel-zaak");
-            if (blocked != null) return blocked;
+            await _internetaakGuardService.GuardAgainstVerwerktAsync(internetaakGuid);
 
             if (string.IsNullOrWhiteSpace(request.ZaakIdentificatie))
                 return BadRequest(new ProblemDetails

--- a/InterneTaakAfhandeling.Web.Server/Features/KoppelZaakAanKlantcontact/KoppelZaakAanKlantcontactController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/KoppelZaakAanKlantcontact/KoppelZaakAanKlantcontactController.cs
@@ -50,18 +50,18 @@ public class KoppelZaakAanKlantcontactController : Controller
     [AllowAnonymous]
     public async Task<IActionResult> KoppelZaakAanKlantcontact([FromBody] KoppelZaakAanKlantcontactRequest request)
     {
+        if (!Guid.TryParse(request.InternetaakId, out var internetaakGuid))
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Ongeldige aanvraag",
+                Detail = "InternetaakId is geen geldig UUID",
+                Status = StatusCodes.Status400BadRequest
+            });
+
+        await _internetaakGuardService.GuardAgainstVerwerktAsync(internetaakGuid);
+
         try
         {
-            if (!Guid.TryParse(request.InternetaakId, out var internetaakGuid))
-                return BadRequest(new ProblemDetails
-                {
-                    Title = "Ongeldige aanvraag",
-                    Detail = "InternetaakId is geen geldig UUID",
-                    Status = StatusCodes.Status400BadRequest
-                });
-
-            await _internetaakGuardService.GuardAgainstVerwerktAsync(internetaakGuid);
-
             if (string.IsNullOrWhiteSpace(request.ZaakIdentificatie))
                 return BadRequest(new ProblemDetails
                 {

--- a/InterneTaakAfhandeling.Web.Server/Guards/IInternetaakGuardService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Guards/IInternetaakGuardService.cs
@@ -1,12 +1,9 @@
-using Microsoft.AspNetCore.Mvc;
-
 namespace InterneTaakAfhandeling.Web.Server.Guards;
 
 public interface IInternetaakGuardService
 {
     /// <summary>
-    /// Checks whether the interne taak has status 'verwerkt'.
-    /// Returns a 409 Conflict ObjectResult if blocked, or null if the mutation is allowed.
+    /// Throws <see cref="Common.Exceptions.ConflictException"/> if the interne taak has status 'verwerkt'.
     /// </summary>
-    Task<ObjectResult?> EnsureNotVerwerktAsync(Guid internetaakId, string actionType);
+    Task GuardAgainstVerwerktAsync(Guid internetaakId);
 }

--- a/InterneTaakAfhandeling.Web.Server/Guards/IInternetaakGuardService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Guards/IInternetaakGuardService.cs
@@ -3,7 +3,7 @@ namespace InterneTaakAfhandeling.Web.Server.Guards;
 public interface IInternetaakGuardService
 {
     /// <summary>
-    /// Throws <see cref="Common.Exceptions.ConflictException"/> if the interne taak has status 'verwerkt'.
+    /// Throws <see cref="InterneTaakAfhandeling.Common.Exceptions.ConflictException"/> if the interne taak has status 'verwerkt'.
     /// </summary>
     Task GuardAgainstVerwerktAsync(Guid internetaakId);
 }

--- a/InterneTaakAfhandeling.Web.Server/Guards/InternetaakGuardService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Guards/InternetaakGuardService.cs
@@ -19,7 +19,7 @@ public class InternetaakGuardService(
 
             throw new ConflictException(
                 "Dit contactverzoek heeft status 'verwerkt' en kan niet meer worden gewijzigd.",
-                "internetaak-verwerkt");
+                "INTERNETAAK_VERWERKT");
         }
     }
 }

--- a/InterneTaakAfhandeling.Web.Server/Guards/InternetaakGuardService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Guards/InternetaakGuardService.cs
@@ -1,5 +1,5 @@
+using InterneTaakAfhandeling.Common.Exceptions;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi;
-using Microsoft.AspNetCore.Mvc;
 
 namespace InterneTaakAfhandeling.Web.Server.Guards;
 
@@ -7,31 +7,19 @@ public class InternetaakGuardService(
     IOpenKlantApiClient openKlantApiClient,
     ILogger<InternetaakGuardService> logger) : IInternetaakGuardService
 {
-    public async Task<ObjectResult?> EnsureNotVerwerktAsync(Guid internetaakId, string actionType)
+    public async Task GuardAgainstVerwerktAsync(Guid internetaakId)
     {
         var internetaak = await openKlantApiClient.GetInternetaakByIdAsync(internetaakId);
 
-        if (internetaak.Status != KnownInternetaakStatussen.Verwerkt)
+        if (internetaak.Status == KnownInternetaakStatussen.Verwerkt)
         {
-            return null;
+            logger.LogWarning(
+                "Mutation blocked: interne taak {InternetaakId} has status 'verwerkt'",
+                internetaakId);
+
+            throw new ConflictException(
+                "Dit contactverzoek heeft status 'verwerkt' en kan niet meer worden gewijzigd.",
+                "internetaak-verwerkt");
         }
-
-        logger.LogWarning(
-            "Mutation blocked: action {ActionType} on interne taak {InternetaakId} has status 'verwerkt'",
-            actionType,
-            internetaakId);
-
-        var problemDetails = new ProblemDetails
-        {
-            Type = "https://tools.ietf.org/html/rfc9110#section-15.5.10",
-            Title = "Contactverzoek is afgehandeld",
-            Detail = "Dit contactverzoek heeft status 'verwerkt' en kan niet meer worden gewijzigd.",
-            Status = StatusCodes.Status409Conflict
-        };
-
-        return new ObjectResult(problemDetails)
-        {
-            StatusCode = StatusCodes.Status409Conflict
-        };
     }
 }


### PR DESCRIPTION
## Summary

Addresses review feedback from @felixcicatt on PR #421 (Feature #344). The `InternetaakGuardService` previously returned an `ObjectResult` directly — leaking HTTP/controller concerns into a service layer. Refactored to throw `ConflictException`, which is already mapped to a 409 ProblemDetails response by `ExceptionToProblemDetailsMapper`.

## Changes

- **Guard service** — renamed `EnsureNotVerwerktAsync` → `GuardAgainstVerwerktAsync`, now throws `ConflictException` instead of returning `ObjectResult`. Removed the `actionType` string parameter (redundant with structured logging context).
- **All mutation controllers** (6 files) — simplified from `var blocked = ...; if (blocked != null) return blocked;` to a single `await ...GuardAgainstVerwerktAsync(id);`.

## Test plan

- [ ] Build compiles without errors
- [ ] Mutation on verwerkt contactverzoek still returns 409 ProblemDetails
- [ ] Mutation on open contactverzoek still succeeds

## Related

Part of Feature #344