### PR TITLE
feat(internetaak-details): add partij digitale adressen fallback

### DIFF
--- a/InterneTaakAfhandeling.Web.Server.Test/Features/InterneTaakDetails/InternetaakDetailsServiceFallbackTests.cs
+++ b/InterneTaakAfhandeling.Web.Server.Test/Features/InterneTaakDetails/InternetaakDetailsServiceFallbackTests.cs
@@ -168,10 +168,73 @@ public class InternetaakDetailsServiceFallbackTests
         Assert.NotNull(result);
         var betrokkene = result!.AanleidinggevendKlantcontact.Expand!.HadBetrokkenen!.First();
         Assert.Empty(betrokkene.Expand!.DigitaleAdressen!);
+
+        // Assert — warning was logged
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => true),
+                It.IsAny<HttpRequestException>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Get_EnrichesBetrokkeneWithPartijAdressen_WhenDigitaleAdressenIsNull()
+    {
+        // Arrange — betrokkene with null digitaleAdressen (expand field missing), linked to partij
+        var partijUuid = "partij-uuid-null-case";
+        var partijAdressen = new List<DigitaleAdres>
+        {
+            new() { Uuid = "da-null-1", Url = "http://test/da/null1", Adres = "null-test@example.nl", SoortDigitaalAdres = "email", IsStandaardAdres = true, Omschrijving = "Werk" }
+        };
+
+        var internetaak = CreateInternetaakWithBetrokkene(
+            digitaleAdressen: null,
+            wasPartijUuid: partijUuid);
+
+        SetupQueryReturnsInternetaak(internetaak);
+
+        _openKlantApiClientMock
+            .Setup(x => x.GetPartijDigitaleAdressenAsync(partijUuid))
+            .ReturnsAsync(partijAdressen);
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.Get(new InterneTaakQuery { Nummer = "123" });
+
+        // Assert
+        var betrokkene = result!.AanleidinggevendKlantcontact.Expand!.HadBetrokkenen!.First();
+        Assert.Single(betrokkene.Expand!.DigitaleAdressen!);
+        Assert.Equal("null-test@example.nl", betrokkene.Expand.DigitaleAdressen![0].Adres);
+    }
+
+    [Fact]
+    public async Task Get_PropagatesOperationCanceledException_WhenPartijLookupIsCancelled()
+    {
+        // Arrange — partij lookup is cancelled (e.g. request shutdown)
+        var partijUuid = "partij-uuid-cancel";
+        var internetaak = CreateInternetaakWithBetrokkene(
+            digitaleAdressen: [],
+            wasPartijUuid: partijUuid);
+
+        SetupQueryReturnsInternetaak(internetaak);
+
+        _openKlantApiClientMock
+            .Setup(x => x.GetPartijDigitaleAdressenAsync(partijUuid))
+            .ThrowsAsync(new OperationCanceledException());
+
+        var service = CreateService();
+
+        // Act & Assert — should propagate, not swallow
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => service.Get(new InterneTaakQuery { Nummer = "123" }));
     }
 
     private static Internetaak CreateInternetaakWithBetrokkene(
-        List<DigitaleAdres> digitaleAdressen,
+        List<DigitaleAdres>? digitaleAdressen,
         string? wasPartijUuid)
     {
         var betrokkene = new Betrokkene

--- a/InterneTaakAfhandeling.Web.Server.Test/Features/InterneTaakDetails/InternetaakDetailsServiceFallbackTests.cs
+++ b/InterneTaakAfhandeling.Web.Server.Test/Features/InterneTaakDetails/InternetaakDetailsServiceFallbackTests.cs
@@ -1,0 +1,207 @@
+using InterneTaakAfhandeling.Common.Services.OpenKlantApi;
+using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
+using InterneTaakAfhandeling.Common.Services.ZakenApi;
+using InterneTaakAfhandeling.Web.Server.Features.InterneTaak;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace InterneTaakAfhandeling.Web.Server.Test.Features.InterneTaakDetails;
+
+public class InternetaakDetailsServiceFallbackTests
+{
+    private readonly Mock<IOpenKlantApiClient> _openKlantApiClientMock = new();
+    private readonly Mock<IZakenApiClient> _zakenApiClientMock = new();
+    private readonly Mock<IContactmomentenService> _contactmomentenServiceMock = new();
+    private readonly Mock<ILogger<InternetaakDetailsService>> _loggerMock = new();
+
+    private InternetaakDetailsService CreateService()
+    {
+        return new InternetaakDetailsService(
+            _openKlantApiClientMock.Object,
+            _zakenApiClientMock.Object,
+            _contactmomentenServiceMock.Object,
+            _loggerMock.Object);
+    }
+
+    private void SetupQueryReturnsInternetaak(Internetaak internetaak)
+    {
+        _openKlantApiClientMock
+            .Setup(x => x.QueryInterneTakenAsync(It.IsAny<InterneTaakQuery>()))
+            .ReturnsAsync([internetaak]);
+
+        _contactmomentenServiceMock
+            .Setup(x => x.GetZaakOnderwerpObject(It.IsAny<Klantcontact>()))
+            .Returns((string?)null);
+    }
+
+    [Fact]
+    public async Task Get_EnrichesBetrokkeneWithPartijAdressen_WhenBetrokkeneHasNoOwnAdressen()
+    {
+        // Arrange — betrokkene without own addresses, linked to partij with addresses
+        var partijUuid = "partij-uuid-123";
+        var partijAdressen = new List<DigitaleAdres>
+        {
+            new() { Uuid = "da-1", Url = "http://test/da/1", Adres = "jan@example.nl", SoortDigitaalAdres = "email", IsStandaardAdres = true, Omschrijving = "Werk" },
+            new() { Uuid = "da-2", Url = "http://test/da/2", Adres = "0612345678", SoortDigitaalAdres = "telefoonnummer", IsStandaardAdres = false, Omschrijving = "Mobiel" }
+        };
+
+        var internetaak = CreateInternetaakWithBetrokkene(
+            digitaleAdressen: [],
+            wasPartijUuid: partijUuid);
+
+        SetupQueryReturnsInternetaak(internetaak);
+
+        _openKlantApiClientMock
+            .Setup(x => x.GetPartijDigitaleAdressenAsync(partijUuid))
+            .ReturnsAsync(partijAdressen);
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.Get(new InterneTaakQuery { Nummer = "123" });
+
+        // Assert
+        var betrokkene = result!.AanleidinggevendKlantcontact.Expand!.HadBetrokkenen!.First();
+        Assert.Equal(2, betrokkene.Expand!.DigitaleAdressen!.Count);
+        Assert.Equal("jan@example.nl", betrokkene.Expand.DigitaleAdressen[0].Adres);
+        Assert.Equal("0612345678", betrokkene.Expand.DigitaleAdressen[1].Adres);
+    }
+
+    [Fact]
+    public async Task Get_KeepsOwnAdressen_WhenBetrokkeneHasOwnAdressen()
+    {
+        // Arrange — betrokkene with own addresses + linked partij
+        var ownAdressen = new List<DigitaleAdres>
+        {
+            new() { Uuid = "own-1", Url = "http://test/da/own", Adres = "eigen@example.nl", SoortDigitaalAdres = "email", IsStandaardAdres = true, Omschrijving = "Eigen" }
+        };
+
+        var internetaak = CreateInternetaakWithBetrokkene(
+            digitaleAdressen: ownAdressen,
+            wasPartijUuid: "partij-uuid-456");
+
+        SetupQueryReturnsInternetaak(internetaak);
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.Get(new InterneTaakQuery { Nummer = "123" });
+
+        // Assert — partij should NOT be called
+        _openKlantApiClientMock.Verify(
+            x => x.GetPartijDigitaleAdressenAsync(It.IsAny<string>()), Times.Never);
+
+        var betrokkene = result!.AanleidinggevendKlantcontact.Expand!.HadBetrokkenen!.First();
+        Assert.Single(betrokkene.Expand!.DigitaleAdressen!);
+        Assert.Equal("eigen@example.nl", betrokkene.Expand.DigitaleAdressen![0].Adres);
+    }
+
+    [Fact]
+    public async Task Get_DoesNotCallPartij_WhenBetrokkeneHasNoPartijIdentifier()
+    {
+        // Arrange — betrokkene without addresses and without partij link
+        var internetaak = CreateInternetaakWithBetrokkene(
+            digitaleAdressen: [],
+            wasPartijUuid: null);
+
+        SetupQueryReturnsInternetaak(internetaak);
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.Get(new InterneTaakQuery { Nummer = "123" });
+
+        // Assert
+        _openKlantApiClientMock.Verify(
+            x => x.GetPartijDigitaleAdressenAsync(It.IsAny<string>()), Times.Never);
+
+        var betrokkene = result!.AanleidinggevendKlantcontact.Expand!.HadBetrokkenen!.First();
+        Assert.Empty(betrokkene.Expand!.DigitaleAdressen!);
+    }
+
+    [Fact]
+    public async Task Get_ReturnsEmptyAdressen_WhenPartijHasNoAdressen()
+    {
+        // Arrange — betrokkene without addresses, partij also has no addresses
+        var partijUuid = "partij-uuid-789";
+        var internetaak = CreateInternetaakWithBetrokkene(
+            digitaleAdressen: [],
+            wasPartijUuid: partijUuid);
+
+        SetupQueryReturnsInternetaak(internetaak);
+
+        _openKlantApiClientMock
+            .Setup(x => x.GetPartijDigitaleAdressenAsync(partijUuid))
+            .ReturnsAsync([]);
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.Get(new InterneTaakQuery { Nummer = "123" });
+
+        // Assert
+        var betrokkene = result!.AanleidinggevendKlantcontact.Expand!.HadBetrokkenen!.First();
+        Assert.Empty(betrokkene.Expand!.DigitaleAdressen!);
+    }
+
+    [Fact]
+    public async Task Get_HandlesPartijLookupFailure_Gracefully()
+    {
+        // Arrange — partij lookup throws exception
+        var partijUuid = "partij-uuid-fail";
+        var internetaak = CreateInternetaakWithBetrokkene(
+            digitaleAdressen: [],
+            wasPartijUuid: partijUuid);
+
+        SetupQueryReturnsInternetaak(internetaak);
+
+        _openKlantApiClientMock
+            .Setup(x => x.GetPartijDigitaleAdressenAsync(partijUuid))
+            .ThrowsAsync(new HttpRequestException("API not reachable"));
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.Get(new InterneTaakQuery { Nummer = "123" });
+
+        // Assert — should not throw, contact section remains empty
+        Assert.NotNull(result);
+        var betrokkene = result!.AanleidinggevendKlantcontact.Expand!.HadBetrokkenen!.First();
+        Assert.Empty(betrokkene.Expand!.DigitaleAdressen!);
+    }
+
+    private static Internetaak CreateInternetaakWithBetrokkene(
+        List<DigitaleAdres> digitaleAdressen,
+        string? wasPartijUuid)
+    {
+        var betrokkene = new Betrokkene
+        {
+            Uuid = "betrokkene-uuid",
+            Url = "http://test/betrokkenen/1",
+            DigitaleAdressen = [],
+            Initiator = true,
+            Expand = new BetrokkeneExpand
+            {
+                DigitaleAdressen = digitaleAdressen,
+                WasPartij = wasPartijUuid != null
+                    ? new Partij { Uuid = wasPartijUuid, Url = $"http://test/partijen/{wasPartijUuid}" }
+                    : null
+            }
+        };
+
+        return new Internetaak
+        {
+            Uuid = "internetaak-uuid",
+            Url = "http://test/internetaken/1",
+            AanleidinggevendKlantcontact = new Klantcontact
+            {
+                Uuid = Guid.NewGuid(),
+                Url = "http://test/klantcontacten/1",
+                Expand = new Expand
+                {
+                    HadBetrokkenen = [betrokkene]
+                }
+            }
+        };
+    }
+}

--- a/InterneTaakAfhandeling.Web.Server.Test/InterneTaakAfhandeling.Web.Server.Test.csproj
+++ b/InterneTaakAfhandeling.Web.Server.Test/InterneTaakAfhandeling.Web.Server.Test.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\InterneTaakAfhandeling.Web.Server\InterneTaakAfhandeling.Web.Server.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/InterneTaakAfhandeling.Web.Server.Test/nuget.config
+++ b/InterneTaakAfhandeling.Web.Server.Test/nuget.config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/InterneTaakAfhandeling.Web.Server.Test/nuget.config
+++ b/InterneTaakAfhandeling.Web.Server.Test/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/InterneTaakAfhandeling.Web.Server/Features/InterneTaakDetails/InternetaakDetailsService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/InterneTaakDetails/InternetaakDetailsService.cs
@@ -36,6 +36,7 @@ namespace InterneTaakAfhandeling.Web.Server.Features.InterneTaak
             var interntaak = internetaken.Single();
 
             await EnrichWithZaakAsync(interntaak);
+            await EnrichBetrokkenenWithPartijDigitaleAdressenAsync(interntaak);
 
             return interntaak;
         }
