### PR TITLE
feat(email): clear notification email upon contact request assignment

### DIFF
--- a/InterneTaakAfhandeling.Common/Services/Emailservices/Content/EmailContentService.cs
+++ b/InterneTaakAfhandeling.Common/Services/Emailservices/Content/EmailContentService.cs
@@ -1,4 +1,4 @@
-using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
+﻿using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
 using System.Text;
 
 namespace InterneTaakAfhandeling.Common.Services.Emailservices.Content;
@@ -22,8 +22,7 @@ public class EmailContentService : IEmailContentService
     </head>
     <body>
         <p>Beste collega,</p>
-        <p>Er is een vraag of verzoek binnengekomen van een inwoner of ondernemer.<br/>
-        Je kunt het verzoek bekijken en afhandelen via onderstaande link:</p>
+        <p>Er is een vraag of verzoek binnengekomen van een inwoner of ondernemer.<br/>Je kunt het verzoek bekijken en afhandelen via onderstaande link:</p>
         <p><a href=""{Link}"">Contactverzoek {Nummer}</a></p>
         <p>We verzoeken je om dit zo spoedig mogelijk op te pakken.</p>
         <p>Met vriendelijke groet,<br/>KCC/Klantcontactcentrum</p>

--- a/InterneTaakAfhandeling.Common/Services/Emailservices/Content/EmailContentService.cs
+++ b/InterneTaakAfhandeling.Common/Services/Emailservices/Content/EmailContentService.cs
@@ -1,4 +1,5 @@
-﻿using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
+using System.Net;
+using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
 using System.Text;
 
 namespace InterneTaakAfhandeling.Common.Services.Emailservices.Content;
@@ -34,11 +35,11 @@ public class EmailContentService : IEmailContentService
         var contactmomentNummer = internetaak.AanleidinggevendKlantcontact?.Nummer
             ?? throw new InvalidOperationException($"AanleidinggevendKlantcontact.Nummer ontbreekt voor internetaak {internetaak.Nummer}");
 
-        var deeplink = $"{itaBaseUrl.TrimEnd('/')}/contactmoment/{contactmomentNummer}";
+        var deeplink = $"{itaBaseUrl.TrimEnd('/')}/contactmoment/{Uri.EscapeDataString(contactmomentNummer)}";
 
         var sb = new StringBuilder(EmailTemplate);
-        sb.Replace("{Link}", deeplink)
-          .Replace("{Nummer}", contactmomentNummer);
+        sb.Replace("{Link}", WebUtility.HtmlEncode(deeplink))
+          .Replace("{Nummer}", WebUtility.HtmlEncode(contactmomentNummer));
 
         return sb.ToString();
     }

--- a/InterneTaakAfhandeling.Common/Services/Emailservices/Content/EmailContentService.cs
+++ b/InterneTaakAfhandeling.Common/Services/Emailservices/Content/EmailContentService.cs
@@ -24,7 +24,7 @@ public class EmailContentService : IEmailContentService
         <p>Beste collega,</p>
         <p>Er is een vraag of verzoek binnengekomen van een inwoner of ondernemer.<br/>
         Je kunt het verzoek bekijken en afhandelen via onderstaande link:</p>
-        <p>Contactverzoek <a href=""{Link}"">{Nummer}</a></p>
+        <p><a href=""{Link}"">Contactverzoek {Nummer}</a></p>
         <p>We verzoeken je om dit zo spoedig mogelijk op te pakken.</p>
         <p>Met vriendelijke groet,<br/>KCC/Klantcontactcentrum</p>
     </body>

--- a/InterneTaakAfhandeling.Common/Services/Emailservices/Content/EmailContentService.cs
+++ b/InterneTaakAfhandeling.Common/Services/Emailservices/Content/EmailContentService.cs
@@ -21,8 +21,12 @@ public class EmailContentService : IEmailContentService
         </style>
     </head>
     <body>
-        <p>Er is een nieuw contactverzoek voor jou.</p>
-        <p>Bekijk <a href=""{Link}"">contactverzoek {Nummer} in ITA Contactverzoeken</a>.</p>
+        <p>Beste collega,</p>
+        <p>Er is een vraag of verzoek binnengekomen van een inwoner of ondernemer.<br/>
+        Je kunt het verzoek bekijken en afhandelen via onderstaande link:</p>
+        <p>Contactverzoek <a href=""{Link}"">{Nummer}</a></p>
+        <p>We verzoeken je om dit zo spoedig mogelijk op te pakken.</p>
+        <p>Met vriendelijke groet,<br/>KCC/Klantcontactcentrum</p>
     </body>
     </html>";
 


### PR DESCRIPTION
## Summary

The notification email sent to KCC employees when a contact request is assigned was minimal and impersonal. This change replaces it with a complete, clearly structured email containing a personal greeting, explanation of the request, a clickable deep link to the contact request, a call to action, and a formal closing — matching KCC communication style so recipients immediately understand what's expected of them.

Implements Feature #336.

## Changes

- **Email template overhaul** — Replaced the single-line notification text in `EmailContentService` with a multi-paragraph HTML email using proper `<p>` tag separation for greeting, body, link, request, and closing sections
- **Link text improvement** — The deep link now reads "Contactverzoek {Nummer}" (using the AanleidinggevendKlantcontact number) instead of generic link text
- **HTML structure fix** — Added `<br/>` for correct rendering of the closing signature across email clients

## Test plan

- [ ] Notification email contains the full text per specification (greeting, body, link, request, closing)
- [ ] HTML formatting correctly separates paragraphs with whitespace
- [ ] Clickable link contains "Contactverzoek {Nummer}" with correct href

> ℹ️ Per [QA.md Phase 1](docs/steering/QA.md): implementation verified via code inspection. E2E tests follow in Phase 2 after deploy to test environment.

## Related

Closes #336