### PR TITLE
fix(middleware): set HTTP status code in ExceptionToProblemDetailsMapper

### DIFF
--- a/InterneTaakAfhandeling.Web.Server/Middleware/ExceptionToProblemDetailsMapper.cs
+++ b/InterneTaakAfhandeling.Web.Server/Middleware/ExceptionToProblemDetailsMapper.cs
@@ -30,6 +30,7 @@ namespace InterneTaakAfhandeling.Web.Server.Middleware
             _logger.LogError(exception, "An unhandled exception has occurred");
              
             var statusCode = GetStatusCode(exception);
+            httpContext.Response.StatusCode = statusCode;
              
             var problemDetails = _problemDetailsFactory.CreateProblemDetails(
                 httpContext,

--- a/InterneTaakAfhandeling.Web.Server/Middleware/ExceptionToProblemDetailsMapper.cs
+++ b/InterneTaakAfhandeling.Web.Server/Middleware/ExceptionToProblemDetailsMapper.cs
@@ -30,6 +30,11 @@ namespace InterneTaakAfhandeling.Web.Server.Middleware
             _logger.LogError(exception, "An unhandled exception has occurred");
              
             var statusCode = GetStatusCode(exception);
+            if (httpContext.Response.HasStarted)
+            {
+                return false;
+            }
+
             httpContext.Response.StatusCode = statusCode;
              
             var problemDetails = _problemDetailsFactory.CreateProblemDetails(


### PR DESCRIPTION
## Summary

The `ExceptionToProblemDetailsMapper` (our global `IExceptionHandler`) was writing the correct status code inside the ProblemDetails JSON body (`"status": 409`) but never setting `httpContext.Response.StatusCode`. This caused all exceptions handled by the mapper to return **HTTP 500** to clients, even though the body correctly described the actual error.

This was discovered after PR #427 refactored the `InternetaakGuardService` to throw `ConflictException` instead of returning `ObjectResult` directly — making it the first code path to actually rely on the mapper for 409 responses.

## Why this wasn't caught before

Most controllers in the codebase catch `ConflictException` locally and return the status code manually, so the exception never reaches the global mapper. Here's the full map:

| Path | How ConflictException is handled | Reaches mapper? |
|---|---|---|
| `CreateKlantContactController` | `catch (ConflictException)` → returns `StatusCode(409, ITAException)` | ❌ |
| `CloseInterneTaakWithKlantContactController` | `catch (ConflictException)` → returns `StatusCode(409, ITAException)` | ❌ |
| `InternetaakDetailsController` | `catch (ConflictException)` → returns `Conflict(ProblemDetails)` | ❌ |
| `CreateKlantContactService` (8 throws) | Caught by controller catch blocks above | ❌ |
| **InternetaakGuardService** (new) | Guard before try-catch → propagates | ✅ **Broken** |
| **KoppelZaakAanKlantcontactController** | Re-throws from catch as new ConflictException | ✅ **Broken** |
| **GebruikerGroepenAndAfdelingenController** | Direct throw, no try-catch | ✅ **Broken** |

The same bug also affects `ValidationException` → would return HTTP 500 with `"status": 400` in the body.

## Changes

- Set `httpContext.Response.StatusCode = statusCode` before writing the ProblemDetails response body.

## Test plan

- [x] ConflictException from guard returns HTTP 409 (not 500)
- [x] ConflictException from KoppelZaak re-throw returns HTTP 409
- [x] ValidationException returns HTTP 400 (not 500)
- [x] Unknown exceptions still return HTTP 500

## Related

Follow-up to #427
Part of Feature #344