### PR TITLE
fix(e2e): resolve non-deterministic test flakiness 2

### DIFF
--- a/EndToEndTest.Common/Infrastructure/AzureAdLoginHelper.cs
+++ b/EndToEndTest.Common/Infrastructure/AzureAdLoginHelper.cs
@@ -71,9 +71,6 @@ namespace EndToEndTest.Common.Infrastructure
             await _page.FillAsync("input[name='passwd']", _password);
             await _page.ClickAsync("input[type='submit']");
 
-            // Wait for Azure AD to process the password before expecting 2FA
-            await _page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-
             await Handle2FAAsync();
         }
 

--- a/EndToEndTest.Common/Infrastructure/BasePlaywrightTest.cs
+++ b/EndToEndTest.Common/Infrastructure/BasePlaywrightTest.cs
@@ -86,6 +86,9 @@ namespace EndToEndTest.Common.Infrastructure
         [TestInitialize]
         public virtual async Task TestInitialize()
         {
+            // Ensure Expect timeout is always applied (30s), regardless of .runsettings file discovery.
+            SetDefaultExpectTimeout(30_000);
+
             // Handle Azure AD authentication if credentials are configured
             await HandleAuthenticationAsync();
 

--- a/InterneTaakAfhandeling.EndToEndTest/AlleContactverzoeken/AlleContactverzoekenAccessScenarios.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/AlleContactverzoeken/AlleContactverzoekenAccessScenarios.cs
@@ -13,7 +13,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.AlleContactverzoeken
         {
             await Step("Navigate directly to /alle-contactverzoeken");
             await Page.GotoAsync("/alle-contactverzoeken");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Verify the page is displayed with correct heading");
             var heading = Page.GetByRole(AriaRole.Heading, new() { Name = "Alle contactverzoeken", Level = 1 });
@@ -42,13 +41,11 @@ namespace InterneTaakAfhandeling.EndToEndTest.AlleContactverzoeken
 
             await Step("Navigate to /alle-contactverzoeken");
             await Page.GotoAsync("/alle-contactverzoeken");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Click the details link for the test contactverzoek");
             var detailsLink = Page.GetDetailsLink(testOnderwerp);
             await detailsLink.WaitForAsync(new() { State = WaitForSelectorState.Visible });
             await detailsLink.ClickAsync();
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Verify URL uses /contactmoment/ with the contactmoment number");
             await Expect(Page).ToHaveURLAsync(new Regex($"/contactmoment/{Regex.Escape(contactmomentNummer)}"));

--- a/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/AlleContactverzoekenNavigatieScenarios.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/AlleContactverzoekenNavigatieScenarios.cs
@@ -12,7 +12,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Contactverzoek
         {
             await Step("Given een medewerker met de rol 'Beheerder' is ingelogd");
             await Page.GotoAsync("/");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("When de navigatie wordt weergegeven");
             var navLink = Page.GetByRole(AriaRole.Link, new() { Name = "Alle contactverzoeken" });

--- a/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/BackwardCompatibleRoutingScenarios.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/BackwardCompatibleRoutingScenarios.cs
@@ -36,7 +36,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Contactverzoek
 
             await Step($"When de medewerker navigeert naar /contactverzoek/{internetaak.Nummer} via een oude e-maillink");
             await Page.GotoAsync($"/contactverzoek/{internetaak.Nummer}");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Then wordt het contactverzoek correct getoond");
             await Expect(Page.Locator($"text={testOnderwerp}")).ToBeVisibleAsync();

--- a/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekScenarioHelpers.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekScenarioHelpers.cs
@@ -20,14 +20,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             return uuid;
         }
 
-        private async Task<Guid> SetupContactverzoek(string onderwerp, bool attachZaak, string internetaakNummer)
-        {
-            await Step("Setup test data via API");
-            var uuid = await TestDataHelper.CreateContactverzoek(onderwerp, attachZaak, internetaakNummer);
-            RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(uuid.ToString()));
-            return uuid;
-        }
-
         private async Task CreateAssignAndCloseContactverzoek(string onderwerp, string informatieText)
         {
             await Step("Create and close contactverzoek");
@@ -61,9 +53,9 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             await VerifyInternetaakStatusInOpenKlant(internetaakUuid.Value, "verwerkt", shouldHaveAfgehandeldOp: true);
         }
 
-        private async Task<(Guid internetaakUuid, string internetaakNummer)> SetupAndResolveContactverzoek(string onderwerp, string internetaakNummer)
+        private async Task<(Guid internetaakUuid, string internetaakNummer)> SetupAndResolveContactverzoek(string onderwerp)
         {
-            var contactmomentUuid = await SetupContactverzoek(onderwerp, attachZaak: false, internetaakNummer: internetaakNummer);
+            var contactmomentUuid = await SetupContactverzoek(onderwerp, attachZaak: false);
             var internetaakUuid = await TestDataHelper.GetInternetaakUuidFromContactmomentAsync(contactmomentUuid);
             Assert.IsNotNull(internetaakUuid, "Internetaak UUID should be found");
 

--- a/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekScenarioHelpers.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekScenarioHelpers.cs
@@ -207,17 +207,8 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
             // The "Informatie voor burger" field loads from a nested API call
             // (internetaak → aanleidinggevendKlantcontact.inhoud). In CI, this
-            // external API call can silently fail or be slow. Reload once to
-            // give the frontend a second chance to fetch the data.
-            try
-            {
-                await Expect(Page.GetInformatieVoorBurgerValue()).ToBeVisibleAsync();
-            }
-            catch (PlaywrightException)
-            {
-                await Page.ReloadAsync(new() { WaitUntil = WaitUntilState.NetworkIdle });
-                await Expect(Page.GetInformatieVoorBurgerValue()).ToBeVisibleAsync();
-            }
+            // external API call can silently fail or be slow.
+            await ExpectWithReloadRetry(Page.GetInformatieVoorBurgerValue());
             await Expect(Page.GetInformatieVoorBurgerValue()).ToContainTextAsync(
                 "This is a test contact request created during an end-to-end test run.");
         }
@@ -227,16 +218,8 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             await Step($"Verify ZAAK '{zaakIdentificatie}' is visible");
             var zaakLocator = Page.Locator("dd.utrecht-data-list__item-value").Filter(new() { HasText = zaakIdentificatie });
             // Zaak details are fetched from the external Zaken API. In CI, this
-            // call can silently fail or be slow. Reload once to retry.
-            try
-            {
-                await Expect(zaakLocator).ToBeVisibleAsync();
-            }
-            catch (PlaywrightException)
-            {
-                await Page.ReloadAsync(new() { WaitUntil = WaitUntilState.NetworkIdle });
-                await Expect(zaakLocator).ToBeVisibleAsync();
-            }
+            // call can silently fail or be slow.
+            await ExpectWithReloadRetry(zaakLocator);
         }
 
         private async Task VerifyActionTabsArePresent()

--- a/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekScenarioHelpers.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekScenarioHelpers.cs
@@ -96,7 +96,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             await Page.GetContactmomentOpslaanButton().ClickAsync();
             await Expect(Page.GetByRole(AriaRole.Dialog)).ToBeVisibleAsync();
             await Page.GetOpslaanEnAfrondenButton().ClickAsync();
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
         }
 
         private async Task SafeGotoAsync(string url)
@@ -131,13 +130,11 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
         {
             await Step("Navigate to home page");
             await SafeGotoAsync("/");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step($"Click on contactverzoek '{onderwerp}'");
             var detailsLink = Page.GetDetailsLink(onderwerp);
             await detailsLink.WaitForAsync(new() { State = WaitForSelectorState.Visible });
             await detailsLink.ClickAsync();
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
             // Wait for detail page to fully render (tab proves the SPA route loaded)
             await Expect(Page.GetContactmomentRegistrerenTab()).ToBeVisibleAsync();
         }
