### PR TITLE
feat(open-klant): add GetPartijDigitaleAdressenAsync to OpenKlantApiClient

### DIFF
--- a/InterneTaakAfhandeling.Common.Test/InterneTaakAfhandeling.Common.Test.csproj
+++ b/InterneTaakAfhandeling.Common.Test/InterneTaakAfhandeling.Common.Test.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\InterneTaakAfhandeling.Common\InterneTaakAfhandeling.Common.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/InterneTaakAfhandeling.Common.Test/Services/OpenKlantApi/GetPartijDigitaleAdressenAsyncTests.cs
+++ b/InterneTaakAfhandeling.Common.Test/Services/OpenKlantApi/GetPartijDigitaleAdressenAsyncTests.cs
@@ -1,0 +1,140 @@
+using System.Net;
+using InterneTaakAfhandeling.Common.Services.OpenKlantApi;
+using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace InterneTaakAfhandeling.Common.Test.Services.OpenKlantApi;
+
+public class GetPartijDigitaleAdressenAsyncTests
+{
+    private readonly Mock<ILogger<OpenKlantApiClient>> _loggerMock = new();
+
+    private OpenKlantApiClient CreateClient(HttpMessageHandler handler)
+    {
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://openklant.test/api/v1/")
+        };
+        return new OpenKlantApiClient(httpClient, _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task GetPartijDigitaleAdressenAsync_ReturnsDigitaleAdressen_WhenPartijHasAddresses()
+    {
+        // Arrange
+        var partijUuid = "e8203b1b-f97a-4d4b-bf69-14a2a7c5e57a";
+        var responseJson = """
+        {
+            "uuid": "e8203b1b-f97a-4d4b-bf69-14a2a7c5e57a",
+            "url": "https://openklant.test/api/v1/partijen/e8203b1b-f97a-4d4b-bf69-14a2a7c5e57a",
+            "naam": "Jan Jansen",
+            "_expand": {
+                "digitaleAdressen": [
+                    {
+                        "uuid": "aaa-111",
+                        "url": "https://openklant.test/api/v1/digitaleadressen/aaa-111",
+                        "adres": "jan@example.nl",
+                        "soortDigitaalAdres": "email",
+                        "isStandaardAdres": true,
+                        "omschrijving": "Werk e-mail"
+                    },
+                    {
+                        "uuid": "bbb-222",
+                        "url": "https://openklant.test/api/v1/digitaleadressen/bbb-222",
+                        "adres": "0612345678",
+                        "soortDigitaalAdres": "telefoonnummer",
+                        "isStandaardAdres": false,
+                        "omschrijving": "Mobiel"
+                    }
+                ]
+            }
+        }
+        """;
+
+        var handler = MockHttpMessageHandler.WithJsonResponse(responseJson);
+        var client = CreateClient(handler);
+
+        // Act
+        var result = await client.GetPartijDigitaleAdressenAsync(partijUuid);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Count);
+
+        Assert.Equal("jan@example.nl", result[0].Adres);
+        Assert.Equal("email", result[0].SoortDigitaalAdres);
+        Assert.True(result[0].IsStandaardAdres);
+
+        Assert.Equal("0612345678", result[1].Adres);
+        Assert.Equal("telefoonnummer", result[1].SoortDigitaalAdres);
+        Assert.False(result[1].IsStandaardAdres);
+    }
+
+    [Fact]
+    public async Task GetPartijDigitaleAdressenAsync_ReturnsEmptyList_WhenPartijHasNoAddresses()
+    {
+        // Arrange
+        var partijUuid = "e8203b1b-f97a-4d4b-bf69-14a2a7c5e57a";
+        var responseJson = """
+        {
+            "uuid": "e8203b1b-f97a-4d4b-bf69-14a2a7c5e57a",
+            "url": "https://openklant.test/api/v1/partijen/e8203b1b-f97a-4d4b-bf69-14a2a7c5e57a",
+            "naam": "Jan Jansen",
+            "_expand": {
+                "digitaleAdressen": []
+            }
+        }
+        """;
+
+        var handler = MockHttpMessageHandler.WithJsonResponse(responseJson);
+        var client = CreateClient(handler);
+
+        // Act
+        var result = await client.GetPartijDigitaleAdressenAsync(partijUuid);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetPartijDigitaleAdressenAsync_ReturnsEmptyListAndLogs_WhenPartijNotFound()
+    {
+        // Arrange
+        var partijUuid = "non-existent-uuid";
+        var handler = MockHttpMessageHandler.WithStatusCode(HttpStatusCode.NotFound);
+        var client = CreateClient(handler);
+
+        // Act
+        var result = await client.GetPartijDigitaleAdressenAsync(partijUuid);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetPartijDigitaleAdressenAsync_ReturnsEmptyList_WhenExpandFieldMissing()
+    {
+        // Arrange — response has no _expand field at all
+        var partijUuid = "e8203b1b-f97a-4d4b-bf69-14a2a7c5e57a";
+        var responseJson = """
+        {
+            "uuid": "e8203b1b-f97a-4d4b-bf69-14a2a7c5e57a",
+            "url": "https://openklant.test/api/v1/partijen/e8203b1b-f97a-4d4b-bf69-14a2a7c5e57a",
+            "naam": "Jan Jansen"
+        }
+        """;
+
+        var handler = MockHttpMessageHandler.WithJsonResponse(responseJson);
+        var client = CreateClient(handler);
+
+        // Act
+        var result = await client.GetPartijDigitaleAdressenAsync(partijUuid);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+}

--- a/InterneTaakAfhandeling.Common.Test/Services/OpenKlantApi/GetPartijDigitaleAdressenAsyncTests.cs
+++ b/InterneTaakAfhandeling.Common.Test/Services/OpenKlantApi/GetPartijDigitaleAdressenAsyncTests.cs
@@ -69,6 +69,13 @@ public class GetPartijDigitaleAdressenAsyncTests
         Assert.Equal("0612345678", result[1].Adres);
         Assert.Equal("telefoonnummer", result[1].SoortDigitaalAdres);
         Assert.False(result[1].IsStandaardAdres);
+
+        // Verify correct endpoint was called
+        Assert.NotNull(handler.LastRequest);
+        Assert.Equal(HttpMethod.Get, handler.LastRequest.Method);
+        Assert.Equal(
+            $"https://openklant.test/api/v1/partijen/{partijUuid}?expand=digitaleAdressen",
+            handler.LastRequest.RequestUri?.ToString());
     }
 
     [Fact]
@@ -112,6 +119,15 @@ public class GetPartijDigitaleAdressenAsyncTests
         // Assert
         Assert.NotNull(result);
         Assert.Empty(result);
+
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((o, t) => o.ToString()!.Contains(partijUuid)),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
     }
 
     [Fact]

--- a/InterneTaakAfhandeling.Common.Test/Services/OpenKlantApi/MockHttpMessageHandler.cs
+++ b/InterneTaakAfhandeling.Common.Test/Services/OpenKlantApi/MockHttpMessageHandler.cs
@@ -1,0 +1,28 @@
+using System.Net;
+
+namespace InterneTaakAfhandeling.Common.Test.Services.OpenKlantApi;
+
+public class MockHttpMessageHandler(
+    Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler) : HttpMessageHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        return handler(request, cancellationToken);
+    }
+
+    public static MockHttpMessageHandler WithJsonResponse(string json, HttpStatusCode statusCode = HttpStatusCode.OK)
+    {
+        return new MockHttpMessageHandler((_, _) =>
+            Task.FromResult(new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+            }));
+    }
+
+    public static MockHttpMessageHandler WithStatusCode(HttpStatusCode statusCode)
+    {
+        return new MockHttpMessageHandler((_, _) =>
+            Task.FromResult(new HttpResponseMessage(statusCode)));
+    }
+}

