### PR TITLE
feat(reopen): add heropen-endpoint with inactive-behandelaar check

### DIFF
--- a/InterneTaakAfhandeling.Common/Exceptions/UnprocessableEntityException.cs
+++ b/InterneTaakAfhandeling.Common/Exceptions/UnprocessableEntityException.cs
@@ -1,0 +1,13 @@
+namespace InterneTaakAfhandeling.Common.Exceptions;
+
+public class UnprocessableEntityException : Exception
+{
+    public string? Code { get; set; }
+
+    public UnprocessableEntityException(string message) : base(message) { }
+
+    public UnprocessableEntityException(string message, string code) : base(message)
+    {
+        Code = code;
+    }
+}

--- a/InterneTaakAfhandeling.Common/Services/ObjectApi/KnownLogboekValues.cs
+++ b/InterneTaakAfhandeling.Common/Services/ObjectApi/KnownLogboekValues.cs
@@ -8,6 +8,7 @@ public static class ActiviteitTypes
     public const string ZaakkoppelingGewijzigd = "zaakkoppeling-gewijzigd";
     public const string InterneNotitie = "interne-notitie";
     public const string Doorsturen = "doorsturen";
+    public const string Heropend = "heropend";
 
 }
 

--- a/InterneTaakAfhandeling.Web.Server/Config/ServiceCollectionExtensions.cs
+++ b/InterneTaakAfhandeling.Web.Server/Config/ServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ using InterneTaakAfhandeling.Web.Server.Features.InterneTaak;
 using InterneTaakAfhandeling.Web.Server.Features.InterneTakenOverzicht;
 using InterneTaakAfhandeling.Web.Server.Features.KlantContact;
 using InterneTaakAfhandeling.Web.Server.Features.MyInterneTakenOverview;
+using InterneTaakAfhandeling.Web.Server.Features.ReopenContactRequest;
 using InterneTaakAfhandeling.Web.Server.Middleware;
 using InterneTaakAfhandeling.Web.Server.Services;
 using InterneTaakAfhandeling.Web.Server.Guards;
@@ -62,6 +63,7 @@ namespace InterneTaakAfhandeling.Web.Server.Config
             services.AddScoped<IMedewerkersOverzichtService, MedewerkersOverzichtService>();
             services.AddScoped<ILogboekService, LogboekService>();
             services.AddScoped<IInternetaakGuardService, InternetaakGuardService>();
+            services.AddScoped<IReopenContactRequestService, ReopenContactRequestService>();
             services.AddScoped<IMyInterneTakenOverviewService, MyInterneTakenOverviewService>();
             services.AddSmtpClients(configuration);
             

--- a/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/IReopenContactRequestService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/IReopenContactRequestService.cs
@@ -1,0 +1,14 @@
+using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
+
+namespace InterneTaakAfhandeling.Web.Server.Features.ReopenContactRequest;
+
+public interface IReopenContactRequestService
+{
+    Task<ReopenResult> ReopenAsync(Guid internetaakId);
+}
+
+public class ReopenResult
+{
+    public required Internetaak Internetaak { get; set; }
+    public string? Waarschuwing { get; set; }
+}

--- a/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/IReopenContactRequestService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/IReopenContactRequestService.cs
@@ -1,10 +1,11 @@
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
+using InterneTaakAfhandeling.Web.Server.Authentication;
 
 namespace InterneTaakAfhandeling.Web.Server.Features.ReopenContactRequest;
 
 public interface IReopenContactRequestService
 {
-    Task<ReopenResult> ReopenAsync(Guid internetaakId);
+    Task<ReopenResult> ReopenAsync(Guid internetaakId, string reden, ITAUser user);
 }
 
 public class ReopenResult