@@ -146,7 +143,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
         {
             await Step($"Navigate to contactverzoek by nummer: {internetaakNummer}");
             await SafeGotoAsync($"/contactverzoek/{internetaakNummer}");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
             // Heading now shows AanleidinggevendKlantcontact.Nummer (contactmoment number), not the
             // interne-taaknummer. Use the action tab as a reliable page-loaded indicator instead.
             await Expect(Page.GetContactmomentRegistrerenTab()).ToBeVisibleAsync();
@@ -156,7 +152,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
         {
             await Step($"Navigate to verwerkt contactverzoek by nummer: {internetaakNummer}");
             await SafeGotoAsync($"/contactverzoek/{internetaakNummer}");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
             // Verwerkt contactverzoeken hide the action tabs; wait for the afgehandeld message instead.
             await Expect(Page.GetAfgehandeldMessage()).ToBeVisibleAsync();
         }
@@ -173,13 +168,14 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
         {
             await Step("Navigate to Afdelingshistorie");
             await SafeGotoAsync("/");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-            await Page.GetByRole(AriaRole.Link, new() { Name = "Afdelingshistorie", Exact = true }).ClickAsync();
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            var afdelingshistorieLink = Page.GetByRole(AriaRole.Link, new() { Name = "Afdelingshistorie", Exact = true });
+            await afdelingshistorieLink.WaitForAsync(new() { State = WaitForSelectorState.Visible });
+            await afdelingshistorieLink.ClickAsync();
 
             await Step($"Select department '{organisatorischeEenheidNaam}' from dropdown");
-            await Page.GetByLabel("Selecteer een afdeling of").SelectOptionAsync(new[] { organisatorischeEenheidNaam });
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            var dropdown = Page.GetByLabel("Selecteer een afdeling of");
+            await dropdown.WaitForAsync(new() { State = WaitForSelectorState.Visible });
+            await dropdown.SelectOptionAsync(new[] { organisatorischeEenheidNaam });
         }
 
         // Verification Helpers
@@ -204,7 +200,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             await Expect(Page.GetVraagValue(onderwerp)).ToHaveTextAsync(onderwerp);
 
             await Expect(Page.GetInformatieVoorBurgerLabel()).ToBeVisibleAsync();
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
             // The "Informatie voor burger" field loads from a nested API call
             // (internetaak → aanleidinggevendKlantcontact.inhoud). In CI, this
             // external API call can silently fail or be slow.
@@ -284,7 +279,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
         {
             await Step("Navigate to History tab (Mijn historie)");
             await SafeGotoAsync("/historie");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Verify both closed contact requests are displayed in the history tab");
             await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Mijn historie", Level = 1 })).ToBeVisibleAsync();
@@ -337,7 +331,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
         {
             await Step("Verify validation: Afsluiten question is required");
             await Page.GetContactmomentOpslaanButton().ClickAsync();
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
             var radioButton = Page.Locator("input[type='radio'][name*='afsluiten']").First;
             await Expect(radioButton).ToHaveJSPropertyAsync("validity.valueMissing", true);
 
@@ -376,9 +369,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
         {
             await Step("Verify success message");
             await Expect(Page.GetByText("Contactmoment succesvol bijgewerkt")).ToBeVisibleAsync();
-
-            await Step("Wait and refresh to load Logboek");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step($"Verify '{logboekText}' is displayed in Logboek");
             await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Logboek contactverzoek" })).ToBeVisibleAsync();
@@ -448,7 +438,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
                 {
                     await Task.Delay(3000);
                     await Page.ReloadAsync();
-                    await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
                 }
             }
         }

--- a/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekScenarioHelpers.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekScenarioHelpers.cs
@@ -202,8 +202,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             await Expect(Page.GetInformatieVoorBurgerLabel()).ToBeVisibleAsync();
             // The "Informatie voor burger" field loads from a nested API call
             // (internetaak → aanleidinggevendKlantcontact.inhoud). In CI, this
-            // external API call can silently fail or be slow.
-            await ExpectWithReloadRetry(Page.GetInformatieVoorBurgerValue());
+            // external API call can be slow.
             await Expect(Page.GetInformatieVoorBurgerValue()).ToContainTextAsync(
                 "This is a test contact request created during an end-to-end test run.");
         }
@@ -214,7 +213,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             var zaakLocator = Page.Locator("dd.utrecht-data-list__item-value").Filter(new() { HasText = zaakIdentificatie });
             // Zaak details are fetched from the external Zaken API. In CI, this
             // call can silently fail or be slow.
-            await ExpectWithReloadRetry(zaakLocator);
+            await Expect(zaakLocator).ToBeVisibleAsync();
         }
 
         private async Task VerifyActionTabsArePresent()
@@ -283,7 +282,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             await Step("Verify both closed contact requests are displayed in the history tab");
             await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Mijn historie", Level = 1 })).ToBeVisibleAsync();
             await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Mijn afgeronde contactverzoeken", Level = 2 })).ToBeVisibleAsync();
-            await ExpectWithReloadRetry(Page.Locator($"text={newestOnderwerp}"));
+            await Expect(Page.Locator($"text={newestOnderwerp}")).ToBeVisibleAsync();
             await Expect(Page.Locator($"text={olderOnderwerp}")).ToBeVisibleAsync();
 
             await Step("Verify list is sorted in descending order (most recent first)");
@@ -416,29 +415,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
                 var timeDifference = Math.Abs((DateTimeOffset.UtcNow - internetaak.AfgehandeldOp.Value).TotalMinutes);
                 Assert.IsTrue(timeDifference < 5,
                     $"AfgehandeldOp should be close to current time. Difference: {timeDifference} minutes");
-            }
-        }
-
-        /// <summary>
-        /// After closing a contactverzoek, the backend may need time to propagate
-        /// the status change before the history page reflects the new entry.
-        /// This helper waits for a locator to appear, retrying with page reloads
-        /// up to 3 times with increasing delays to handle slow CI propagation.
-        /// </summary>
-        private async Task ExpectWithReloadRetry(ILocator locator, int maxRetries = 3)
-        {
-            for (var attempt = 0; attempt <= maxRetries; attempt++)
-            {
-                try
-                {
-                    await Expect(locator).ToBeVisibleAsync();
-                    return;
-                }
-                catch (PlaywrightException) when (attempt < maxRetries)
-                {
-                    await Task.Delay(3000);
-                    await Page.ReloadAsync();
-                }
             }
         }
     }

--- a/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekScenarios.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekScenarios.cs
@@ -363,8 +363,8 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             var secondOnderwerp = $"Test_Second_{Guid.NewGuid().ToString().Substring(0, 8)}";
 
             await Step("Create first and second contactverzoek one after another");
-            var first = await SetupAndResolveContactverzoek(firstOnderwerp, TestDataConstants.ContactverzoekNummers.HistorieFirst);
-            var second = await SetupAndResolveContactverzoek(secondOnderwerp, TestDataConstants.ContactverzoekNummers.HistorieSecond);
+            var first = await SetupAndResolveContactverzoek(firstOnderwerp);
+            var second = await SetupAndResolveContactverzoek(secondOnderwerp);
 
             await Step("Verify both interne taken are created before closing");
             await VerifyInternetaakStatusInOpenKlant(first.internetaakUuid, "te_verwerken");
@@ -385,7 +385,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             var testOnderwerp = "Test_Contact_with_BSN_Partij";
 
             await Step("Setup contactverzoek with BSN partij");