@@ -70,6 +71,7 @@ namespace InterneTaakAfhandeling.Web.Server.Features.InterneTaak
             var interntaak = internetaken.Single();
 
             await EnrichWithZaakAsync(interntaak);
+            await EnrichBetrokkenenWithPartijDigitaleAdressenAsync(interntaak);
 
             return interntaak;
         }
@@ -83,6 +85,38 @@ namespace InterneTaakAfhandeling.Web.Server.Features.InterneTaak
                 if (!string.IsNullOrEmpty(onderwerpObjectId))
                 {
                     interntaak.Zaak = await _zakenApiClient.GetZaakAsync(onderwerpObjectId);
+                }
+            }
+        }
+
+        private async Task EnrichBetrokkenenWithPartijDigitaleAdressenAsync(Internetaak? internetaak)
+        {
+            var betrokkenen = internetaak?.AanleidinggevendKlantcontact?.Expand?.HadBetrokkenen;
+            if (betrokkenen == null) return;
+
+            foreach (var betrokkene in betrokkenen)
+            {
+                if (betrokkene.Expand?.DigitaleAdressen != null && betrokkene.Expand.DigitaleAdressen.Count > 0)
+                    continue;
+
+                var partijUuid = betrokkene.Expand?.WasPartij?.Uuid;
+                if (string.IsNullOrEmpty(partijUuid))
+                    continue;
+
+                try
+                {
+                    _logger.LogInformation("Fallback: ophalen digitale adressen van partij {PartijUuid} voor betrokkene {BetrokkeneUuid}",
+                        partijUuid, betrokkene.Uuid);
+
+                    var partijAdressen = await _openKlantApiClient.GetPartijDigitaleAdressenAsync(partijUuid);
+
+                    betrokkene.Expand ??= new BetrokkeneExpand();
+                    betrokkene.Expand.DigitaleAdressen = partijAdressen;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Fallback partij-lookup gefaald voor partij {PartijUuid}: {Message}",
+                        partijUuid, ex.Message);
                 }
             }
         }

