### PR TITLE
feat(contactverzoek): beheerder kan gesloten contactverzoek heropenen

### DIFF
--- a/InterneTaakAfhandeling.Common/Exceptions/UnprocessableEntityException.cs
+++ b/InterneTaakAfhandeling.Common/Exceptions/UnprocessableEntityException.cs
@@ -1,0 +1,13 @@
+namespace InterneTaakAfhandeling.Common.Exceptions;
+
+public class UnprocessableEntityException : Exception
+{
+    public string? Code { get; set; }
+
+    public UnprocessableEntityException(string message) : base(message) { }
+
+    public UnprocessableEntityException(string message, string code) : base(message)
+    {
+        Code = code;
+    }
+}

--- a/InterneTaakAfhandeling.Common/Services/ObjectApi/KnownLogboekValues.cs
+++ b/InterneTaakAfhandeling.Common/Services/ObjectApi/KnownLogboekValues.cs
@@ -8,6 +8,7 @@ public static class ActiviteitTypes
     public const string ZaakkoppelingGewijzigd = "zaakkoppeling-gewijzigd";
     public const string InterneNotitie = "interne-notitie";
     public const string Doorsturen = "doorsturen";
+    public const string Heropend = "heropend";
 
 }
 

--- a/InterneTaakAfhandeling.Web.Client/src/features/reopen-contactverzoek/ReopenContactverzoek.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/features/reopen-contactverzoek/ReopenContactverzoek.vue
@@ -30,7 +30,7 @@
       </utrecht-button-group>
     </form>
   </utrecht-alert-dialog>
-  <utrecht-button type="button" appearance="primary-action-button" @click="show">
+  <utrecht-button type="button" appearance="secondary-action-button" @click="show">
     Heropenen
   </utrecht-button>
 </template>

--- a/InterneTaakAfhandeling.Web.Client/src/features/reopen-contactverzoek/ReopenContactverzoek.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/features/reopen-contactverzoek/ReopenContactverzoek.vue
@@ -1,0 +1,91 @@
+<template>
+  <utrecht-alert-dialog ref="heropenAlertRef">
+    <form method="dialog" @submit.prevent="heropen">
+      <utrecht-heading :level="2">Contactverzoek heropenen</utrecht-heading>
+      <utrecht-paragraph>
+        Geef een reden op voor het heropenen van dit contactverzoek.
+      </utrecht-paragraph>
+      <utrecht-form-field>
+        <utrecht-form-label for="reopen-reden">Reden</utrecht-form-label>
+        <utrecht-textarea
+          id="reopen-reden"
+          v-model="reden"
+          :required="true"
+          placeholder="Beschrijf waarom dit contactverzoek heropend moet worden"
+          rows="3"
+        />
+      </utrecht-form-field>
+      <utrecht-button-group>
+        <utrecht-button appearance="primary-action-button" type="submit" :disabled="isLoading">
+          {{ isLoading ? "Bezig..." : "Heropenen" }}
+        </utrecht-button>
+        <utrecht-button
+          appearance="secondary-action-button"
+          type="button"
+          :disabled="isLoading"
+          @click="close"
+        >
+          Annuleren
+        </utrecht-button>
+      </utrecht-button-group>
+    </form>
+  </utrecht-alert-dialog>
+  <utrecht-button type="button" appearance="primary-action-button" @click="show">
+    Heropenen
+  </utrecht-button>
+</template>
+
+<script setup lang="ts">
+import { toast } from "@/components/toast/toast";
+import { ref } from "vue";
+import { internetakenService } from "@/services/internetakenService";
+
+const props = defineProps<{
+  id: string;
+}>();
+
+const emit = defineEmits(["success"]);
+
+const heropenAlertRef = ref<{ dialogRef?: HTMLDialogElement }>();
+const reden = ref("");
+const isLoading = ref(false);
+
+const show = () => heropenAlertRef.value?.dialogRef?.showModal();
+const close = () => {
+  reden.value = "";
+  heropenAlertRef.value?.dialogRef?.close();
+};
+
+const heropen = async () => {
+  isLoading.value = true;
+  try {
+    const response = await internetakenService.reopenInternetaak(props.id, reden.value.trim());
+
+    if (response.waarschuwing) {
+      toast.add({ text: response.waarschuwing, type: "ok", timeout: 5000 });
+    } else {
+      toast.add("Contactverzoek heropend");
+    }
+
+    emit("success");
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Er ging iets mis. Probeer het later opnieuw.";
+    toast.add({ text: message, type: "error" });
+  } finally {
+    isLoading.value = false;
+    close();
+  }
+};
+</script>
+
+<style scoped>
+/* Override Utrecht :invalid styling — only show invalid state after user interaction */
+.utrecht-textarea:invalid:not(:user-invalid) {
+  border-color: var(--utrecht-textarea-border-color, var(--utrecht-form-control-border-color));
+  background-color: var(
+    --utrecht-textarea-background-color,
+    var(--utrecht-form-control-background-color)
+  );
+}
+</style>