-            var uuid = await TestDataHelper.CreateContactverzoekWithAfdelingMedewerkerAndPartij(
+            var (uuid, _) = await TestDataHelper.CreateContactverzoekWithAfdelingMedewerkerAndPartij(
                 onderwerp: testOnderwerp,
                 bsn: TestDataConstants.Partijen.TestBsn,
                 attachZaak: false
@@ -510,7 +510,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
         public async Task ToewijzenKnop_IsHidden_WhenCurrentUserIndividuallyAssigned()
         {
             var testOnderwerp = "Test_ToewijzenKnop_Verborgen_IndividueleToewijzing";
-            var uuid = await TestDataHelper.CreateContactverzoekWithCurrentUserAssigned(testOnderwerp);
+            var (uuid, _) = await TestDataHelper.CreateContactverzoekWithCurrentUserAssigned(testOnderwerp);
             RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(uuid.ToString()));
 
             await NavigateToContactverzoekDetails(testOnderwerp);
@@ -523,10 +523,10 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
         public async Task ToewijzenKnop_IsVisible_WhenCurrentUserNotIndividuallyAssigned()
         {
             var testOnderwerp = "Test_ToewijzenKnop_Zichtbaar_GeenIndividueleToewijzing";
-            var uuid = await TestDataHelper.CreateContactverzoekWithTeamAssignmentNotCurrentUser(testOnderwerp);
+            var (uuid, nummer) = await TestDataHelper.CreateContactverzoekWithTeamAssignmentNotCurrentUser(testOnderwerp);
             RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(uuid.ToString()));
 
-            await NavigateToContactverzoekByNummer(TestDataConstants.ContactverzoekNummers.WithTeamAssignmentNotCurrentUser);
+            await NavigateToContactverzoekByNummer(nummer);
 
             await Step("Verify 'Toewijzen aan mezelf' button is visible");
             await Expect(Page.GetToewijzenAanMezelfButton()).ToBeVisibleAsync();
@@ -536,10 +536,10 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
         public async Task ToewijzenKnop_IsVisible_WhenCurrentUserOnlyTeamAssigned()
         {
             var testOnderwerp = "Test_ToewijzenKnop_Zichtbaar_AlleenTeamToewijzing";
-            var uuid = await TestDataHelper.CreateContactverzoekWithTeamAssignmentOnly(testOnderwerp);
+            var (uuid, nummer) = await TestDataHelper.CreateContactverzoekWithTeamAssignmentOnly(testOnderwerp);
             RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(uuid.ToString()));
 
-            await NavigateToContactverzoekByNummer(TestDataConstants.ContactverzoekNummers.WithTeamAssignmentOnly);
+            await NavigateToContactverzoekByNummer(nummer);
 
             await Step("Verify 'Toewijzen aan mezelf' button is visible (team assignment does not count as individual)");
             await Expect(Page.GetToewijzenAanMezelfButton()).ToBeVisibleAsync();
@@ -549,10 +549,10 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
         public async Task ToewijzenKnop_IsVisible_WhenNoAssignmentsExist()
         {
             var testOnderwerp = "Test_ToewijzenKnop_Zichtbaar_GeenToewijzingen";
-            var uuid = await TestDataHelper.CreateContactverzoekWithNoAssignments(testOnderwerp);
+            var (uuid, nummer) = await TestDataHelper.CreateContactverzoekWithNoAssignments(testOnderwerp);
             RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(uuid.ToString()));
 
-            await NavigateToContactverzoekByNummer(TestDataConstants.ContactverzoekNummers.WithNoAssignments);
+            await NavigateToContactverzoekByNummer(nummer);
 
             await Step("Verify 'Toewijzen aan mezelf' button is visible");
             await Expect(Page.GetToewijzenAanMezelfButton()).ToBeVisibleAsync();
@@ -562,10 +562,10 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
         public async Task ToewijzenKnop_IsHidden_WhenCurrentUserAssignedViaObjectRegisterId()
         {
             var testOnderwerp = "Test_ToewijzenKnop_Verborgen_ObjectRegisterId";
-            var uuid = await TestDataHelper.CreateContactverzoekWithCurrentUserAssignedViaObjectRegisterId(testOnderwerp);
+            var (uuid, nummer) = await TestDataHelper.CreateContactverzoekWithCurrentUserAssignedViaObjectRegisterId(testOnderwerp);
             RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(uuid.ToString()));
 
-            await NavigateToContactverzoekByNummer(TestDataConstants.ContactverzoekNummers.WithCurrentUserAssignedViaObjectRegisterId);
+            await NavigateToContactverzoekByNummer(nummer);
 
             await Step("Verify 'Toewijzen aan mezelf' button is NOT visible when assigned via ObjectRegisterId");
             await Expect(Page.GetToewijzenAanMezelfButton()).Not.ToBeVisibleAsync();
@@ -575,10 +575,10 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
         public async Task Assigning_Contactverzoek_To_Yourself()
         {
             var testOnderwerp = "Test_Contact_from_ITA_E2E_test_without_ZAAK";
-            var uuid = await TestDataHelper.CreateContactverzoekWithTeamAssignmentOnly(testOnderwerp);
+            var (uuid, nummer) = await TestDataHelper.CreateContactverzoekWithTeamAssignmentOnly(testOnderwerp);
             RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(uuid.ToString()));
 
-            await NavigateToContactverzoekByNummer(TestDataConstants.ContactverzoekNummers.WithTeamAssignmentOnly);
+            await NavigateToContactverzoekByNummer(nummer);
             
             await Step("Click on 'Toewijzen aan mezelf' button");
             await Page.GetToewijzenAanMezelfButton().ClickAsync();
@@ -596,10 +596,10 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
         public async Task Assigning_Contactverzoek_To_Yourself_Annuleren()
         {
             var testOnderwerp = "Test_Contact_from_ITA_E2E_test_without_ZAAK";
-            var uuid = await TestDataHelper.CreateContactverzoekWithTeamAssignmentOnly(testOnderwerp);
+            var (uuid, nummer) = await TestDataHelper.CreateContactverzoekWithTeamAssignmentOnly(testOnderwerp);
             RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(uuid.ToString()));
 
-            await NavigateToContactverzoekByNummer(TestDataConstants.ContactverzoekNummers.WithTeamAssignmentOnly);
+            await NavigateToContactverzoekByNummer(nummer);
             
             await Step("Capture initial Behandelaar value");
             var initialBehandelaar = await Page.GetBehandelaarValue().InnerTextAsync();
@@ -690,17 +690,14 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             var testOnderwerp = $"Test_Unassigned_Reassignment_{Guid.NewGuid().ToString().Substring(0, 8)}";
             
             await Step("Given user is on ITA - Create contactverzoek without individual assignment");
-            var contactmomentUuid = await TestDataHelper.CreateContactverzoekWithTeamAssignmentOnly(testOnderwerp);
+            var (contactmomentUuid, internetaakNummer) = await TestDataHelper.CreateContactverzoekWithTeamAssignmentOnly(testOnderwerp);
             RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(contactmomentUuid.ToString()));
 
-            await Step("Look up the internetaak nummer from the created contactmoment");
-            var internetaakUuidForNav = await TestDataHelper.GetInternetaakUuidFromContactmomentAsync(contactmomentUuid);
-            Assert.IsNotNull(internetaakUuidForNav, "Internetaak UUID should be found after setup");
-            var internetaakForNav = await TestDataHelper.GetInternetaakByIdAsync(internetaakUuidForNav.Value);
-            Assert.IsNotNull(internetaakForNav.Nummer, "Internetaak nummer should be found after setup");
+            var internetaakUuid = await TestDataHelper.GetInternetaakUuidFromContactmomentAsync(contactmomentUuid);
+            Assert.IsNotNull(internetaakUuid, "Internetaak UUID should be found after setup");
 
-            await Step("And navigates to a contactverzoek that is not individually assigned to current user");
-            await SafeGotoAsync($"/contactverzoek/{internetaakForNav.Nummer}");
+            await Step("Navigate to the contactverzoek");
+            await SafeGotoAsync($"/contactverzoek/{internetaakNummer}");
 
             await Step("Verify contactverzoek page is loaded");
             // var contactmomentNummer = internetaakForNav.AanleidinggevendKlantcontact?.Nummer;
@@ -732,7 +729,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             // await Expect(Page.GetContactmomentSuccesvolOpgeslagenEnAfgerondMessage()).ToBeVisibleAsync(new() { Timeout = 10000 });
 
             await Step("Wait for backend to process the close");
-            await VerifyInternetaakStatusInOpenKlant(internetaakUuidForNav.Value, "verwerkt", shouldHaveAfgehandeldOp: true);
+            await VerifyInternetaakStatusInOpenKlant(internetaakUuid.Value, "verwerkt", shouldHaveAfgehandeldOp: true);
 
             await Step("And navigates to History tab");
             await SafeGotoAsync("/");
@@ -751,7 +748,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             Assert.IsTrue(firstRowText.Contains(testOnderwerp), $"Expected to find reassigned and closed contactverzoek '{testOnderwerp}' in the history table");
 
             await Step("Verify status in OpenKlant is verwerkt with AfgehandeldOp set");
-            await VerifyInternetaakStatusInOpenKlant(internetaakUuidForNav.Value, "verwerkt", shouldHaveAfgehandeldOp: true);
+            await VerifyInternetaakStatusInOpenKlant(internetaakUuid.Value, "verwerkt", shouldHaveAfgehandeldOp: true);
         }
 
         [TestMethod("Detail page toont het contactmoment-nummer als heading (Feature #299)")]
@@ -818,10 +815,10 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
         public async Task User_AssignContactverzoekToSelf_VerifyLogbookEntry()
         {
             var testOnderwerp = "Test_Contact_Opgepakt_Logbook";
-            var uuid = await TestDataHelper.CreateContactverzoekWithTeamAssignmentOnly(testOnderwerp);
+            var (uuid, nummer) = await TestDataHelper.CreateContactverzoekWithTeamAssignmentOnly(testOnderwerp);
             RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(uuid.ToString()));
 
-            await NavigateToContactverzoekByNummer(TestDataConstants.ContactverzoekNummers.WithTeamAssignmentOnly);
+            await NavigateToContactverzoekByNummer(nummer);
 
             await Step("Click on 'Toewijzen aan mezelf' button");
             await Page.GetToewijzenAanMezelfButton().ClickAsync();
@@ -1156,10 +1153,10 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
         public async Task ActionControls_AreAvailable_WhenTeVerwerken()
         {
             var onderwerp = $"Test_Open_Controls_{Guid.NewGuid().ToString().Substring(0, 8)}";
-            var uuid = await TestDataHelper.CreateContactverzoekWithTeamAssignmentNotCurrentUser(onderwerp);
+            var (uuid, nummer) = await TestDataHelper.CreateContactverzoekWithTeamAssignmentNotCurrentUser(onderwerp);
             RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(uuid.ToString()));
 
-            await NavigateToContactverzoekByNummer(TestDataConstants.ContactverzoekNummers.WithTeamAssignmentNotCurrentUser);
+            await NavigateToContactverzoekByNummer(nummer);
 
             await Step("Verify action controls are visible for te_verwerken contactverzoek");
             await Expect(Page.GetToewijzenAanMezelfButton()).ToBeVisibleAsync();

--- a/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekScenarios.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekScenarios.cs
@@ -317,7 +317,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Mijn afgeronde contactverzoeken", Level = 2 })).ToBeVisibleAsync();
 
             await Step("Verify closed contactverzoek is displayed in the table");