--- a/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/ReopenContactRequestController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/ReopenContactRequestController.cs
@@ -1,0 +1,55 @@
+using System.ComponentModel.DataAnnotations;
+using InterneTaakAfhandeling.Web.Server.Authentication;
+using InterneTaakAfhandeling.Web.Server.Guards;
+using InterneTaakAfhandeling.Web.Server.Services.LogboekService;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace InterneTaakAfhandeling.Web.Server.Features.ReopenContactRequest;
+
+[Route("api/internetaken")]
+[ApiController]
+[Authorize(Policy = FunctioneelBeheerderPolicy.Name)]
+[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+[ProducesResponseType(StatusCodes.Status403Forbidden)]
+public class ReopenContactRequestController(
+    IReopenContactRequestService reopenContactRequestService,
+    ILogboekService logboekService,
+    IInternetaakGuardService internetaakGuardService,
+    ITAUser user,
+    ILogger<ReopenContactRequestController> logger) : Controller
+{
+    private readonly ITAUser _user = user ?? throw new ArgumentNullException(nameof(user));
+
+    [ProducesResponseType(typeof(ReopenContactRequestResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    [HttpPost("{id:guid}/heropen")]
+    public async Task<IActionResult> ReopenContactRequestAsync(
+        [FromRoute] Guid id,
+        [FromBody] ReopenContactRequestModel request)
+    {
+        if (string.IsNullOrWhiteSpace(request.Reden))
+        {
+            throw new ValidationException("Reden is verplicht en mag niet leeg zijn.");
+        }
+
+        await internetaakGuardService.GuardAgainstNietVerwerktAsync(id);
+
+        logger.LogInformation(
+            "Reopening internetaak {InternetaakId} by user {UserId} with reason: {Reden}",
+            id, _user.Email, request.Reden);
+
+        var result = await reopenContactRequestService.ReopenAsync(id);
+
+        await logboekService.LogContactRequestAction(
+            KnownContactAction.Reopened(request.Reden, _user), id);
+
+        return Ok(new ReopenContactRequestResponse
+        {
+            Internetaak = result.Internetaak,
+            Waarschuwing = result.Waarschuwing
+        });
+    }
+}

--- a/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/ReopenContactRequestController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/ReopenContactRequestController.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel.DataAnnotations;
+using InterneTaakAfhandeling.Common.Helpers;
 using InterneTaakAfhandeling.Web.Server.Authentication;
 using InterneTaakAfhandeling.Web.Server.Guards;
-using InterneTaakAfhandeling.Web.Server.Services.LogboekService;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -14,7 +14,6 @@ namespace InterneTaakAfhandeling.Web.Server.Features.ReopenContactRequest;
 [ProducesResponseType(StatusCodes.Status403Forbidden)]
 public class ReopenContactRequestController(
     IReopenContactRequestService reopenContactRequestService,
-    ILogboekService logboekService,
     IInternetaakGuardService internetaakGuardService,
     ITAUser user,
     ILogger<ReopenContactRequestController> logger) : Controller
@@ -38,13 +37,10 @@ public class ReopenContactRequestController(
         await internetaakGuardService.GuardAgainstNietVerwerktAsync(id);
 
         logger.LogInformation(
-            "Reopening internetaak {InternetaakId} by user {UserId} with reason: {Reden}",
-            id, _user.Email, request.Reden);
+            "Reopening internetaak {InternetaakId} by user {UserId}",
+            id, SecureLogging.SanitizeAndTruncate(_user.Email, 5));
 
-        var result = await reopenContactRequestService.ReopenAsync(id);
-
-        await logboekService.LogContactRequestAction(
-            KnownContactAction.Reopened(request.Reden, _user), id);
+        var result = await reopenContactRequestService.ReopenAsync(id, request.Reden, _user);
 
         return Ok(new ReopenContactRequestResponse
         {

--- a/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/ReopenContactRequestModel.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/ReopenContactRequestModel.cs
@@ -1,3 +1,5 @@
+using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
+
 namespace InterneTaakAfhandeling.Web.Server.Features.ReopenContactRequest;
 
 public class ReopenContactRequestModel
@@ -7,6 +9,6 @@ public class ReopenContactRequestModel
 
 public class ReopenContactRequestResponse
 {
-    public required object Internetaak { get; set; }
+    public required Internetaak Internetaak { get; set; }
     public string? Waarschuwing { get; set; }
 }

--- a/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/ReopenContactRequestModel.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/ReopenContactRequestModel.cs
@@ -1,0 +1,12 @@
+namespace InterneTaakAfhandeling.Web.Server.Features.ReopenContactRequest;
+
+public class ReopenContactRequestModel
+{
+    public required string Reden { get; set; }
+}
+
+public class ReopenContactRequestResponse
+{
+    public required object Internetaak { get; set; }
+    public string? Waarschuwing { get; set; }
+}

--- a/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/ReopenContactRequestService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/ReopenContactRequestService.cs
@@ -1,14 +1,17 @@
 using InterneTaakAfhandeling.Common.Exceptions;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
+using InterneTaakAfhandeling.Web.Server.Authentication;
+using InterneTaakAfhandeling.Web.Server.Services.LogboekService;
 
 namespace InterneTaakAfhandeling.Web.Server.Features.ReopenContactRequest;
 
 public class ReopenContactRequestService(
     IOpenKlantApiClient openKlantApiClient,
+    ILogboekService logboekService,
     ILogger<ReopenContactRequestService> logger) : IReopenContactRequestService
 {
-    public async Task<ReopenResult> ReopenAsync(Guid internetaakId)
+    public async Task<ReopenResult> ReopenAsync(Guid internetaakId, string reden, ITAUser user)
     {
         var internetaak = await openKlantApiClient.GetInternetaakByIdAsync(internetaakId);
 
@@ -56,6 +59,9 @@ public class ReopenContactRequestService(
         };
 
         var updatedInternetaak = await openKlantApiClient.PatchInternetaakStatusAsync(statusRequest, internetaak.Uuid);
+
+        await logboekService.LogContactRequestAction(
+            KnownContactAction.Reopened(reden, user), internetaakId);
 
         return new ReopenResult
         {

--- a/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/ReopenContactRequestService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/ReopenContactRequestService.cs
@@ -1,0 +1,82 @@
+using InterneTaakAfhandeling.Common.Exceptions;
+using InterneTaakAfhandeling.Common.Services.OpenKlantApi;
+using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
+
+namespace InterneTaakAfhandeling.Web.Server.Features.ReopenContactRequest;
+
+public class ReopenContactRequestService(
+    IOpenKlantApiClient openKlantApiClient,
+    ILogger<ReopenContactRequestService> logger) : IReopenContactRequestService
+{
+    public async Task<ReopenResult> ReopenAsync(Guid internetaakId)
+    {
+        var internetaak = await openKlantApiClient.GetInternetaakByIdAsync(internetaakId);
+
+        var actors = await ResolveActorsAsync(internetaak);
+        var medewerkerActors = actors.Where(a => a.SoortActor == SoortActor.medewerker).ToList();
+        var orgEenheidActors = actors.Where(a => a.SoortActor == SoortActor.organisatorische_eenheid).ToList();
+
+        string? waarschuwing = null;
+        var hasInactiveMedewerker = medewerkerActors.Any(a => a.IndicatieActief == false);
+
+        if (hasInactiveMedewerker)
+        {
+            if (orgEenheidActors.Count == 0)
+            {
+                logger.LogWarning(
+                    "Reopen blocked: interne taak {InternetaakId} has inactive medewerker and no organisatorische eenheid",
+                    internetaakId);
+
+                throw new UnprocessableEntityException(
+                    "De oorspronkelijke behandelaar is niet meer actief en er is geen organisatorische eenheid gekoppeld. Heropening is niet mogelijk.",
+                    "GEEN_ORGANISATORISCHE_EENHEID");
+            }
+
+            // Reassign to the organisatorische eenheid actors only
+            var reassignRequest = new InternetakenPatchActorsRequest
+            {
+                ToegewezenAanActoren = orgEenheidActors
+                    .Select(a => new UuidObject { Uuid = Guid.Parse(a.Uuid) })
+                    .ToList()
+            };
+
+            await openKlantApiClient.PatchInternetaakActorAsync(reassignRequest, internetaak.Uuid);
+
+            waarschuwing = "De oorspronkelijke behandelaar is niet meer actief. Het contactverzoek is toegewezen aan de organisatorische eenheid.";
+
+            logger.LogInformation(
+                "Interne taak {InternetaakId} reassigned to organisatorische eenheid due to inactive medewerker",
+                internetaakId);
+        }
+
+        // Patch status to te_verwerken
+        var statusRequest = new InternetakenPatchStatusRequest
+        {
+            Status = KnownInternetaakStatussen.TeVerwerken
+        };
+
+        var updatedInternetaak = await openKlantApiClient.PatchInternetaakStatusAsync(statusRequest, internetaak.Uuid);
+
+        return new ReopenResult
+        {
+            Internetaak = updatedInternetaak,
+            Waarschuwing = waarschuwing
+        };
+    }
+
+    private async Task<List<Actor>> ResolveActorsAsync(Internetaak internetaak)
+    {
+        if (internetaak.ToegewezenAanActoren == null || internetaak.ToegewezenAanActoren.Count == 0)
+        {
+            return [];
+        }
+
+        var resolvedActors = await Task.WhenAll(
+            internetaak.ToegewezenAanActoren
+                .Where(a => !string.IsNullOrEmpty(a.Uuid))
+                .Select(a => openKlantApiClient.GetActorAsync(a.Uuid))
+        );
+
+        return resolvedActors.ToList();
+    }
+}

--- a/InterneTaakAfhandeling.Web.Server/Guards/IInternetaakGuardService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Guards/IInternetaakGuardService.cs
@@ -6,4 +6,10 @@ public interface IInternetaakGuardService
     /// Throws <see cref="InterneTaakAfhandeling.Common.Exceptions.ConflictException"/> if the interne taak has status 'verwerkt'.
     /// </summary>
     Task GuardAgainstVerwerktAsync(Guid internetaakId);
+
+    /// <summary>
+    /// Throws <see cref="InterneTaakAfhandeling.Common.Exceptions.ConflictException"/> if the interne taak does NOT have status 'verwerkt'.
+    /// Used to ensure only closed contactverzoeken can be reopened.
+    /// </summary>
+    Task GuardAgainstNietVerwerktAsync(Guid internetaakId);
 }

--- a/InterneTaakAfhandeling.Web.Server/Guards/InternetaakGuardService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Guards/InternetaakGuardService.cs
@@ -22,4 +22,21 @@ public class InternetaakGuardService(
                 "INTERNETAAK_VERWERKT");
         }
     }
+
+    public async Task GuardAgainstNietVerwerktAsync(Guid internetaakId)
+    {
+        var internetaak = await openKlantApiClient.GetInternetaakByIdAsync(internetaakId);
+
+        if (internetaak.Status != KnownInternetaakStatussen.Verwerkt)
+        {
+            logger.LogWarning(
+                "Reopen blocked: interne taak {InternetaakId} has status '{Status}', expected 'verwerkt'",
+                internetaakId,
+                internetaak.Status);
+
+            throw new ConflictException(
+                "Dit contactverzoek is niet gesloten en kan niet worden heropend.",
+                "INTERNETAAK_NIET_VERWERKT");
+        }
+    }
 }

--- a/InterneTaakAfhandeling.Web.Server/Middleware/ExceptionToProblemDetailsMapper.cs
+++ b/InterneTaakAfhandeling.Web.Server/Middleware/ExceptionToProblemDetailsMapper.cs
@@ -48,6 +48,11 @@ namespace InterneTaakAfhandeling.Web.Server.Middleware
             {
                 problemDetails.Extensions["conflictCode"] = conflictEx.Code;
             }
+
+            if (exception is UnprocessableEntityException unprocessableEx && !string.IsNullOrEmpty(unprocessableEx.Code))
+            {
+                problemDetails.Extensions["errorCode"] = unprocessableEx.Code;
+            }
              
             if (exception is ValidationException validationEx)
             {
@@ -85,6 +90,7 @@ namespace InterneTaakAfhandeling.Web.Server.Middleware
         private static int GetStatusCode(Exception exception) => exception switch
         {
             ConflictException => StatusCodes.Status409Conflict,
+            UnprocessableEntityException => StatusCodes.Status422UnprocessableEntity,
             ValidationException => StatusCodes.Status400BadRequest,
             _ => StatusCodes.Status500InternalServerError
         };
@@ -92,6 +98,7 @@ namespace InterneTaakAfhandeling.Web.Server.Middleware
         private static string GetTitle(Exception exception) => exception switch
         {
             ConflictException => "Conflict Error",
+            UnprocessableEntityException => "Unprocessable Entity",
             ValidationException => "Validation Error",
             _ => "An unexpected error occurred"
         };
@@ -99,6 +106,7 @@ namespace InterneTaakAfhandeling.Web.Server.Middleware
         private static string GetType(Exception exception) => exception switch
         {
             ConflictException => "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409",
+            UnprocessableEntityException => "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422",
             ValidationException => "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
             _ => "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500"
         };

--- a/InterneTaakAfhandeling.Web.Server/Services/LogboekService/KnownContactAction.cs
+++ b/InterneTaakAfhandeling.Web.Server/Services/LogboekService/KnownContactAction.cs
@@ -157,6 +157,17 @@ public class KnownContactAction
         };
     }
 
+    public static KnownContactAction Reopened(string reden, ITAUser loggedByUser)
+    {
+        return new KnownContactAction
+        {
+            Description = "heropend",
+            Type = ActiviteitTypes.Heropend,
+            Actor = CreateActor(loggedByUser),
+            Notitie = reden,
+        };
+    }
+
 
 
     private static ActiviteitActor CreateActor(ITAUser loggedByUser)

--- a/InterneTaakAfhandeling.Web.Server/Services/LogboekService/LogboekService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Services/LogboekService/LogboekService.cs
@@ -122,6 +122,17 @@ public class LogboekService(IObjectApiClient objectenApiClient, IOpenKlantApiCli
                         }
                         break;
                     }
+
+                case ActiviteitTypes.Heropend:
+                    {
+                        activiteit.UitgevoerdDoor = GetName(item);
+                        activiteit.Tekst = "Contactverzoek heropend";
+                        if (!string.IsNullOrEmpty(item.Notitie))
+                        {
+                            activiteit.Notitie = item.Notitie;
+                        }
+                        break;
+                    }
             }
 
             activiteiten.Add(activiteit);
@@ -184,6 +195,7 @@ public class LogboekService(IObjectApiClient objectenApiClient, IOpenKlantApiCli
         ActiviteitTypes.Toegewezen => "Opgepakt",
         ActiviteitTypes.InterneNotitie => "Interne notitie",
         ActiviteitTypes.Doorsturen => "Doorgestuurd",
+        ActiviteitTypes.Heropend => "Heropend",
 
         _ => type ?? "Onbekende actie"
     };


### PR DESCRIPTION
## Summary

Enables a functioneel beheerder to reopen a closed contactverzoek (status `verwerkt` → `te_verwerken`) with a mandatory reason. If the assigned behandelaar is no longer active, the contactverzoek is reassigned to the linked organisatorische eenheid. If no organisatorische eenheid exists and the behandelaar is inactive, the reopen is blocked. A warning field in the response signals when reassignment occurred.

Serves Feature #391: Beheerder kan gesloten contactverzoek heropenen.

## Changes

- **New endpoint** `POST /api/internetaken/{id}/heropen` with `FunctioneelBeheerderPolicy` authorization
- **Guard** `GuardAgainstNietVerwerktAsync` — rejects reopen if status ≠ `verwerkt` (409 Conflict)
- **Reopen service** — orchestrates actor activity check, optional reassignment to org unit, status patch, and logbook entry
- **Logbook** — new `ActiviteitType.Heropend` and `KnownContactAction.Reopened` factory method
- **Error handling** — new `UnprocessableEntityException` mapped to 422 in the exception middleware

## Test plan

- [ ] Beheerder heropent contactverzoek met geldige reden
- [ ] Heropening zonder reden wordt geweigerd
- [ ] Niet-beheerder kan niet heropenen
- [ ] Heropening terwijl behandelaar niet meer actief is (reassignment + warning)
- [ ] Heropening geblokkeerd bij inactieve behandelaar zonder organisatorische eenheid
- [ ] Contactverzoek wordt meerdere malen heropend
- [ ] Heropenen van contactverzoek dat niet gesloten is

## Related

Closes #433