--- a/InterneTaakAfhandeling.Common.Test/Services/OpenKlantApi/MockHttpMessageHandler.cs
+++ b/InterneTaakAfhandeling.Common.Test/Services/OpenKlantApi/MockHttpMessageHandler.cs
@@ -5,9 +5,12 @@ namespace InterneTaakAfhandeling.Common.Test.Services.OpenKlantApi;
 public class MockHttpMessageHandler(
     Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler) : HttpMessageHandler
 {
+    public HttpRequestMessage? LastRequest { get; private set; }
+
     protected override Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request, CancellationToken cancellationToken)
     {
+        LastRequest = request;
         return handler(request, cancellationToken);
     }
 

--- a/InterneTaakAfhandeling.Common.Test/nuget.config
+++ b/InterneTaakAfhandeling.Common.Test/nuget.config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/InterneTaakAfhandeling.Common.Test/nuget.config
+++ b/InterneTaakAfhandeling.Common.Test/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/InterneTaakAfhandeling.Common/Services/OpenKlantApi/Models/Klantcontact.cs
+++ b/InterneTaakAfhandeling.Common/Services/OpenKlantApi/Models/Klantcontact.cs
@@ -136,5 +136,13 @@ namespace InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models
         public required string Uuid { get; set; }
         public required string Url { get; set; }
         public string? Naam { get; set; }
+
+        [JsonPropertyName("_expand")]
+        public PartijExpand? Expand { get; set; }
+    }
+
+    public class PartijExpand
+    {
+        public List<DigitaleAdres>? DigitaleAdressen { get; set; }
     }
 }

