### PR TITLE
fix(forward): expand AanleidinggevendKlantcontact before sending notification email

### DIFF
--- a/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestService.cs
@@ -38,15 +38,19 @@ public class ForwardContactRequestService(
 
         var updatedInternetaak = await openKlantApiClient.PatchInternetaakActorAsync(internetakenUpdateRequest, internetaak.Uuid);
 
-        if (updatedInternetaak.AanleidinggevendKlantcontact?.Uuid != null)
+        if (updatedInternetaak.AanleidinggevendKlantcontact?.Uuid == null)
         {
-            updatedInternetaak.AanleidinggevendKlantcontact = await openKlantApiClient.GetKlantcontactAsync(updatedInternetaak.AanleidinggevendKlantcontact.Uuid);
-        }
-        else
-        {
-            logger.LogWarning("AanleidinggevendKlantcontact ontbreekt op internetaak {Uuid} — notificatie wordt overgeslagen", internetaak.Uuid);
+            logger.LogError("Uuid van AanleidinggevendKlantcontact onbekend voor internetaak {Uuid}", internetaak.Uuid);
+            return new ForwardContactRequestResponse
+            {
+                Internetaak = updatedInternetaak,
+                NotificationResult = GenericError
+            };
         }
 
+        //Although the AanleidinggevendKlantcontact was returned from the patch endpoint, it does not contain all details (like Nummer) that are needed for the email notification. Therefore, we need to fetch the full Klantcontact details.
+        updatedInternetaak.AanleidinggevendKlantcontact = await openKlantApiClient.GetKlantcontactAsync(updatedInternetaak.AanleidinggevendKlantcontact.Uuid);
+        
         var notficationResult = await NotifyInternetaakActors(updatedInternetaak, actors);
 
         return new ForwardContactRequestResponse

--- a/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestService.cs
@@ -70,8 +70,9 @@ public class ForwardContactRequestService(
             if (!actorEmailResult.FoundEmails.Any())
                 return GetResultMessageWhenNoEmails(actorEmailResult);
 
+            var contactmomentNummer = (internetaken.AanleidinggevendKlantcontact?.Nummer) ?? throw new InvalidOperationException(
+                    $"AanleidinggevendKlantcontact.Nummer ontbreekt voor internetaak {internetaken.Nummer}");
             var emailContent = emailContentService.BuildInternetakenEmailContent(internetaken, _itaBaseUrl);
-            var contactmomentNummer = internetaken.AanleidinggevendKlantcontact.Nummer;
             var subject = $"Contactverzoek Doorgestuurd - {contactmomentNummer}";
 
             var sendResults = await SendEmailsAsync(actorEmailResult.FoundEmails, subject, emailContent);

--- a/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestService.cs
@@ -42,6 +42,10 @@ public class ForwardContactRequestService(
         {
             updatedInternetaak.AanleidinggevendKlantcontact = await openKlantApiClient.GetKlantcontactAsync(updatedInternetaak.AanleidinggevendKlantcontact.Uuid);
         }
+        else
+        {
+            logger.LogWarning("AanleidinggevendKlantcontact ontbreekt op internetaak {Uuid} — notificatie wordt overgeslagen", internetaak.Uuid);
+        }
 
         var notficationResult = await NotifyInternetaakActors(updatedInternetaak, actors);
 

--- a/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestService.cs
@@ -38,6 +38,11 @@ public class ForwardContactRequestService(
 
         var updatedInternetaak = await openKlantApiClient.PatchInternetaakActorAsync(internetakenUpdateRequest, internetaak.Uuid);
 
+        if (updatedInternetaak.AanleidinggevendKlantcontact?.Uuid != null)
+        {
+            updatedInternetaak.AanleidinggevendKlantcontact = await openKlantApiClient.GetKlantcontactAsync(updatedInternetaak.AanleidinggevendKlantcontact.Uuid);
+        }
+
         var notficationResult = await NotifyInternetaakActors(updatedInternetaak, actors);
 
         return new ForwardContactRequestResponse
@@ -62,8 +67,7 @@ public class ForwardContactRequestService(
                 return GetResultMessageWhenNoEmails(actorEmailResult);
 
             var emailContent = emailContentService.BuildInternetakenEmailContent(internetaken, _itaBaseUrl);
-            var contactmomentNummer = internetaken.AanleidinggevendKlantcontact?.Nummer
-                ?? throw new InvalidOperationException($"AanleidinggevendKlantcontact.Nummer ontbreekt voor internetaak {internetaken.Nummer}");
+            var contactmomentNummer = internetaken.AanleidinggevendKlantcontact.Nummer;
             var subject = $"Contactverzoek Doorgestuurd - {contactmomentNummer}";
 
             var sendResults = await SendEmailsAsync(actorEmailResult.FoundEmails, subject, emailContent);


### PR DESCRIPTION
The PATCH response from OpenKlant only returns a reference object for AanleidinggevendKlantcontact (UUID only, no Nummer). ForwardContactRequestService was using this response directly to build the notification email, causing EmailContentService to throw when Nummer was null.

Fix: call GetKlantcontactAsync after the PATCH to expand the reference, identical to the pattern already used in InternetakenNotifier.

Also removed the duplicate Nummer null-check in NotifyInternetaakActors since EmailContentService already guards against it.

