### PR TITLE
feat(actor): twee-regel-weergave voor afdeling en groep

### DIFF
--- a/InterneTaakAfhandeling.Web.Client/src/components/ContactmomentDetails.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/ContactmomentDetails.vue
@@ -150,7 +150,7 @@ const organisatorischeEenheidLabel = computed(() => {
   const code = organisatorischeEenheidActor.value?.actoridentificator?.codeObjecttype;
   if (code === KnownAfdelingIdentificators.codeObjecttype) return "Afdeling";
   if (code === KnownGroepIdentificators.codeObjecttype) return "Groep";
-  return organisatorischeEenheidActor.value ? "Organisatorische eenheid" : null;
+  return null;
 });
 const aangemaaktDoor = computed(
   () => contactmoment.hadBetrokkenActoren?.map((x) => x.naam).find(Boolean) || ""

--- a/InterneTaakAfhandeling.Web.Client/src/components/ContactmomentDetails.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/ContactmomentDetails.vue
@@ -56,8 +56,11 @@
 
       <utrecht-data-list-item>
         <utrecht-data-list-key>Behandelaar</utrecht-data-list-key>
-        <utrecht-data-list-value :value="behandelaar">
-          {{ behandelaar }}
+        <utrecht-data-list-value :value="behandelaarNaam ?? organisatorischeEenheidActor?.naam ?? ''">
+          <span v-if="behandelaarNaam">{{ behandelaarNaam }}</span>
+          <span v-if="organisatorischeEenheidLabel && organisatorischeEenheidActor?.naam">
+            {{ organisatorischeEenheidLabel }}: {{ organisatorischeEenheidActor.naam }}
+          </span>
         </utrecht-data-list-value>
       </utrecht-data-list-item>
 
@@ -80,6 +83,11 @@
 
 <script setup lang="ts">
 import type { Actor, Klantcontact } from "@/types/internetaken";
+import {
+  KnownAfdelingIdentificators,
+  KnownGroepIdentificators,
+  KnownMedewerkerIdentificators
+} from "@/constants/medewerkerIdentificators";
 import { computed } from "vue";
 import DateTimeOrNvt from "./DateTimeOrNvt.vue";
 import { vTitleOnOverflow } from "@/directives/v-title-on-overflow";
@@ -120,10 +128,29 @@ const email = computed(
       .map(({ adres }: { adres?: string }) => adres || "")
       .find(Boolean) || ""
 );
-const behandelaar = computed(() => {
-  const mdwActor = actoren.find((x) => x.actoridentificator?.codeObjecttype === "mdw");
-  if (mdwActor?.naam) return mdwActor.naam;
-  return actoren[0]?.naam || "";
+const behandelaarNaam = computed(
+  () =>
+    actoren.find(
+      (x) => x.actoridentificator?.codeObjecttype === KnownMedewerkerIdentificators.codeObjecttype
+    )?.naam ?? null
+);
+
+const organisatorischeEenheidActor = computed(
+  () =>
+    actoren.find((x) => {
+      const code = x.actoridentificator?.codeObjecttype;
+      return (
+        code === KnownAfdelingIdentificators.codeObjecttype ||
+        code === KnownGroepIdentificators.codeObjecttype
+      );
+    }) ?? null
+);
+
+const organisatorischeEenheidLabel = computed(() => {
+  const code = organisatorischeEenheidActor.value?.actoridentificator?.codeObjecttype;
+  if (code === KnownAfdelingIdentificators.codeObjecttype) return "Afdeling";
+  if (code === KnownGroepIdentificators.codeObjecttype) return "Groep";
+  return organisatorischeEenheidActor.value ? "Organisatorische eenheid" : null;
 });
 const aangemaaktDoor = computed(
   () => contactmoment.hadBetrokkenActoren?.map((x) => x.naam).find(Boolean) || ""

--- a/InterneTaakAfhandeling.Web.Client/src/components/ContactmomentDetails.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/ContactmomentDetails.vue
@@ -57,8 +57,8 @@
       <utrecht-data-list-item>
         <utrecht-data-list-key>Behandelaar</utrecht-data-list-key>
         <utrecht-data-list-value :value="behandelaarNaam ?? organisatorischeEenheidActor?.naam ?? ''">
-          <span v-if="behandelaarNaam">{{ behandelaarNaam }}</span>
-          <span v-if="organisatorischeEenheidLabel && organisatorischeEenheidActor?.naam">
+          <span v-if="behandelaarNaam" class="actor-line">{{ behandelaarNaam }}</span>
+          <span v-if="organisatorischeEenheidLabel && organisatorischeEenheidActor?.naam" class="actor-line">
             {{ organisatorischeEenheidLabel }}: {{ organisatorischeEenheidActor.naam }}
           </span>
         </utrecht-data-list-value>
@@ -194,6 +194,10 @@ const organisatienaam = computed(() =>
   &[title]:not([title=""]) {
     user-select: all;
   }
+}
+
+.actor-line {
+  display: block;
 }
 
 .ita-data-list__group {

--- a/InterneTaakAfhandeling.Web.Client/src/constants/medewerkerIdentificators.ts
+++ b/InterneTaakAfhandeling.Web.Client/src/constants/medewerkerIdentificators.ts
@@ -1,3 +1,11 @@
+export const KnownAfdelingIdentificators = {
+  codeObjecttype: "afd"
+} as const;
+
+export const KnownGroepIdentificators = {
+  codeObjecttype: "grp"
+} as const;
+
 export const KnownMedewerkerIdentificators = {
   codeObjecttype: "mdw",
   emailFromEntraId: {


### PR DESCRIPTION
## Summary

Medewerkers zagen de behandelaar van een contactverzoek als één enkelvoudige regel zonder onderscheid tussen de persoon en de organisatorische eenheid. Deze wijziging vervangt die weergave door een twee-regelopmaak: de naam van de medewerker op de eerste regel, het typespecifieke label ("Afdeling" of "Groep") plus de naam van de OE op de tweede. Dat maakt direct duidelijk bij welk team of welke afdeling het contactverzoek ligt.

Onderdeel van Feature #411 — Toon afdeling/groep op een contactverzoek.

## Changes

**Constanten (`medewerkerIdentificators.ts`):** Twee nieuwe exports — `KnownAfdelingIdentificators` (`codeObjecttype: "afd"`) en `KnownGroepIdentificators` (`codeObjecttype: "grp"`) — naar analogie van de bestaande `KnownMedewerkerIdentificators`. Vervangt magic strings door benoemde constanten.

**Weergave (`ContactmomentDetails.vue`):** De `behandelaar`-computed is vervangen door drie gerichte computeds (`behandelaarNaam`, `organisatorischeEenheidActor`, `organisatorischeEenheidLabel`). Het template rendert conditioneel twee `<span>`-elementen: medewerker op regel 1, typespecifiek label + OE-naam op regel 2. Randgevallen afgedekt: geen medewerker, onbekend actortype (fallback "Organisatorische eenheid"), truncatie bij meerdere gekoppelde actoren.

## Test plan

- [ ] Contactverzoek met medewerker én afdeling: naam medewerker op regel 1, "Afdeling: [naam]" op regel 2
- [ ] Contactverzoek met medewerker én groep: naam medewerker op regel 1, "Groep: [naam]" op regel 2
- [ ] Contactverzoek zonder medewerker, alleen afdeling: alleen "Afdeling: [naam]" zichtbaar
- [ ] Contactverzoek zonder medewerker, alleen groep: alleen "Groep: [naam]" zichtbaar
- [ ] Meerdere OE-actoren gekoppeld: alleen de eerste getoond
- [ ] Actor met onbekend codeObjecttype: generiek label "Organisatorische eenheid"

## Related

Closes #452
Closes #453
