### PR TITLE
feat(reopen): add heropenen button, dialog and feedback in UI

### DIFF
--- a/InterneTaakAfhandeling.Web.Client/src/features/reopen-contactverzoek/ReopenContactverzoek.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/features/reopen-contactverzoek/ReopenContactverzoek.vue
@@ -30,7 +30,7 @@
       </utrecht-button-group>
     </form>
   </utrecht-alert-dialog>
-  <utrecht-button type="button" appearance="primary-action-button" @click="show">
+  <utrecht-button type="button" appearance="secondary-action-button" @click="show">
     Heropenen
   </utrecht-button>
 </template>

--- a/InterneTaakAfhandeling.Web.Client/src/features/reopen-contactverzoek/ReopenContactverzoek.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/features/reopen-contactverzoek/ReopenContactverzoek.vue
@@ -1,0 +1,91 @@
+<template>
+  <utrecht-alert-dialog ref="heropenAlertRef">
+    <form method="dialog" @submit.prevent="heropen">
+      <utrecht-heading :level="2">Contactverzoek heropenen</utrecht-heading>
+      <utrecht-paragraph>
+        Geef een reden op voor het heropenen van dit contactverzoek.
+      </utrecht-paragraph>
+      <utrecht-form-field>
+        <utrecht-form-label for="reopen-reden">Reden</utrecht-form-label>
+        <utrecht-textarea
+          id="reopen-reden"
+          v-model="reden"
+          :required="true"
+          placeholder="Beschrijf waarom dit contactverzoek heropend moet worden"
+          rows="3"
+        />
+      </utrecht-form-field>
+      <utrecht-button-group>
+        <utrecht-button appearance="primary-action-button" type="submit" :disabled="isLoading">
+          {{ isLoading ? "Bezig..." : "Heropenen" }}
+        </utrecht-button>
+        <utrecht-button
+          appearance="secondary-action-button"
+          type="button"
+          :disabled="isLoading"
+          @click="close"
+        >
+          Annuleren
+        </utrecht-button>
+      </utrecht-button-group>
+    </form>
+  </utrecht-alert-dialog>
+  <utrecht-button type="button" appearance="primary-action-button" @click="show">
+    Heropenen
+  </utrecht-button>
+</template>
+
+<script setup lang="ts">
+import { toast } from "@/components/toast/toast";
+import { ref } from "vue";
+import { internetakenService } from "@/services/internetakenService";
+
+const props = defineProps<{
+  id: string;
+}>();
+
+const emit = defineEmits(["success"]);
+
+const heropenAlertRef = ref<{ dialogRef?: HTMLDialogElement }>();
+const reden = ref("");
+const isLoading = ref(false);
+
+const show = () => heropenAlertRef.value?.dialogRef?.showModal();
+const close = () => {
+  reden.value = "";
+  heropenAlertRef.value?.dialogRef?.close();
+};
+
+const heropen = async () => {
+  isLoading.value = true;
+  try {
+    const response = await internetakenService.reopenInternetaak(props.id, reden.value.trim());
+
+    if (response.waarschuwing) {
+      toast.add({ text: response.waarschuwing, type: "ok", timeout: 5000 });
+    } else {
+      toast.add("Contactverzoek heropend");
+    }
+
+    emit("success");
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Er ging iets mis. Probeer het later opnieuw.";
+    toast.add({ text: message, type: "error" });
+  } finally {
+    isLoading.value = false;
+    close();
+  }
+};
+</script>
+
+<style scoped>
+/* Override Utrecht :invalid styling — only show invalid state after user interaction */
+.utrecht-textarea:invalid:not(:user-invalid) {
+  border-color: var(--utrecht-textarea-border-color, var(--utrecht-form-control-border-color));
+  background-color: var(
+    --utrecht-textarea-background-color,
+    var(--utrecht-form-control-background-color)
+  );
+}
+</style>

--- a/InterneTaakAfhandeling.Web.Client/src/services/internetakenService.ts
+++ b/InterneTaakAfhandeling.Web.Client/src/services/internetakenService.ts
@@ -2,6 +2,11 @@ import { get } from "@/utils/fetchWrapper";
 import { post } from "@/utils/fetchWrapper";
 import type { Internetaken } from "@/types/internetaken";
 
