### PR TITLE
feat(email): update notification email template to full KCC text

### DIFF
--- a/InterneTaakAfhandeling.Common/Services/Emailservices/Content/EmailContentService.cs
+++ b/InterneTaakAfhandeling.Common/Services/Emailservices/Content/EmailContentService.cs
@@ -1,4 +1,4 @@
-using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
+﻿using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
 using System.Text;
 
 namespace InterneTaakAfhandeling.Common.Services.Emailservices.Content;
@@ -22,8 +22,7 @@ public class EmailContentService : IEmailContentService
     </head>
     <body>
         <p>Beste collega,</p>
-        <p>Er is een vraag of verzoek binnengekomen van een inwoner of ondernemer.<br/>
-        Je kunt het verzoek bekijken en afhandelen via onderstaande link:</p>
+        <p>Er is een vraag of verzoek binnengekomen van een inwoner of ondernemer.<br/>Je kunt het verzoek bekijken en afhandelen via onderstaande link:</p>
         <p><a href=""{Link}"">Contactverzoek {Nummer}</a></p>
         <p>We verzoeken je om dit zo spoedig mogelijk op te pakken.</p>
         <p>Met vriendelijke groet,<br/>KCC/Klantcontactcentrum</p>

--- a/InterneTaakAfhandeling.Common/Services/Emailservices/Content/EmailContentService.cs
+++ b/InterneTaakAfhandeling.Common/Services/Emailservices/Content/EmailContentService.cs
@@ -24,7 +24,7 @@ public class EmailContentService : IEmailContentService
         <p>Beste collega,</p>
         <p>Er is een vraag of verzoek binnengekomen van een inwoner of ondernemer.<br/>
         Je kunt het verzoek bekijken en afhandelen via onderstaande link:</p>
-        <p>Contactverzoek <a href=""{Link}"">{Nummer}</a></p>
+        <p><a href=""{Link}"">Contactverzoek {Nummer}</a></p>
         <p>We verzoeken je om dit zo spoedig mogelijk op te pakken.</p>
         <p>Met vriendelijke groet,<br/>KCC/Klantcontactcentrum</p>
     </body>

--- a/InterneTaakAfhandeling.Common/Services/Emailservices/Content/EmailContentService.cs
+++ b/InterneTaakAfhandeling.Common/Services/Emailservices/Content/EmailContentService.cs
@@ -21,8 +21,12 @@ public class EmailContentService : IEmailContentService
         </style>
     </head>
     <body>
-        <p>Er is een nieuw contactverzoek voor jou.</p>
-        <p>Bekijk <a href=""{Link}"">contactverzoek {Nummer} in ITA Contactverzoeken</a>.</p>
+        <p>Beste collega,</p>
+        <p>Er is een vraag of verzoek binnengekomen van een inwoner of ondernemer.<br/>
+        Je kunt het verzoek bekijken en afhandelen via onderstaande link:</p>
+        <p>Contactverzoek <a href=""{Link}"">{Nummer}</a></p>
+        <p>We verzoeken je om dit zo spoedig mogelijk op te pakken.</p>
+        <p>Met vriendelijke groet,<br/>KCC/Klantcontactcentrum</p>
     </body>
     </html>";
 


### PR DESCRIPTION
## Summary

De huidige onpersoonlijke notificatietekst ("Er is een nieuw contactverzoek voor jou") is vervangen door de volledige KCC-communicatie inclusief aanhef, toelichting, klikbare link, oproep tot actie en formele afsluiting. Dit zorgt ervoor dat de KCC-medewerker direct weet wat er verwacht wordt en het bericht past bij de communicatiestijl van het KCC.

## Changes

- **E-mail template bijgewerkt** — HTML-template in `EmailContentService` uitgebreid met volledige tekst: "Beste collega," aanhef, body met uitleg, link naar contactverzoek (alleen nummer klikbaar), verzoek tot actie, en "Met vriendelijke groet, KCC/Klantcontactcentrum" afsluiting
- **HTML-structuur verbeterd** — `<p>`-tags voor correcte alinea-scheiding in e-mailclients

## Test plan

- [ ] Notificatie-e-mail bevat volledige tekst conform specificatie
- [ ] HTML-opmaak scheidt alinea's correct met witruimte

## Related

Closes #442