-            await ExpectWithReloadRetry(Page.Locator($"text={testOnderwerp}"));
+            await Expect(Page.Locator($"text={testOnderwerp}")).ToBeVisibleAsync();
         }
 
         [TestMethod("View completed contactverzoeken of afdeling")]
@@ -330,7 +330,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             await NavigateToAfdelingshistorieAndSelectOrganisatorischeEenheid(afdelingNaam);
 
             await Step("Verify the closed contactverzoek appears in afdeling history");
-            await ExpectWithReloadRetry(Page.Locator($"text={testOnderwerp}"));
+            await Expect(Page.Locator($"text={testOnderwerp}")).ToBeVisibleAsync();
         }
 
         [TestMethod("View completed contactverzoeken of groep")]
@@ -655,7 +655,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             await Step("Then closed contact request assigned to the employee is displayed");
             await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Mijn historie", Level = 1 })).ToBeVisibleAsync();
             await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Mijn afgeronde contactverzoeken", Level = 2 })).ToBeVisibleAsync();
-            await ExpectWithReloadRetry(Page.Locator($"text={testOnderwerp}"));
+            await Expect(Page.Locator($"text={testOnderwerp}")).ToBeVisibleAsync();
 
             await Step("Verify the contact request shows as assigned to current user");
             var tableRows = Page.Locator("table tbody tr");
@@ -742,7 +742,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             await Step("Then the closed contact request is displayed in the history tab");
             await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Mijn historie", Level = 1 })).ToBeVisibleAsync();
             await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Mijn afgeronde contactverzoeken", Level = 2 })).ToBeVisibleAsync();
-            await ExpectWithReloadRetry(Page.Locator($"text={testOnderwerp}"));
+            await Expect(Page.Locator($"text={testOnderwerp}")).ToBeVisibleAsync();
 
             await Step("Verify the reassigned and closed contact request shows in user's history");
             var tableRows = Page.Locator("table tbody tr");
@@ -973,7 +973,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             await SafeGotoAsync("/historie");
 
             await Step("Verify the closed contactverzoek appears in historie");
-            await ExpectWithReloadRetry(Page.Locator($"text={testOnderwerp}"));
+            await Expect(Page.Locator($"text={testOnderwerp}")).ToBeVisibleAsync();
 
             await Step("Click on the contactverzoek from the historie list");
             await Page.GetDetailsLink(testOnderwerp).ClickAsync();
@@ -1181,7 +1181,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             await SafeGotoAsync("/historie");
 
             await Step("Find the closed contactverzoek in the history list and click through");
-            await ExpectWithReloadRetry(Page.Locator($"text={onderwerp}"));
+            await Expect(Page.Locator($"text={onderwerp}")).ToBeVisibleAsync();
             var contactverzoekRow = Page.Locator("table tbody tr").Filter(new() { HasText = onderwerp });
             await contactverzoekRow.GetByRole(AriaRole.Link).Filter(new() { HasText = "Klik hier" }).ClickAsync();
 

--- a/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekScenarios.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekScenarios.cs
@@ -341,17 +341,15 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
 
             await Step("Verify closed contactverzoeken for the groep are displayed");
             var tableRows = Page.Locator("table tbody tr");
-            var rowCount = await tableRows.CountAsync();
-            if (rowCount == 0)
+            try
             {
-                // Wait briefly for potential async data load
-                await Task.Delay(2000);
-                rowCount = await tableRows.CountAsync();
+                await Expect(tableRows.First).ToBeVisibleAsync();
             }
-            if (rowCount == 0)
+            catch (PlaywrightException)
             {
                 Assert.Inconclusive("No completed contactverzoeken found for groep — test environment has no data for this scenario");
             }
+            var rowCount = await tableRows.CountAsync();
 
             await VerifyLatestRecordIsOnTopInHistorieTable(tableRows, rowCount);
         }

--- a/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekScenarios.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekScenarios.cs
@@ -116,7 +116,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
 
             await Step("Select 'Contact opnemen niet gelukt'");
             await Page.GetContactOpnemenNietGeluktRadio().ClickAsync();
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Select Kanaal");
             await Page.GetKanalenSelect().SelectOptionAsync(new[] { "Telefoon" });
@@ -176,7 +175,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
 
             await Step("Verify request is closed - success message");
             await Expect(Page.GetContactmomentSuccesvolOpgeslagenEnAfgerondMessage()).ToBeVisibleAsync();
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Get internetaak UUID and verify status in OpenKlant");
             var internetaakUuid = await TestDataHelper.GetInternetaakUuidFromContactmomentAsync(contactmomentUuid);
@@ -311,7 +309,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
 
             await Step("Navigate to Mijn historie page");
             await SafeGotoAsync("/historie");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Verify page title is 'Mijn historie'");
             await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Mijn historie", Level = 1 })).ToBeVisibleAsync();
@@ -396,8 +393,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
 
            RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(uuid.ToString()));
 
-           await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-
             await NavigateToContactverzoekDetails(testOnderwerp);
 
             await Step("Verify klantnaam has a value");
@@ -470,9 +465,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             await Step("Click on button 'Koppelen'");
             await Page.GetKoppelenButton().ClickAsync();
             
-            await Step("Wait for the zaak to be connected");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-            
             await VerifyZaakIsVisible("ZAAK-2023-009");
         }
 
@@ -494,9 +486,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             await Step("Verify success message for first zaak");
             await Expect(Page.GetZaakSuccesvolGekoppeldMessage()).ToBeVisibleAsync();
             
-            await Step("Wait for the first zaak to be connected");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-            
             await Step("Verify first Zaak ZAAK-2023-005 is visible");
             await VerifyZaakIsVisible("ZAAK-2023-005");
             
@@ -509,9 +498,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             
             await Step("Verify success message for second zaak");
             await Expect(Page.GetZaakSuccesvolGekoppeldMessage()).ToBeVisibleAsync();
-            
-            await Step("Wait for the second zaak to be connected");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
             
             await Step("Verify second Zaak ZAAK-2023-009 is visible");
             await VerifyZaakIsVisible("ZAAK-2023-009");
@@ -631,14 +617,12 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
         {
             await Step("Navigate to Dashboard");
             await SafeGotoAsync("/");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Verify menu option 'Afdelingshistorie' is visible");
             await Expect(Page.GetByRole(AriaRole.Link, new() { Name = "Afdelingshistorie", Exact = true })).ToBeVisibleAsync();
 
             await Step("Click menu option 'Afdelingshistorie'");
             await Page.GetByRole(AriaRole.Link, new() { Name = "Afdelingshistorie", Exact = true }).ClickAsync();
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Verify page contains no Contactverzoeken");
             var tableRows = Page.Locator("table tbody tr");
@@ -664,9 +648,9 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
 
             await Step("When user clicks on MijnHistorie");
             await SafeGotoAsync("/");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-            await Page.GetByRole(AriaRole.Link, new() { Name = "Mijn historie", Exact = true }).ClickAsync();
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            var mijnHistorieLink = Page.GetByRole(AriaRole.Link, new() { Name = "Mijn historie", Exact = true });
+            await mijnHistorieLink.WaitForAsync(new() { State = WaitForSelectorState.Visible });
+            await mijnHistorieLink.ClickAsync();
 
             await Step("Then closed contact request assigned to the employee is displayed");
             await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Mijn historie", Level = 1 })).ToBeVisibleAsync();
@@ -683,7 +667,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             var contactverzoekRow = Page.Locator("table tbody tr").Filter(new() { HasText = testOnderwerp });
             var detailsLink = contactverzoekRow.GetByRole(AriaRole.Link).Filter(new() { HasText = "Klik hier" });
             await detailsLink.ClickAsync();
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Then the detail screen of the contact request shows read-only mode for closed contactverzoek");
             await VerifyBasicContactverzoekFields(testOnderwerp);
@@ -718,7 +701,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
 
             await Step("And navigates to a contactverzoek that is not individually assigned to current user");
             await SafeGotoAsync($"/contactverzoek/{internetaakForNav.Nummer}");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Verify contactverzoek page is loaded");
             // var contactmomentNummer = internetaakForNav.AanleidinggevendKlantcontact?.Nummer;
@@ -737,7 +719,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             await Step("When user closes the contact request");
             await NavigateToContactmomentRegistrerenTab();
             await Expect(Page.GetContactOpnemenGeluktRadio()).ToBeCheckedAsync();
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Page.GetKanalenSelect().SelectOptionAsync(new[] { "Telefoon" });
             await Page.GetInformatieBurgerTextbox().FillAsync("Contact request closed after reassignment");
@@ -747,7 +728,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             
             await Step("Click 'Opslaan & afronden' and wait for success message");
             await Page.GetOpslaanEnAfrondenButton().ClickAsync();
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
             // TODO: Fix session timeout issue before uncommenting
             // await Expect(Page.GetContactmomentSuccesvolOpgeslagenEnAfgerondMessage()).ToBeVisibleAsync(new() { Timeout = 10000 });
 
@@ -756,9 +736,8 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
 
             await Step("And navigates to History tab");
             await SafeGotoAsync("/");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.GetMijnHistorieLink().WaitForAsync(new() { State = WaitForSelectorState.Visible });
             await Page.GetMijnHistorieLink().ClickAsync();
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Then the closed contact request is displayed in the history tab");
             await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Mijn historie", Level = 1 })).ToBeVisibleAsync();
@@ -791,7 +770,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
 
             await Step($"Navigate to /contactmoment/{contactmomentNummer}");
             await SafeGotoAsync($"/contactmoment/{contactmomentNummer}");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Verify heading shows the contactmoment number, not the interne-taaknummer");
             await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = $"Contactverzoek {contactmomentNummer}" })).ToBeVisibleAsync();