--- a/InterneTaakAfhandeling.Web.Client/src/services/internetakenService.ts
+++ b/InterneTaakAfhandeling.Web.Client/src/services/internetakenService.ts
@@ -2,6 +2,11 @@ import { get } from "@/utils/fetchWrapper";
 import { post } from "@/utils/fetchWrapper";
 import type { Internetaken } from "@/types/internetaken";
 
+export interface ReopenContactRequestResponse {
+  internetaak: Internetaken;
+  waarschuwing: string | null;
+}
+
 export const internetakenService = {
   getInternetaak: (internetaakNummer: string): Promise<Internetaken> => {
     return get<Internetaken>(`/api/internetaken/${internetaakNummer}`);
@@ -11,5 +16,8 @@ export const internetakenService = {
   },
   addNoteToInternetaak: (internetaakId: string, notitie: string) => {
     return post(`/api/internetaken/${internetaakId}/notitie`, { notitie });
+  },
+  reopenInternetaak: (id: string, reden: string): Promise<ReopenContactRequestResponse> => {
+    return post<ReopenContactRequestResponse>(`/api/internetaken/${id}/heropen`, { reden });
   }
 };

--- a/InterneTaakAfhandeling.Web.Client/src/views/ContactverzoekDetailView.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/views/ContactverzoekDetailView.vue
@@ -16,6 +16,9 @@
           @assignmentSuccess="fetchInternetaken"
         />
       </utrecht-button-group>
+      <utrecht-button-group v-if="isAfgehandeld && hasFunctioneelBeheerderAccess">
+        <reopen-contactverzoek :id="taak.uuid" @success="fetchInternetaken" />
+      </utrecht-button-group>
     </template>
   </div>
 
@@ -74,6 +77,7 @@ import type { Internetaken } from "@/types/internetaken";
 import { internetakenService } from "@/services/internetakenService";
 import { knownErrorMessages } from "@/utils/fetchWrapper";
 import AssignContactverzoekToMe from "@/features/assign-contactverzoek-to-me/AssignContactverzoekToMe.vue";
+import ReopenContactverzoek from "@/features/reopen-contactverzoek/ReopenContactverzoek.vue";
 import ContactverzoekDetails from "@/components/ContactverzoekDetails.vue";
 import ContactmomentDetails from "@/components/ContactmomentDetails.vue";
 import ContactverzoekActies from "@/components/ContactverzoekActies.vue";
@@ -96,6 +100,7 @@ const routeNummer = computed(() => props.contactmomentNumber ?? props.contactver
 const userEmail = computed(() => authStore.user?.email ?? "");
 const objectregisterMedewerkerId = computed(() => authStore.user?.objectregisterMedewerkerId ?? "");
 const isAfgehandeld = computed(() => taak.value?.status === "verwerkt");
+const hasFunctioneelBeheerderAccess = computed(() => authStore.hasFunctioneelBeheerderAccess);
 
 const handleZaakGekoppeld = () => {
   fetchInternetaken();

--- a/InterneTaakAfhandeling.Web.Server/Config/ServiceCollectionExtensions.cs
+++ b/InterneTaakAfhandeling.Web.Server/Config/ServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ using InterneTaakAfhandeling.Web.Server.Features.InterneTaak;
 using InterneTaakAfhandeling.Web.Server.Features.InterneTakenOverzicht;
 using InterneTaakAfhandeling.Web.Server.Features.KlantContact;
 using InterneTaakAfhandeling.Web.Server.Features.MyInterneTakenOverview;
+using InterneTaakAfhandeling.Web.Server.Features.ReopenContactRequest;
 using InterneTaakAfhandeling.Web.Server.Middleware;
 using InterneTaakAfhandeling.Web.Server.Services;
 using InterneTaakAfhandeling.Web.Server.Guards;
@@ -62,6 +63,7 @@ namespace InterneTaakAfhandeling.Web.Server.Config
             services.AddScoped<IMedewerkersOverzichtService, MedewerkersOverzichtService>();
             services.AddScoped<ILogboekService, LogboekService>();
             services.AddScoped<IInternetaakGuardService, InternetaakGuardService>();
+            services.AddScoped<IReopenContactRequestService, ReopenContactRequestService>();
             services.AddScoped<IMyInterneTakenOverviewService, MyInterneTakenOverviewService>();
             services.AddSmtpClients(configuration);
             

--- a/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/IReopenContactRequestService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/IReopenContactRequestService.cs
@@ -1,0 +1,14 @@
+using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
+
+namespace InterneTaakAfhandeling.Web.Server.Features.ReopenContactRequest;
+
+public interface IReopenContactRequestService
+{
+    Task<ReopenResult> ReopenAsync(Guid internetaakId);
+}
+
+public class ReopenResult
+{
+    public required Internetaak Internetaak { get; set; }
+    public string? Waarschuwing { get; set; }
+}

--- a/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/IReopenContactRequestService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/IReopenContactRequestService.cs
@@ -1,10 +1,11 @@
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
+using InterneTaakAfhandeling.Web.Server.Authentication;
 
 namespace InterneTaakAfhandeling.Web.Server.Features.ReopenContactRequest;
 
 public interface IReopenContactRequestService
 {
-    Task<ReopenResult> ReopenAsync(Guid internetaakId);
+    Task<ReopenResult> ReopenAsync(Guid internetaakId, string reden, ITAUser user);
 }
 
 public class ReopenResult

--- a/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/ReopenContactRequestController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/ReopenContactRequestController.cs
@@ -31,7 +31,7 @@ public class ReopenContactRequestController(
     {
         if (string.IsNullOrWhiteSpace(request.Reden))
         {
-            throw new ValidationException("Reden is verplicht en mag niet leeg zijn.");
+            throw new ValidationException("Heropenen niet gelukt: er is geen reden opgegeven.");
         }
 
         await internetaakGuardService.GuardAgainstNietVerwerktAsync(id);

--- a/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/ReopenContactRequestController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/ReopenContactRequestController.cs
@@ -1,0 +1,55 @@
+using System.ComponentModel.DataAnnotations;
+using InterneTaakAfhandeling.Web.Server.Authentication;
+using InterneTaakAfhandeling.Web.Server.Guards;
+using InterneTaakAfhandeling.Web.Server.Services.LogboekService;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace InterneTaakAfhandeling.Web.Server.Features.ReopenContactRequest;
+
+[Route("api/internetaken")]
+[ApiController]
+[Authorize(Policy = FunctioneelBeheerderPolicy.Name)]
+[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+[ProducesResponseType(StatusCodes.Status403Forbidden)]
+public class ReopenContactRequestController(
+    IReopenContactRequestService reopenContactRequestService,
+    ILogboekService logboekService,
+    IInternetaakGuardService internetaakGuardService,
+    ITAUser user,
+    ILogger<ReopenContactRequestController> logger) : Controller
+{
+    private readonly ITAUser _user = user ?? throw new ArgumentNullException(nameof(user));
+
+    [ProducesResponseType(typeof(ReopenContactRequestResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    [HttpPost("{id:guid}/heropen")]
+    public async Task<IActionResult> ReopenContactRequestAsync(
+        [FromRoute] Guid id,
+        [FromBody] ReopenContactRequestModel request)
+    {
+        if (string.IsNullOrWhiteSpace(request.Reden))
+        {
+            throw new ValidationException("Reden is verplicht en mag niet leeg zijn.");
+        }
+
+        await internetaakGuardService.GuardAgainstNietVerwerktAsync(id);
+
+        logger.LogInformation(
+            "Reopening internetaak {InternetaakId} by user {UserId} with reason: {Reden}",
+            id, _user.Email, request.Reden);
+
+        var result = await reopenContactRequestService.ReopenAsync(id);
+
+        await logboekService.LogContactRequestAction(
+            KnownContactAction.Reopened(request.Reden, _user), id);
+
+        return Ok(new ReopenContactRequestResponse
+        {
+            Internetaak = result.Internetaak,
+            Waarschuwing = result.Waarschuwing
+        });
+    }
+}

--- a/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/ReopenContactRequestController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/ReopenContactRequestController.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel.DataAnnotations;
+using InterneTaakAfhandeling.Common.Helpers;
 using InterneTaakAfhandeling.Web.Server.Authentication;
 using InterneTaakAfhandeling.Web.Server.Guards;
-using InterneTaakAfhandeling.Web.Server.Services.LogboekService;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -14,7 +14,6 @@ namespace InterneTaakAfhandeling.Web.Server.Features.ReopenContactRequest;
 [ProducesResponseType(StatusCodes.Status403Forbidden)]
 public class ReopenContactRequestController(
     IReopenContactRequestService reopenContactRequestService,
-    ILogboekService logboekService,
     IInternetaakGuardService internetaakGuardService,
     ITAUser user,
     ILogger<ReopenContactRequestController> logger) : Controller
@@ -38,13 +37,10 @@ public class ReopenContactRequestController(
         await internetaakGuardService.GuardAgainstNietVerwerktAsync(id);
 
         logger.LogInformation(
-            "Reopening internetaak {InternetaakId} by user {UserId} with reason: {Reden}",
-            id, _user.Email, request.Reden);
+            "Reopening internetaak {InternetaakId} by user {UserId}",
+            id, SecureLogging.SanitizeAndTruncate(_user.Email, 5));
 
-        var result = await reopenContactRequestService.ReopenAsync(id);
-
-        await logboekService.LogContactRequestAction(
-            KnownContactAction.Reopened(request.Reden, _user), id);
+        var result = await reopenContactRequestService.ReopenAsync(id, request.Reden, _user);
 
         return Ok(new ReopenContactRequestResponse
         {

--- a/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/ReopenContactRequestModel.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/ReopenContactRequestModel.cs
@@ -1,3 +1,5 @@
+using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
+
 namespace InterneTaakAfhandeling.Web.Server.Features.ReopenContactRequest;
 
 public class ReopenContactRequestModel
@@ -7,6 +9,6 @@ public class ReopenContactRequestModel
 
 public class ReopenContactRequestResponse
 {
-    public required object Internetaak { get; set; }
+    public required Internetaak Internetaak { get; set; }
     public string? Waarschuwing { get; set; }
 }

--- a/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/ReopenContactRequestModel.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/ReopenContactRequestModel.cs
@@ -1,0 +1,12 @@
+namespace InterneTaakAfhandeling.Web.Server.Features.ReopenContactRequest;
+
+public class ReopenContactRequestModel
+{
+    public required string Reden { get; set; }
+}
+
+public class ReopenContactRequestResponse
+{
+    public required object Internetaak { get; set; }
+    public string? Waarschuwing { get; set; }
+}

--- a/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/ReopenContactRequestService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/ReopenContactRequestService.cs
@@ -1,14 +1,17 @@
 using InterneTaakAfhandeling.Common.Exceptions;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
+using InterneTaakAfhandeling.Web.Server.Authentication;
+using InterneTaakAfhandeling.Web.Server.Services.LogboekService;
 
 namespace InterneTaakAfhandeling.Web.Server.Features.ReopenContactRequest;
 
 public class ReopenContactRequestService(
     IOpenKlantApiClient openKlantApiClient,
+    ILogboekService logboekService,
     ILogger<ReopenContactRequestService> logger) : IReopenContactRequestService
 {
-    public async Task<ReopenResult> ReopenAsync(Guid internetaakId)
+    public async Task<ReopenResult> ReopenAsync(Guid internetaakId, string reden, ITAUser user)
     {
         var internetaak = await openKlantApiClient.GetInternetaakByIdAsync(internetaakId);
 
@@ -56,6 +59,9 @@ public class ReopenContactRequestService(
         };
 
         var updatedInternetaak = await openKlantApiClient.PatchInternetaakStatusAsync(statusRequest, internetaak.Uuid);
+
+        await logboekService.LogContactRequestAction(
+            KnownContactAction.Reopened(reden, user), internetaakId);
 
         return new ReopenResult
         {

--- a/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/ReopenContactRequestService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ReopenContactRequest/ReopenContactRequestService.cs
@@ -1,0 +1,82 @@
+using InterneTaakAfhandeling.Common.Exceptions;
+using InterneTaakAfhandeling.Common.Services.OpenKlantApi;
+using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
+
+namespace InterneTaakAfhandeling.Web.Server.Features.ReopenContactRequest;
+
+public class ReopenContactRequestService(
+    IOpenKlantApiClient openKlantApiClient,
+    ILogger<ReopenContactRequestService> logger) : IReopenContactRequestService
+{
+    public async Task<ReopenResult> ReopenAsync(Guid internetaakId)
+    {
+        var internetaak = await openKlantApiClient.GetInternetaakByIdAsync(internetaakId);
+
+        var actors = await ResolveActorsAsync(internetaak);
+        var medewerkerActors = actors.Where(a => a.SoortActor == SoortActor.medewerker).ToList();
+        var orgEenheidActors = actors.Where(a => a.SoortActor == SoortActor.organisatorische_eenheid).ToList();
+
+        string? waarschuwing = null;
+        var hasInactiveMedewerker = medewerkerActors.Any(a => a.IndicatieActief == false);
+
+        if (hasInactiveMedewerker)
+        {
+            if (orgEenheidActors.Count == 0)
+            {
+                logger.LogWarning(
+                    "Reopen blocked: interne taak {InternetaakId} has inactive medewerker and no organisatorische eenheid",
+                    internetaakId);
+
+                throw new UnprocessableEntityException(
+                    "De oorspronkelijke behandelaar is niet meer actief en er is geen organisatorische eenheid gekoppeld. Heropening is niet mogelijk.",
+                    "GEEN_ORGANISATORISCHE_EENHEID");
+            }
+
+            // Reassign to the organisatorische eenheid actors only
+            var reassignRequest = new InternetakenPatchActorsRequest
+            {
+                ToegewezenAanActoren = orgEenheidActors
+                    .Select(a => new UuidObject { Uuid = Guid.Parse(a.Uuid) })
+                    .ToList()
+            };
+
+            await openKlantApiClient.PatchInternetaakActorAsync(reassignRequest, internetaak.Uuid);
+
+            waarschuwing = "De oorspronkelijke behandelaar is niet meer actief. Het contactverzoek is toegewezen aan de organisatorische eenheid.";
+
+            logger.LogInformation(
+                "Interne taak {InternetaakId} reassigned to organisatorische eenheid due to inactive medewerker",
+                internetaakId);
+        }
+
+        // Patch status to te_verwerken
+        var statusRequest = new InternetakenPatchStatusRequest
+        {
+            Status = KnownInternetaakStatussen.TeVerwerken
+        };
+
+        var updatedInternetaak = await openKlantApiClient.PatchInternetaakStatusAsync(statusRequest, internetaak.Uuid);
+
+        return new ReopenResult
+        {
+            Internetaak = updatedInternetaak,
+            Waarschuwing = waarschuwing
+        };
+    }
+
+    private async Task<List<Actor>> ResolveActorsAsync(Internetaak internetaak)
+    {
+        if (internetaak.ToegewezenAanActoren == null || internetaak.ToegewezenAanActoren.Count == 0)
+        {
+            return [];
+        }
+
+        var resolvedActors = await Task.WhenAll(
+            internetaak.ToegewezenAanActoren
+                .Where(a => !string.IsNullOrEmpty(a.Uuid))
+                .Select(a => openKlantApiClient.GetActorAsync(a.Uuid))
+        );
+
+        return resolvedActors.ToList();
+    }
+}

--- a/InterneTaakAfhandeling.Web.Server/Guards/IInternetaakGuardService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Guards/IInternetaakGuardService.cs
@@ -6,4 +6,10 @@ public interface IInternetaakGuardService
     /// Throws <see cref="InterneTaakAfhandeling.Common.Exceptions.ConflictException"/> if the interne taak has status 'verwerkt'.
     /// </summary>
     Task GuardAgainstVerwerktAsync(Guid internetaakId);
+
+    /// <summary>
+    /// Throws <see cref="InterneTaakAfhandeling.Common.Exceptions.ConflictException"/> if the interne taak does NOT have status 'verwerkt'.
+    /// Used to ensure only closed contactverzoeken can be reopened.
+    /// </summary>
+    Task GuardAgainstNietVerwerktAsync(Guid internetaakId);
 }

--- a/InterneTaakAfhandeling.Web.Server/Guards/InternetaakGuardService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Guards/InternetaakGuardService.cs
@@ -22,4 +22,21 @@ public class InternetaakGuardService(
                 "INTERNETAAK_VERWERKT");
         }
     }
+
+    public async Task GuardAgainstNietVerwerktAsync(Guid internetaakId)
+    {
+        var internetaak = await openKlantApiClient.GetInternetaakByIdAsync(internetaakId);
+
+        if (internetaak.Status != KnownInternetaakStatussen.Verwerkt)
+        {
+            logger.LogWarning(
+                "Reopen blocked: interne taak {InternetaakId} has status '{Status}', expected 'verwerkt'",
+                internetaakId,
+                internetaak.Status);
+
+            throw new ConflictException(
+                "Dit contactverzoek is niet gesloten en kan niet worden heropend.",
+                "INTERNETAAK_NIET_VERWERKT");
+        }
+    }
 }

--- a/InterneTaakAfhandeling.Web.Server/Middleware/ExceptionToProblemDetailsMapper.cs
+++ b/InterneTaakAfhandeling.Web.Server/Middleware/ExceptionToProblemDetailsMapper.cs
@@ -48,6 +48,11 @@ namespace InterneTaakAfhandeling.Web.Server.Middleware
             {
                 problemDetails.Extensions["conflictCode"] = conflictEx.Code;
             }
+
+            if (exception is UnprocessableEntityException unprocessableEx && !string.IsNullOrEmpty(unprocessableEx.Code))
+            {
+                problemDetails.Extensions["errorCode"] = unprocessableEx.Code;
+            }
              
             if (exception is ValidationException validationEx)
             {
@@ -85,6 +90,7 @@ namespace InterneTaakAfhandeling.Web.Server.Middleware
         private static int GetStatusCode(Exception exception) => exception switch
         {
             ConflictException => StatusCodes.Status409Conflict,
+            UnprocessableEntityException => StatusCodes.Status422UnprocessableEntity,
             ValidationException => StatusCodes.Status400BadRequest,
             _ => StatusCodes.Status500InternalServerError
         };
@@ -92,6 +98,7 @@ namespace InterneTaakAfhandeling.Web.Server.Middleware
         private static string GetTitle(Exception exception) => exception switch
         {
             ConflictException => "Conflict Error",
+            UnprocessableEntityException => "Unprocessable Entity",
             ValidationException => "Validation Error",
             _ => "An unexpected error occurred"
         };
@@ -99,6 +106,7 @@ namespace InterneTaakAfhandeling.Web.Server.Middleware
         private static string GetType(Exception exception) => exception switch
         {
             ConflictException => "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409",
+            UnprocessableEntityException => "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422",
             ValidationException => "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
             _ => "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500"
         };

--- a/InterneTaakAfhandeling.Web.Server/Services/LogboekService/KnownContactAction.cs
+++ b/InterneTaakAfhandeling.Web.Server/Services/LogboekService/KnownContactAction.cs
@@ -157,6 +157,17 @@ public class KnownContactAction
         };
     }
 
+    public static KnownContactAction Reopened(string reden, ITAUser loggedByUser)
+    {
+        return new KnownContactAction
+        {
+            Description = "heropend",
+            Type = ActiviteitTypes.Heropend,
+            Actor = CreateActor(loggedByUser),
+            Notitie = reden,
+        };
+    }
+
 
 
     private static ActiviteitActor CreateActor(ITAUser loggedByUser)

--- a/InterneTaakAfhandeling.Web.Server/Services/LogboekService/LogboekService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Services/LogboekService/LogboekService.cs
@@ -122,6 +122,17 @@ public class LogboekService(IObjectApiClient objectenApiClient, IOpenKlantApiCli
                         }
                         break;
                     }
+
+                case ActiviteitTypes.Heropend:
+                    {
+                        activiteit.UitgevoerdDoor = GetName(item);
+                        activiteit.Tekst = "Contactverzoek heropend";
+                        if (!string.IsNullOrEmpty(item.Notitie))
+                        {
+                            activiteit.Notitie = item.Notitie;
+                        }
+                        break;
+                    }
             }
 
             activiteiten.Add(activiteit);
@@ -184,6 +195,7 @@ public class LogboekService(IObjectApiClient objectenApiClient, IOpenKlantApiCli
         ActiviteitTypes.Toegewezen => "Opgepakt",
         ActiviteitTypes.InterneNotitie => "Interne notitie",
         ActiviteitTypes.Doorsturen => "Doorgestuurd",
+        ActiviteitTypes.Heropend => "Heropend",
 
         _ => type ?? "Onbekende actie"
     };


### PR DESCRIPTION
## Summary

Voegt de mogelijkheid toe voor een Functioneel Beheerder om een gesloten contactverzoek (status `verwerkt`) te heropenen met opgave van een verplichte reden. Dit is nodig zodat een behandelaar het opnieuw kan opvolgen wanneer dat relevant blijkt — bijvoorbeeld bij aanvullende vragen van de klant. De heropening wordt vastgelegd in het logboek voor traceerbaarheid. Bevat ook een guard tegen inactieve behandelaars: bij heropening wordt het contactverzoek dan toegewezen aan de gekoppelde organisatorische eenheid.

## Changes

- **Backend heropen-endpoint**: nieuw `POST /api/internetaken/{id}/heropen` met autorisatie (FunctioneelBeheerderPolicy), validatie, status-PATCH naar `te_verwerken`, logboekregel via LogboekService, en inactieve-behandelaar-check met hertoewijzing aan organisatorische eenheid
- **Frontend heropenen-flow**: "Heropenen"-knop op de detailpagina (alleen zichtbaar voor beheerder bij status `verwerkt`), dialoogvenster met verplicht reden-veld, data-herlaad na succes, en toast bij waarschuwing of fout
- **Infrastructuur**: nieuw `UnprocessableEntityException` type, guard `GuardAgainstNietVerwerkt`, en `KnownContactAction.Reopened` factory method

## Test plan

- [ ] Beheerder heropent contactverzoek met geldige reden → status wordt `te verwerken`, logboekregel aangemaakt
- [ ] Heropening zonder reden wordt geweigerd (400)
- [ ] Niet-beheerder kan niet heropenen (403)
- [ ] Heropening terwijl behandelaar niet meer actief is → hertoewijzing aan organisatorische eenheid + waarschuwing
- [ ] Heropening geblokkeerd bij inactieve behandelaar zonder organisatorische eenheid (422)
- [ ] Contactverzoek wordt meerdere malen heropend → meerdere logboekregels
- [ ] Heropenen van contactverzoek dat niet gesloten is wordt geweigerd (409)
- [ ] Heropenen-knop is zichtbaar voor Beheerder bij gesloten contactverzoek
- [ ] Heropenen-knop is niet zichtbaar voor Medewerker
- [ ] Heropenen-knop is niet zichtbaar bij open contactverzoek
- [ ] Beheerder opent dialoog en bevestigt heropening → pagina toont status `te verwerken`
- [ ] Bevestigen zonder reden is niet mogelijk (native validatie)
- [ ] Annuleren van dialoog heeft geen effect
- [ ] Toast bij waarschuwing over inactieve behandelaar
- [ ] Foutmelding bij mislukte heropening → fout-toast

## Related

Closes #433
Closes #434
Closes #391