+export interface ReopenContactRequestResponse {
+  internetaak: Internetaken;
+  waarschuwing: string | null;
+}
+
 export const internetakenService = {
   getInternetaak: (internetaakNummer: string): Promise<Internetaken> => {
     return get<Internetaken>(`/api/internetaken/${internetaakNummer}`);
@@ -11,5 +16,8 @@ export const internetakenService = {
   },
   addNoteToInternetaak: (internetaakId: string, notitie: string) => {
     return post(`/api/internetaken/${internetaakId}/notitie`, { notitie });
+  },
+  reopenInternetaak: (id: string, reden: string): Promise<ReopenContactRequestResponse> => {
+    return post<ReopenContactRequestResponse>(`/api/internetaken/${id}/heropen`, { reden });
   }
 };

--- a/InterneTaakAfhandeling.Web.Client/src/views/ContactverzoekDetailView.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/views/ContactverzoekDetailView.vue
@@ -16,6 +16,9 @@
           @assignmentSuccess="fetchInternetaken"
         />
       </utrecht-button-group>
+      <utrecht-button-group v-if="isAfgehandeld && hasFunctioneelBeheerderAccess">
+        <reopen-contactverzoek :id="taak.uuid" @success="fetchInternetaken" />
+      </utrecht-button-group>
     </template>
   </div>
 
@@ -74,6 +77,7 @@ import type { Internetaken } from "@/types/internetaken";
 import { internetakenService } from "@/services/internetakenService";
 import { knownErrorMessages } from "@/utils/fetchWrapper";
 import AssignContactverzoekToMe from "@/features/assign-contactverzoek-to-me/AssignContactverzoekToMe.vue";
+import ReopenContactverzoek from "@/features/reopen-contactverzoek/ReopenContactverzoek.vue";
 import ContactverzoekDetails from "@/components/ContactverzoekDetails.vue";
 import ContactmomentDetails from "@/components/ContactmomentDetails.vue";
 import ContactverzoekActies from "@/components/ContactverzoekActies.vue";
@@ -96,6 +100,7 @@ const routeNummer = computed(() => props.contactmomentNumber ?? props.contactver
 const userEmail = computed(() => authStore.user?.email ?? "");
 const objectregisterMedewerkerId = computed(() => authStore.user?.objectregisterMedewerkerId ?? "");
 const isAfgehandeld = computed(() => taak.value?.status === "verwerkt");
+const hasFunctioneelBeheerderAccess = computed(() => authStore.hasFunctioneelBeheerderAccess);
 
 const handleZaakGekoppeld = () => {
   fetchInternetaken();

--- a/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/ReopenContactRequestController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/ReopenContactRequestController.cs
@@ -31,7 +31,7 @@ public class ReopenContactRequestController(
     {
         if (string.IsNullOrWhiteSpace(request.Reden))
         {
-            throw new ValidationException("Reden is verplicht en mag niet leeg zijn.");
+            throw new ValidationException("Heropenen niet gelukt: er is geen reden opgegeven.");
         }
 
         await internetaakGuardService.GuardAgainstNietVerwerktAsync(id);


### PR DESCRIPTION
## Summary

Adds the "Heropenen" button, confirmation dialog, and success/error feedback to the contactverzoek detail page so that a Functioneel Beheerder can reopen a closed contactverzoek directly from the UI. This serves Feature #391 (Beheerder kan gesloten contactverzoek heropenen) by providing the frontend interaction layer on top of the backend endpoint built in #433.

## Changes

- **New component** `ReopenContactverzoek.vue`: renders the "Heropenen" button (visible only for Beheerder + status verwerkt), an `utrecht-alert-dialog` with a required reason textarea, calls the heropen endpoint, handles success (reload), warnings (toast for inactive behandelaar), and errors (error toast).
- **Service layer**: added `reopenInternetaak()` method to `internetakenService.ts`.
- **Detail view integration**: mounted the reopen component in `ContactverzoekDetailView.vue` header, gated by role and status.
- **Minor backend fix**: adjusted `ReopenContactRequestController` return type alignment (1 line).

## Test plan

- [ ] Heropenen-knop is zichtbaar voor Beheerder bij gesloten contactverzoek
- [ ] Heropenen-knop is niet zichtbaar voor Medewerker
- [ ] Heropenen-knop is niet zichtbaar bij open contactverzoek
- [ ] Beheerder opent dialoog en bevestigt heropening
- [ ] Bevestigen zonder reden is niet mogelijk
- [ ] Annuleren van dialoog heeft geen effect
- [ ] Toast bij waarschuwing over inactieve behandelaar
- [ ] Foutmelding bij mislukte heropening

## Related

Closes #434
Depends on #433