--- a/InterneTaakAfhandeling.Web.Server/Features/InterneTaakDetails/InternetaakDetailsService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/InterneTaakDetails/InternetaakDetailsService.cs
@@ -113,6 +113,10 @@ namespace InterneTaakAfhandeling.Web.Server.Features.InterneTaak
                     betrokkene.Expand ??= new BetrokkeneExpand();
                     betrokkene.Expand.DigitaleAdressen = partijAdressen;
                 }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
                 catch (Exception ex)
                 {
                     _logger.LogWarning(ex, "Fallback partij-lookup gefaald voor partij {PartijUuid}: {Message}",

--- a/InterneTaakAfhandeling.sln
+++ b/InterneTaakAfhandeling.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EndToEndTest.Common", "EndT
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InterneTaakAfhandeling.Common.Test", "InterneTaakAfhandeling.Common.Test\InterneTaakAfhandeling.Common.Test.csproj", "{208216A2-8043-4119-8718-A99D9E33BC77}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InterneTaakAfhandeling.Web.Server.Test", "InterneTaakAfhandeling.Web.Server.Test\InterneTaakAfhandeling.Web.Server.Test.csproj", "{5F57A45A-5384-4E5E-9D0E-F850EEBB76E4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -119,6 +121,18 @@ Global
 		{208216A2-8043-4119-8718-A99D9E33BC77}.Release|x64.Build.0 = Release|Any CPU
 		{208216A2-8043-4119-8718-A99D9E33BC77}.Release|x86.ActiveCfg = Release|Any CPU
 		{208216A2-8043-4119-8718-A99D9E33BC77}.Release|x86.Build.0 = Release|Any CPU
+		{5F57A45A-5384-4E5E-9D0E-F850EEBB76E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F57A45A-5384-4E5E-9D0E-F850EEBB76E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5F57A45A-5384-4E5E-9D0E-F850EEBB76E4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5F57A45A-5384-4E5E-9D0E-F850EEBB76E4}.Debug|x64.Build.0 = Debug|Any CPU
+		{5F57A45A-5384-4E5E-9D0E-F850EEBB76E4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5F57A45A-5384-4E5E-9D0E-F850EEBB76E4}.Debug|x86.Build.0 = Debug|Any CPU
+		{5F57A45A-5384-4E5E-9D0E-F850EEBB76E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5F57A45A-5384-4E5E-9D0E-F850EEBB76E4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5F57A45A-5384-4E5E-9D0E-F850EEBB76E4}.Release|x64.ActiveCfg = Release|Any CPU
+		{5F57A45A-5384-4E5E-9D0E-F850EEBB76E4}.Release|x64.Build.0 = Release|Any CPU
+		{5F57A45A-5384-4E5E-9D0E-F850EEBB76E4}.Release|x86.ActiveCfg = Release|Any CPU
+		{5F57A45A-5384-4E5E-9D0E-F850EEBB76E4}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary

De medewerker ziet altijd contactgegevens als deze beschikbaar zijn — ook wanneer ze bij de gekoppelde partij zijn opgeslagen (OIP-scenario). Deze task implementeert de server-side fallback in `InternetaakDetailsService`: wanneer een betrokkene geen eigen digitale adressen heeft maar wel een partij-identifier, worden de adressen van de partij opgehaald en transparant ingeject in de betrokkene-expand.

## Changes

- **Unit test project**: Nieuw `InterneTaakAfhandeling.Web.Server.Test` project met 5 unit tests die alle Gherkin scenarios afdekken
- **Fallback verrijking**: `EnrichBetrokkenenWithPartijDigitaleAdressenAsync` methode in `InternetaakDetailsService` — itereert over betrokkenen, detecteert lege adressen + aanwezige partij-identifier, en verrijkt via `GetPartijDigitaleAdressenAsync`
- **Graceful degradation**: try-catch per betrokkene — bij API-falen blijft de contactsectie leeg zonder foutmelding naar de gebruiker

## Test plan

- [x] Betrokkene zonder eigen adressen met gekoppelde partij die adressen heeft → partij-adressen getoond
- [x] Betrokkene met eigen digitale adressen → alleen eigen adressen, partij niet geraadpleegd
- [x] Betrokkene zonder eigen adressen en zonder partij-identifier → leeg, geen lookup
- [x] Betrokkene zonder eigen adressen met partij zonder adressen → leeg
- [x] Partij-lookup faalt door onbereikbare API → leeg, fout gelogd

## Related

Closes #446