--- a/InterneTaakAfhandeling.Common/Services/OpenKlantApi/OpenKlantApiClient.cs
+++ b/InterneTaakAfhandeling.Common/Services/OpenKlantApi/OpenKlantApiClient.cs
@@ -45,6 +45,7 @@ public interface IOpenKlantApiClient
 
     Task<ActorKlantcontact> CreateActorKlantcontactAsync(ActorKlantcontactRequest request);
 
+    Task<List<DigitaleAdres>> GetPartijDigitaleAdressenAsync(string partijUuid);
 
 }
 
@@ -481,6 +482,30 @@ public partial class OpenKlantApiClient(
         }
     }
 
+    public async Task<List<DigitaleAdres>> GetPartijDigitaleAdressenAsync(string partijUuid)
+    {
+        try
+        {
+            _logger.LogInformation("Fetching digitale adressen for partij {PartijUuid}", partijUuid);
+
+            var response = await _httpClient.GetAsync($"partijen/{partijUuid}?expand=digitaleAdressen");
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Failed to fetch partij {PartijUuid}: {StatusCode}", partijUuid, response.StatusCode);
+                return [];
+            }
+
+            var partij = await response.Content.ReadFromJsonAsync<Partij>();
+
+            return partij?.Expand?.DigitaleAdressen ?? [];
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error fetching digitale adressen for partij {PartijUuid}: {Message}", partijUuid, ex.Message);
+            return [];
+        }
+    }
 
 
     public async Task<Internetaak> GetInternetaakByIdAsync(Guid uuid)

--- a/InterneTaakAfhandeling.sln
+++ b/InterneTaakAfhandeling.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InterneTaakAfhandeling.EndT
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EndToEndTest.Common", "EndToEndTest.Common\EndToEndTest.Common.csproj", "{8C403FB2-10EF-4AFE-82E8-86E0B658242E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InterneTaakAfhandeling.Common.Test", "InterneTaakAfhandeling.Common.Test\InterneTaakAfhandeling.Common.Test.csproj", "{208216A2-8043-4119-8718-A99D9E33BC77}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -105,6 +107,18 @@ Global
 		{8C403FB2-10EF-4AFE-82E8-86E0B658242E}.Release|x64.Build.0 = Release|Any CPU
 		{8C403FB2-10EF-4AFE-82E8-86E0B658242E}.Release|x86.ActiveCfg = Release|Any CPU
 		{8C403FB2-10EF-4AFE-82E8-86E0B658242E}.Release|x86.Build.0 = Release|Any CPU
+		{208216A2-8043-4119-8718-A99D9E33BC77}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{208216A2-8043-4119-8718-A99D9E33BC77}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{208216A2-8043-4119-8718-A99D9E33BC77}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{208216A2-8043-4119-8718-A99D9E33BC77}.Debug|x64.Build.0 = Debug|Any CPU
+		{208216A2-8043-4119-8718-A99D9E33BC77}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{208216A2-8043-4119-8718-A99D9E33BC77}.Debug|x86.Build.0 = Debug|Any CPU
+		{208216A2-8043-4119-8718-A99D9E33BC77}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{208216A2-8043-4119-8718-A99D9E33BC77}.Release|Any CPU.Build.0 = Release|Any CPU
+		{208216A2-8043-4119-8718-A99D9E33BC77}.Release|x64.ActiveCfg = Release|Any CPU
+		{208216A2-8043-4119-8718-A99D9E33BC77}.Release|x64.Build.0 = Release|Any CPU
+		{208216A2-8043-4119-8718-A99D9E33BC77}.Release|x86.ActiveCfg = Release|Any CPU
+		{208216A2-8043-4119-8718-A99D9E33BC77}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary

De medewerker moet de digitale adressen van een partij kunnen zien wanneer de betrokkene geen eigen adressen heeft. Deze task voegt de `GetPartijDigitaleAdressenAsync` methode toe aan de `OpenKlantApiClient` — de eerste bouwsteen voor de partij-fallback logica (Feature #367).

## Changes

- **Unit test infrastructuur**: Nieuw `InterneTaakAfhandeling.Common.Test` project met xUnit, Moq en coverlet — eerste unit test project in het ITA-systeem
- **Model uitbreiding**: `Partij` model uitgebreid met `PartijExpand` class en `_expand` JSON mapping voor `DigitaleAdressen`
- **Interface + implementatie**: `GetPartijDigitaleAdressenAsync(string partijUuid)` op `IOpenKlantApiClient` — doet `GET /partijen/{uuid}?expand=digitaleAdressen` met graceful degradation (lege lijst bij 404/fout)

## Test plan

- [x] Partij met digitale adressen → e-mailadres en telefoonnummer worden teruggegeven
- [x] Partij zonder digitale adressen → lege lijst
- [x] Partij niet gevonden (404) → lege lijst + warning gelogd
- [x] Expand veld ontbreekt in response → lege lijst (edge case)

## Related

Closes #445