@@ -814,12 +792,10 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
 
             await Step("Navigate to home and click the contactverzoek row link");
             await SafeGotoAsync("/");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             var detailsLink = Page.GetDetailsLink(testOnderwerp);
             await detailsLink.WaitForAsync(new() { State = WaitForSelectorState.Visible });
             await detailsLink.ClickAsync();
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Verify URL uses /contactmoment/ with the contactmoment number");
             await Expect(Page).ToHaveURLAsync(new Regex($"/contactmoment/{Regex.Escape(contactmomentNummer)}"));
@@ -883,9 +859,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             await Step("Verify success message for zaak linking");
             await Expect(Page.GetZaakSuccesvolGekoppeldMessage()).ToBeVisibleAsync();
 
-            await Step("Wait for the zaak to be connected");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-
             await Step("Verify the zaak is now visible");
             await VerifyZaakIsVisible("ZAAK-2023-009");
 
@@ -914,9 +887,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
 
             await Step("Verify success message for zaak linking");
             await Expect(Page.GetZaakSuccesvolGekoppeldMessage()).ToBeVisibleAsync();
-
-            await Step("Wait for the new zaak to be connected");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Verify the new zaak is now visible");
             await VerifyZaakIsVisible("ZAAK-2023-009");
@@ -956,7 +926,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
 
             await Step("Reload page to ensure logbook is updated");
             await Page.ReloadAsync();
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await VerifyLogbookEntry("Contact gelukt");
 
@@ -999,18 +968,15 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
 
             await Step("Verify contactverzoek was closed successfully");
             await Expect(Page.GetContactmomentSuccesvolOpgeslagenEnAfgerondMessage()).ToBeVisibleAsync();
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
  
             await Step("Navigate to Mijn historie tab");
             await SafeGotoAsync("/historie");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Verify the closed contactverzoek appears in historie");
             await ExpectWithReloadRetry(Page.Locator($"text={testOnderwerp}"));
 
             await Step("Click on the contactverzoek from the historie list");
             await Page.GetDetailsLink(testOnderwerp).ClickAsync();
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Verify contactverzoek details page is displayed");
             await Expect(Page.Locator($"text={testOnderwerp}")).ToBeVisibleAsync();
@@ -1018,7 +984,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             await VerifyLogbookEntry("Afgerond", verifyTimestamp: false);
 
             await Step("Verify the information 'test logboek' is visible in the logbook section");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
             var logbookHeading = Page.GetByRole(AriaRole.Heading, new() { Name = "Logboek contactverzoek" });
             await Expect(logbookHeading).ToBeVisibleAsync();
             var logbookSection = logbookHeading.Locator("xpath=ancestor::section");
@@ -1036,7 +1001,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(contactmomentUuid.ToString()));
 
             await SafeGotoAsync("/");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Make direct API call to aan-mij-toewijzen on verwerkt contactverzoek");
             var response = await Page.Context.APIRequest.PostAsync($"/api/internetaken/{internetaakUuid}/aan-mij-toewijzen");
@@ -1054,7 +1018,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(contactmomentUuid.ToString()));
 
             await SafeGotoAsync("/");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Make direct API call to notitie endpoint on verwerkt contactverzoek");
             var response = await Page.Context.APIRequest.PostAsync(
@@ -1074,7 +1037,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(contactmomentUuid.ToString()));
 
             await SafeGotoAsync("/");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Make direct API call to forward endpoint on verwerkt contactverzoek");
             var response = await Page.Context.APIRequest.PostAsync(
@@ -1094,7 +1056,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(contactmomentUuid.ToString()));
 
             await SafeGotoAsync("/");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Make direct API call to koppel-zaak endpoint on verwerkt contactverzoek");
             // All required fields must be present for the body to deserialize before the guard can run
@@ -1123,7 +1084,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(contactmomentUuid.ToString()));
 
             await SafeGotoAsync("/");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Make direct API call to close-with-klantcontact on verwerkt contactverzoek");
             // All required fields must be present for deserialization to succeed before the guard runs
@@ -1164,7 +1124,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             Assert.IsNotNull(internetaakUuid, "Internetaak UUID should be found");
 
             await SafeGotoAsync("/");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Make direct API call to aan-mij-toewijzen on te_verwerken contactverzoek");
             var response = await Page.Context.APIRequest.PostAsync($"/api/internetaken/{internetaakUuid}/aan-mij-toewijzen");
@@ -1220,13 +1179,11 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
 
             await Step("Navigate to Mijn historie");
             await SafeGotoAsync("/historie");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Find the closed contactverzoek in the history list and click through");
             await ExpectWithReloadRetry(Page.Locator($"text={onderwerp}"));
             var contactverzoekRow = Page.Locator("table tbody tr").Filter(new() { HasText = onderwerp });
             await contactverzoekRow.GetByRole(AriaRole.Link).Filter(new() { HasText = "Klik hier" }).ClickAsync();
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Verify all action controls are hidden");
             await Expect(Page.GetAfgehandeldMessage()).ToBeVisibleAsync();
@@ -1244,7 +1201,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
 
             await Step("Navigate to Alle contactverzoeken screen");
             await SafeGotoAsync("/alle-contactverzoeken");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Verify list of open contact requests is displayed");
             var tableRows = Page.Locator("table tbody tr");
@@ -1266,7 +1222,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
 
             await Step("Navigate to Alle contactverzoeken");
             await SafeGotoAsync("/alle-contactverzoeken");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Verify the closed contact request is no longer in the list");
             await Expect(Page.Locator($"text={testOnderwerp}")).Not.ToBeVisibleAsync();
@@ -1295,7 +1250,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
 
             await Step("Navigate to Alle contactverzoeken screen");
             await SafeGotoAsync("/alle-contactverzoeken");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Verify the list is displayed");
             var tableRows = Page.Locator("table tbody tr");

--- a/InterneTaakAfhandeling.EndToEndTest/Dashboard/DashboardScenarios.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Dashboard/DashboardScenarios.cs
@@ -21,17 +21,11 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             await Page.GotoAsync("/");
 
             await Step("Wait for dashboard to load");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-
-            await Step("Click on contactverzoek to view details");
             var onderwerpElement = Page.Locator($"text={testOnderwerp}");
             await Expect(onderwerpElement).ToBeVisibleAsync();
 
             var detailsLink = Page.GetDetailsLink(testOnderwerp);
             await detailsLink.ClickAsync();
-
-            await Step("Verify details page loads");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Verify contactverzoek details are accessible");
             var onderwerpInDetails = Page.Locator($"text={testOnderwerp}");

--- a/InterneTaakAfhandeling.EndToEndTest/Helpers/PageExtensions.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Helpers/PageExtensions.cs
@@ -55,9 +55,15 @@ namespace InterneTaakAfhandeling.EndToEndTest.Helpers
 
         public static async Task<bool> IsLoggedInAsync(this IPage page)
         {
-            // Navigate to root and check if we stay on ITA domain
+            // Navigate to root and wait for URL to stabilize (either ITA or redirect to login)
             await page.GotoAsync("/");
-            await Task.Delay(2000); // Allow time for potential redirect
+            try
+            {
+                await page.WaitForURLAsync(
+                    url => url.Contains("ita.test.icatt.nl") || url.Contains("login.microsoftonline.com"),
+                    new() { Timeout = 10_000 });
+            }
+            catch (TimeoutException) { }
 
             var currentUrl = page.Url;
             return currentUrl.Contains("ita.test.icatt.nl") &&

--- a/InterneTaakAfhandeling.EndToEndTest/Infrastructure/ITAPlaywrightTest.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Infrastructure/ITAPlaywrightTest.cs
@@ -141,6 +141,11 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
         [TestInitialize]
         public virtual async Task TestInitialize()
         {
+            // Ensure Expect timeout is always applied (30s), regardless of .runsettings file discovery.
+            // This accommodates slower CI runners and external API latency where detail pages
+            // fetch data from multiple external APIs before rendering.
+            SetDefaultExpectTimeout(30_000);
+
             // start tracing (authentication is pre-loaded via StorageStatePath in ContextOptions)
             await Context.Tracing.StartAsync(new()
             {

--- a/InterneTaakAfhandeling.EndToEndTest/Infrastructure/TestDataConstants.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Infrastructure/TestDataConstants.cs
@@ -6,21 +6,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
     
      public static class TestDataConstants
     {
-        public static class ContactverzoekNummers
-        {
-            public const string WithZaak = "8001321008";
-            public const string WithoutZaak = "8001321009";
-            public const string WithPartij = "8001321010";
-            public const string HistorieFirst = "8001321011";
-            public const string HistorieSecond = "8001321012";
-            public const string UnassignedForReassignment = "8001321013";
-            public const string WithCurrentUserAssigned = "8001321014";
-            public const string WithTeamAssignmentOnly = "8001321015";
-            public const string WithNoAssignments = "8001321016";
-            public const string WithCurrentUserAssignedViaObjectRegisterId = "8001321017";
-            public const string WithTeamAssignmentNotCurrentUser = "8001321018";
-        }
-
          public static class Zaken
         {
             public const string TestZaakIdentificatie = "ZAAK-2023-002";

--- a/InterneTaakAfhandeling.EndToEndTest/Infrastructure/TestDataHelper.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Infrastructure/TestDataHelper.cs
@@ -1,4 +1,4 @@
-﻿using InterneTaakAfhandeling.Common.Extensions;
+using InterneTaakAfhandeling.Common.Extensions;
 using InterneTaakAfhandeling.Common.Services;
 using InterneTaakAfhandeling.Common.Services.ObjectApi;
 using InterneTaakAfhandeling.Common.Services.ObjectApi.Models;
@@ -91,16 +91,14 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
 
         public async Task<Guid> CreateContactverzoek(
             string onderwerp, 
-            bool attachZaak = true,
-            string? internetaakNummer = null)
+            bool attachZaak = true)
         {
-            // Generate a unique nummer unless an explicit one is provided.
-            // This ensures full test isolation — no shared state between tests.
-            var contactverzoekNummer = internetaakNummer ?? GenerateUniqueInternetaakNummer();
+            var contactverzoekNummer = GenerateUniqueInternetaakNummer();
 
-            var contactmoment = await GetOrCreateContactmoment(
+            var contactmoment = await CreateContactmoment(
                 onderwerp, 
-                "This is a test contact request created during an end-to-end test run.");
+                "This is a test contact request created during an end-to-end test run.",
+                klantnaam: null);
 
             var submitterActor = await GetOrCreateSubmitterActor();
             
@@ -110,15 +108,14 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
             
             var medewerkerActor = await GetOrCreateMedewerkerActor("icatt-integratie-test@icatt.nl");
 
-            await CreateInternetaakIfNotExists(
+            await CreateInternetaak(
                 contactverzoekNummer,
                 contactmoment.Uuid,
                 new List<Guid> 
                 { 
                     Guid.Parse(medewerkerActor.Uuid), 
                     Guid.Parse(afdelingActor.Uuid) 
-                },
-                isExplicitNummer: internetaakNummer != null);
+                });
 
             if (attachZaak)
             {
@@ -128,13 +125,11 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
             return contactmoment.Uuid;
         }
 
-        public async Task<Guid> CreateContactverzoekWithAfdelingMedewerkerAndPartij(
+        public async Task<(Guid ContactmomentUuid, string InternetaakNummer)> CreateContactverzoekWithAfdelingMedewerkerAndPartij(
             string onderwerp,
             string bsn = TestDataConstants.Partijen.TestBsn,
             bool attachZaak = false)
         {
-            await CleanupExistingContactmomenten(onderwerp);
-
             var partij = await GetPartijByBsn(bsn);
             var contactmoment = await CreateContactmomentWithPartij(
                 onderwerp, 
@@ -147,96 +142,87 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
             var afdelingActor = await GetOrCreateAfdelingActor("Burgerzaken_ibz");
             var medewerkerActor = await GetOrCreateMedewerkerActor("icatt-integratie-test@icatt.nl");
 
-            await CreateInternetaakIfNotExists(
-                TestDataConstants.ContactverzoekNummers.WithPartij,
+            var nummer = await CreateInternetaak(
+                GenerateUniqueInternetaakNummer(),
                 contactmoment.Uuid,
                 new List<Guid> 
                 { 
                     Guid.Parse(medewerkerActor.Uuid), 
                     Guid.Parse(afdelingActor.Uuid) 
-                },
-                isExplicitNummer: true);
+                });
 
             if (attachZaak)
             {
                 await AttachZaakToContactmomentAsync(contactmoment.Uuid, TestDataConstants.Zaken.TestZaakIdentificatie);
             }
 
-            return contactmoment.Uuid;
+            return (contactmoment.Uuid, nummer);
         }
 
-        public async Task<Guid> CreateContactverzoekWithCurrentUserAssigned(string onderwerp)
+        public async Task<(Guid ContactmomentUuid, string InternetaakNummer)> CreateContactverzoekWithCurrentUserAssigned(string onderwerp)
         {
-            await CleanupExistingContactmomenten(onderwerp);
-
-            var contactmoment = await GetOrCreateContactmoment(
+            var contactmoment = await CreateContactmoment(
                 onderwerp,
-                "This is a test contact request created during an end-to-end test run.");
+                "This is a test contact request created during an end-to-end test run.",
+                klantnaam: null);
 
             var submitterActor = await GetOrCreateSubmitterActor();
             await ConnectActorToContactmoment(submitterActor, contactmoment.Uuid);
 
             var afdelingActor = await GetOrCreateAfdelingActor("Burgerzaken_ibz");
 
-            await CreateInternetaakIfNotExists(
-                TestDataConstants.ContactverzoekNummers.WithCurrentUserAssigned,
+            var nummer = await CreateInternetaak(
+                GenerateUniqueInternetaakNummer(),
                 contactmoment.Uuid,
                 new List<Guid>
                 {
                     Guid.Parse(submitterActor.Uuid),
                     Guid.Parse(afdelingActor.Uuid)
-                },
-                isExplicitNummer: true);
+                });
 
-            return contactmoment.Uuid;
+            return (contactmoment.Uuid, nummer);
         }
 
-        public async Task<Guid> CreateContactverzoekWithTeamAssignmentOnly(string onderwerp)
+        public async Task<(Guid ContactmomentUuid, string InternetaakNummer)> CreateContactverzoekWithTeamAssignmentOnly(string onderwerp)
         {
-            await CleanupExistingContactmomenten(onderwerp);
-
-            var contactmoment = await GetOrCreateContactmoment(
+            var contactmoment = await CreateContactmoment(
                 onderwerp,
-                "This is a test contact request created during an end-to-end test run.");
+                "This is a test contact request created during an end-to-end test run.",
+                klantnaam: null);
 
             var submitterActor = await GetOrCreateSubmitterActor();
             await ConnectActorToContactmoment(submitterActor, contactmoment.Uuid);
 
             var afdelingActor = await GetOrCreateAfdelingActor("Burgerzaken_ibz");
 
-            await CreateInternetaakIfNotExists(
-                TestDataConstants.ContactverzoekNummers.WithTeamAssignmentOnly,
+            var nummer = await CreateInternetaak(
+                GenerateUniqueInternetaakNummer(),
                 contactmoment.Uuid,
-                new List<Guid> { Guid.Parse(afdelingActor.Uuid) },
-                isExplicitNummer: true);
+                new List<Guid> { Guid.Parse(afdelingActor.Uuid) });
 
-            return contactmoment.Uuid;
+            return (contactmoment.Uuid, nummer);
         }
 
-        public async Task<Guid> CreateContactverzoekWithNoAssignments(string onderwerp)
+        public async Task<(Guid ContactmomentUuid, string InternetaakNummer)> CreateContactverzoekWithNoAssignments(string onderwerp)
         {
-            await CleanupExistingContactmomenten(onderwerp);
-
-            var contactmoment = await GetOrCreateContactmoment(
+            var contactmoment = await CreateContactmoment(
                 onderwerp,
-                "This is a test contact request created during an end-to-end test run.");
+                "This is a test contact request created during an end-to-end test run.",
+                klantnaam: null);
 
             var submitterActor = await GetOrCreateSubmitterActor();
             await ConnectActorToContactmoment(submitterActor, contactmoment.Uuid);
 
-            await CreateInternetaakIfNotExists(
-                TestDataConstants.ContactverzoekNummers.WithNoAssignments,
+            var nummer = await CreateInternetaak(
+                GenerateUniqueInternetaakNummer(),
                 contactmoment.Uuid,
-                new List<Guid>(),
-                isExplicitNummer: true);
+                new List<Guid>());
 
-            return contactmoment.Uuid;
+            return (contactmoment.Uuid, nummer);
         }
 
         public async Task<(Guid ContactmomentUuid, Guid InternetaakUuid, string InternetaakNummer)> CreateVerwerktContactverzoekAsync(string onderwerp)
         {
-            await CleanupExistingContactmomenten(onderwerp);
-
             var contactmoment = await CreateContactmoment(
                 onderwerp,
                 "Test contactverzoek for readonly guard verification",
@@ -245,11 +231,10 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
             var submitterActor = await GetOrCreateSubmitterActor();
             await ConnectActorToContactmoment(submitterActor, contactmoment.Uuid);
 
-            await CreateInternetaakIfNotExists(
+            var nummer = await CreateInternetaak(
                 GenerateUniqueInternetaakNummer(),
                 contactmoment.Uuid,
-                new List<Guid>(),
-                isExplicitNummer: false);
+                new List<Guid>());
 
             var internetaakUuid = await GetInternetaakUuidFromContactmomentAsync(contactmoment.Uuid)
                 ?? throw new InvalidOperationException($"Internetaak not found after creation for contactmoment {contactmoment.Uuid}");
@@ -258,18 +243,15 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
                 new InternetakenPatchStatusRequest { Status = KnownInternetaakStatussen.Verwerkt },
                 internetaakUuid.ToString());
 
-            var internetaak = await GetInternetaakByIdAsync(internetaakUuid);
-            return (contactmoment.Uuid, internetaakUuid, internetaak.Nummer
-                ?? throw new InvalidOperationException("Internetaak nummer is null after creation"));
+            return (contactmoment.Uuid, internetaakUuid, nummer);
         }
 
-        public async Task<Guid> CreateContactverzoekWithTeamAssignmentNotCurrentUser(string onderwerp)
+        public async Task<(Guid ContactmomentUuid, string InternetaakNummer)> CreateContactverzoekWithTeamAssignmentNotCurrentUser(string onderwerp)
         {
-            await CleanupExistingContactmomenten(onderwerp);
-
-            var contactmoment = await GetOrCreateContactmoment(
+            var contactmoment = await CreateContactmoment(
                 onderwerp,
-                "This is a test contact request created during an end-to-end test run.");
+                "This is a test contact request created during an end-to-end test run.",
+                klantnaam: null);
 
             var submitterActor = await GetOrCreateSubmitterActor();
             await ConnectActorToContactmoment(submitterActor, contactmoment.Uuid);
@@ -277,26 +259,24 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
             var afdelingActor = await GetOrCreateAfdelingActor("Burgerzaken_ibz");
             var otherMedewerkerActor = await GetOrCreateMedewerkerActorDirectly("surbhi@info.nl");
 
-            await CreateInternetaakIfNotExists(
-                TestDataConstants.ContactverzoekNummers.WithTeamAssignmentNotCurrentUser,
+            var nummer = await CreateInternetaak(
+                GenerateUniqueInternetaakNummer(),
                 contactmoment.Uuid,
                 new List<Guid>
                 {
                     Guid.Parse(otherMedewerkerActor.Uuid),
                     Guid.Parse(afdelingActor.Uuid)
-                },
-                isExplicitNummer: true);
+                });
 
-            return contactmoment.Uuid;
+            return (contactmoment.Uuid, nummer);
         }
 
-        public async Task<Guid> CreateContactverzoekWithCurrentUserAssignedViaObjectRegisterId(string onderwerp)
+        public async Task<(Guid ContactmomentUuid, string InternetaakNummer)> CreateContactverzoekWithCurrentUserAssignedViaObjectRegisterId(string onderwerp)
         {
-            await CleanupExistingContactmomenten(onderwerp);
-
-            var contactmoment = await GetOrCreateContactmoment(
+            var contactmoment = await CreateContactmoment(
                 onderwerp,
-                "This is a test contact request created during an end-to-end test run.");
+                "This is a test contact request created during an end-to-end test run.",
+                klantnaam: null);
 
             var submitterActor = await GetOrCreateSubmitterActor();
             await ConnectActorToContactmoment(submitterActor, contactmoment.Uuid);
@@ -304,17 +284,16 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
             var afdelingActor = await GetOrCreateAfdelingActor("Burgerzaken_ibz");
             var medewerkerActorViaObjectRegisterId = await GetOrCreateMedewerkerActor(Username);
 
-            await CreateInternetaakIfNotExists(
-                TestDataConstants.ContactverzoekNummers.WithCurrentUserAssignedViaObjectRegisterId,
+            var nummer = await CreateInternetaak(
+                GenerateUniqueInternetaakNummer(),
                 contactmoment.Uuid,
                 new List<Guid>
                 {
                     Guid.Parse(afdelingActor.Uuid),
                     Guid.Parse(medewerkerActorViaObjectRegisterId.Uuid)
-                },
-                isExplicitNummer: true);
+                });
 
-            return contactmoment.Uuid;
+            return (contactmoment.Uuid, nummer);
         }
 
 
@@ -404,13 +383,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
 
         // Contactmoment Operations
 
-        private async Task<Klantcontact> GetOrCreateContactmoment(string onderwerp, string inhoud)
-        {
-            var existing = await QueryContactmoment(onderwerp);
-            return existing ?? await CreateContactmoment(onderwerp, inhoud, klantnaam: null)
-                ?? throw new Exception("Failed to create contactmoment for testing.");
-        }
-
         private async Task<Klantcontact> CreateContactmomentWithPartij(
             string onderwerp, 
             string inhoud, 
@@ -434,47 +406,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
                 Vertrouwelijk = false,
                 Klantnaam = klantnaam
             });
-        }
-
-        private async Task<Klantcontact?> QueryContactmoment(string onderwerp)
-        {
-            var contactmomenten = await OpenKlantApiClient.QueryKlantcontactAsync(
-                new KlantcontactQuery { Onderwerp = onderwerp });
-
-            // If multiple exist (from failed previous runs), clean them all up
-            if (contactmomenten.Count > 1)
-            {
-                try
-                {
-                    await CleanupExistingContactmomenten(onderwerp);
-                }
-                catch
-                {
-                    // Ignore cleanup failures
-                }
-                return null; // Force creation of a fresh one
-            }
-    
-            return contactmomenten.FirstOrDefault();
-        }
-
-        private async Task CleanupExistingContactmomenten(string onderwerp)
-        {
-            var contactmomenten = await OpenKlantApiClient.QueryKlantcontactAsync(
-                new KlantcontactQuery { Onderwerp = onderwerp });
-
-            foreach (var existing in contactmomenten)
-            {
-                await OpenKlantApiClient.DeleteKlantcontactAsync(existing.Uuid);
-            }
-
-            var remaining = await OpenKlantApiClient.QueryKlantcontactAsync(
-                new KlantcontactQuery { Onderwerp = onderwerp });
-            
-            if (remaining.Count > 0)
-            {
-                throw new InvalidOperationException($"Failed to cleanup contactmomenten. Still found {remaining.Count} contactmomenten after deletion.");
-            }
         }
 
         private async Task ConnectActorToContactmoment(Actor actor, Guid contactmomentUuid)
@@ -694,102 +625,23 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
             return $"{millisPart:00000000}{randomPart:00}";
         }
 
-        private async Task CreateInternetaakIfNotExists(
+        private async Task<string> CreateInternetaak(
             string nummer,
             Guid contactmomentUuid,
-            List<Guid> actorUuids,
-            bool isExplicitNummer = false)
+            List<Guid> actorUuids)
         {
-            // First check if internetaak with this nummer already exists
-            var existing = await OpenKlantApiClient.QueryInterneTakenAsync(new InterneTaakQuery
+            await OpenKlantApiClient.CreateInterneTaak(new InternetaakPostRequest
             {
-                Nummer = nummer
+                AanleidinggevendKlantcontact = new UuidObject { Uuid = contactmomentUuid },
+                GevraagdeHandeling = "terugbellen svp",
+                Nummer = nummer,
+                Status = KnownInternetaakStatussen.TeVerwerken,
+                ToegewezenAanActoren = actorUuids.Select(id => new UuidObject { Uuid = id }).ToList(),
+                Toelichting = "Test contactverzoek from ITA E2E test"
             });
 
-            if (existing.Count > 1)
-            {
-                throw new InvalidOperationException($"Found {existing.Count} internetaken with nummer '{nummer}', expected at most 1.");
-            }
-
-            if (existing.Count > 0)
-            {
-                var existingInternetaak = existing[0];
-
-                // Verify the existing internetaak is linked to the correct contactmoment and has the right status
-                var isCorrectContactmoment = existingInternetaak.AanleidinggevendKlantcontact?.Uuid == contactmomentUuid;
-                var isCorrectStatus = existingInternetaak.Status == KnownInternetaakStatussen.TeVerwerken;
-
-                if (isCorrectContactmoment && isCorrectStatus)
-                {
-                    Logger.LogInformation("Internetaak with nummer '{Nummer}' already exists and is correctly linked, skipping creation", nummer);
-                    return;
-                }
-
-                // Existing internetaak is stale (wrong contactmoment or wrong status) — delete and recreate
-                Logger.LogInformation("Internetaak with nummer '{Nummer}' exists but is stale (wrong contactmoment or status), recreating", nummer);
-                if (!Guid.TryParse(existingInternetaak.Uuid, out var existingUuid))
-                {
-                    throw new InvalidOperationException($"Internetaak has invalid UUID format: '{existingInternetaak.Uuid}'");
-                }
-                await OpenKlantApiClient.DeleteInterneTaakAsync(existingUuid);
-            }
-
-            // Doesn't exist, try to create it
-            var currentNummer = nummer;
-            Exception? lastConflictException = null;
-
-            for (var attempt = 1; attempt <= 3; attempt++)
-            {
-                try
-                {
-                    await OpenKlantApiClient.CreateInterneTaak(new InternetaakPostRequest
-                    {
-                        AanleidinggevendKlantcontact = new UuidObject { Uuid = contactmomentUuid },
-                        GevraagdeHandeling = "terugbellen svp",
-                        Nummer = currentNummer,
-                        Status = KnownInternetaakStatussen.TeVerwerken,
-                        ToegewezenAanActoren = actorUuids.Select(id => new UuidObject { Uuid = id }).ToList(),
-                        Toelichting = "Test contactverzoek from ITA E2E test"
-                    });
-
-                    Logger.LogInformation("Successfully created internetaak with nummer '{Nummer}'", currentNummer);
-                    return; // Success
-                }
-                catch (HttpRequestException ex) when (ex.Message.Contains("409") || ex.Message.Contains("conflict"))
-                {
-                    lastConflictException = ex;
-
-                    if (isExplicitNummer)
-                    {
-                        // Fail fast for explicit nummers - don't mutate them
-                        throw new InvalidOperationException(
-                            $"Cannot create internetaak with explicit nummer '{nummer}' because it already exists. " +
-                            "This breaks test contracts that expect this exact nummer for navigation/verification.", 
-                            ex);
-                    }
-
-                    // Only auto-generate new nummers when no explicit nummer was provided
-                    Logger.LogWarning("Internetaak nummer '{Nummer}' already exists, attempting with different nummer (attempt {Attempt}/3)", 
-                        currentNummer, attempt);
-                    
-                    if (attempt < 3)
-                    {
-                        currentNummer = GenerateUniqueInternetaakNummer();
-                        await Task.Delay(50);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    // Auth, connection, server errors, etc. - don't retry, rethrow immediately
-                    Logger.LogError(ex, "Failed to create internetaak due to non-retryable error: {Message}", ex.Message);
-                    throw;
-                }
-            }
-
-            // If we get here, we've exhausted retries for conflict errors (only for auto-generated nummers)
-            throw new InvalidOperationException(
-                $"Failed to create internetaak after {3} attempts due to nummer conflicts. Last conflict was with nummer '{currentNummer}'.", 
-                lastConflictException);
+            Logger.LogInformation("Successfully created internetaak with nummer '{Nummer}'", nummer);
+            return nummer;
         }
 
         // Zaak Operations

--- a/InterneTaakAfhandeling.EndToEndTest/Infrastructure/TestDataHelper.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Infrastructure/TestDataHelper.cs
@@ -94,9 +94,9 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
             bool attachZaak = true,
             string? internetaakNummer = null)
         {
-            var contactverzoekNummer = internetaakNummer ?? (attachZaak
-                ? TestDataConstants.ContactverzoekNummers.WithZaak
-                : TestDataConstants.ContactverzoekNummers.WithoutZaak);
+            // Generate a unique nummer unless an explicit one is provided.
+            // This ensures full test isolation — no shared state between tests.
+            var contactverzoekNummer = internetaakNummer ?? GenerateUniqueInternetaakNummer();
 
             var contactmoment = await GetOrCreateContactmoment(
                 onderwerp, 

--- a/InterneTaakAfhandeling.EndToEndTest/Kanaal/Kanaal.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Kanaal/Kanaal.cs
@@ -65,15 +65,8 @@ namespace InterneTaakAfhandeling.EndToEndTest.Kanaal
                     Page.Dialog -= AcceptDialog;
                 }
                 
-                // Verify deletion succeeded
-                var stillExists = await locators.GetKanaalListItem(kanaalName).CountAsync() > 0;
-                if (!stillExists)
-                {
-                    return true;
-                }
-                
-                Console.WriteLine($"Kanaal '{kanaalName}' still exists after deletion attempt");
-                return false;
+                await Expect(locators.GetKanaalListItem(kanaalName)).ToHaveCountAsync(0);
+                return true;
             }
             catch (Exception ex)
             {

--- a/InterneTaakAfhandeling.EndToEndTest/Kanaal/Kanaal.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Kanaal/Kanaal.cs
@@ -59,7 +59,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Kanaal
                 try
                 {
                     await locators.GetDeleteButton(kanaalName).ClickAsync();
-                    await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
                 }
                 finally
                 {
@@ -87,7 +86,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Kanaal
         {
             await Step("Navigate to home page");
             await Page.GotoAsync("/");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
             await Step("Navigate to Kanalen via Beheer menu");
             await locators.BeheerLink.ClickAsync();
@@ -100,7 +98,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Kanaal
             await locators.KanaalToevoegenLink.ClickAsync();
             await locators.NaamTextbox.FillAsync(kanaalName);
             await locators.OpslaanButton.ClickAsync();
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
         }
 
         private async Task DeleteKanaal(string kanaalName)
@@ -111,7 +108,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Kanaal
             try
             {
                 await locators.GetDeleteButton(kanaalName).ClickAsync();
-                await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
             }
             finally
             {
@@ -132,7 +128,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Kanaal
             await locators.GetKanaalLink(currentName).ClickAsync();
             await locators.NaamTextbox.FillAsync(newName);
             await locators.OpslaanButton.ClickAsync();
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
         }
 
         // Test Methods


### PR DESCRIPTION
## Summary

Structural fixes for E2E test flakiness in CI. Tests passed locally but failed intermittently in the pipeline due to timing assumptions, stale data reuse, and non-deterministic waits. This PR addresses the root causes systematically.

## Changes

### 1. Remove `WaitForLoadStateAsync(NetworkIdle)` (`b2117d3`)
- Replaced all `NetworkIdle` waits with specific element visibility waits using Playwright's built-in `Expect(...).ToBeVisibleAsync()`
- `NetworkIdle` is unreliable in apps with background polling or long-lived connections — it either times out or returns too early
- Added programmatic `SetDefaultExpectTimeout(30_000)` in test base class to give CI enough headroom
- Removed `playwright.runsettings` (timeout was configured there, now handled in code)

### 2. Remove `ExpectWithReloadRetry` helper (`f19e990`)
- Removed the custom retry-with-page-reload pattern that masked real failures
- Playwright's `Expect()` already retries automatically within the configured timeout
- Page reloads during assertion could reset component state and cause false negatives

### 3. Generate unique `internetaakNummer` per test run (`cde66f0`)
- Replaced all 11 hardcoded `TestDataConstants.ContactverzoekNummers` constants with `GenerateUniqueInternetaakNummer()` (timestamp + random suffix)
- Removed stale data reuse patterns: `GetOrCreateContactmoment`, `QueryContactmoment`, `CleanupExistingContactmomenten`
- Simplified `CreateInternetaak` — single API call, no retry loop needed with unique nummers
- All `CreateContactverzoekWith*` methods now return `(Guid, string)` tuples so tests use the actual created nummer
- Root cause fix for `inhoud = null` failures: stale contactmomenten from previous runs lacked data

### 4. Replace `Task.Delay` with proper Playwright waits (`6e87c70`)
- Table row visibility: replaced `Task.Delay(2000)` + manual row count with `Expect(tableRows.First).ToBeVisibleAsync()`
- Login check: replaced `Task.Delay(2000)` with `WaitForURLAsync` to detect redirect completion
- Remaining `Task.Delay` calls are legitimate API-level retry backoffs (no Playwright alternative)

## Files changed

- `Infrastructure/TestDataHelper.cs` — major refactor: always-create-fresh pattern, removed stale data handling
- `Infrastructure/TestDataConstants.cs` — removed `ContactverzoekNummers` class
- `Infrastructure/ITAPlaywrightTest.cs` — added `SetDefaultExpectTimeout(30_000)`
- `Infrastructure/Locators.cs` — replaced `NetworkIdle` waits with element waits
- `Contactverzoek/ContactverzoekScenarios.cs` — updated all tests to use returned nummers, removed `Task.Delay`
- `Contactverzoek/ContactverzoekScenarioHelpers.cs` — simplified setup helpers, removed `ExpectWithReloadRetry`
- `Helpers/PageExtensions.cs` — replaced `Task.Delay` with `WaitForURLAsync`
- Removed `playwright.runsettings`

## Testing

Run full E2E suite in CI — verify no intermittent failures across multiple runs.