### PR TITLE
test(e2e): add digitale adressen fallback verification scenarios

### DIFF
--- a/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/DigitaleAdressenFallbackScenarios.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/DigitaleAdressenFallbackScenarios.cs
@@ -109,10 +109,24 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
         {
             var onderwerp = $"E2E_Fallback_EigenAdressen_{DateTime.UtcNow.Ticks}";
             var ownEmail = "eigen-test@e2e-ita.nl";
+            var partijEmail = "partij-fallback@e2e-ita.nl";
+
+            // Ensure the partij has an email so the test actually exercises priority logic
+            var partijUuid = await TestDataHelper.GetPartijUuidByBsnAsync();
+            var existingAdressen = await TestDataHelper.GetPartijDigitaleAdressenAsync(partijUuid);
+
+            if (!existingAdressen.Any(a => a.SoortDigitaalAdres == "email"))
+            {
+                await Step("Creating email on partij to exercise priority logic");
+                var partijEmailUuid = await TestDataHelper.CreateDigitaalAdresForPartijAsync(
+                    partijUuid, partijEmail, "email", "Partij e-mail test");
+                RegisterCleanup(async () => await TestDataHelper.DeleteDigitaalAdresAsync(partijEmailUuid));
+            }
 
             await Step("Setup contactverzoek with partij AND own digitale adressen on betrokkene");
-            var (contactmomentUuid, _) = await TestDataHelper.CreateContactverzoekWithPartijAndOwnAdressenAsync(
+            var (contactmomentUuid, _, digitaalAdresUuid) = await TestDataHelper.CreateContactverzoekWithPartijAndOwnAdressenAsync(
                 onderwerp, ownEmail);
+            RegisterCleanup(async () => await TestDataHelper.DeleteDigitaalAdresAsync(digitaalAdresUuid));
             RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(contactmomentUuid.ToString()));
 
             var internetaakUuid = await TestDataHelper.GetInternetaakUuidFromContactmomentAsync(contactmomentUuid);
@@ -165,11 +179,8 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
         public async Task Medewerker_ZietLegeContactsectie_WanneerPartijGeenAdressenHeeft()
         {
             // This scenario requires a partij without digitale adressen in the test environment.
-            // The unit tests (InternetaakDetailsServiceFallbackTests.Get_ReturnsEmptyAdressen_WhenPartijHasNoAdressen)
-            // cover the server-side behavior. This E2E test validates the full stack.
-            //
-            // Setup: uses a partij that exists in OpenKlant but has no digitale adressen.
-            // If no such partij is available, this test should be marked Inconclusive.
+            // Setup: creates a partij that exists in OpenKlant but has no digitale adressen.
+            // If no such partij can be created, this test is marked Inconclusive.
 
             var onderwerp = $"E2E_Fallback_PartijZonderAdressen_{DateTime.UtcNow.Ticks}";
 
@@ -183,8 +194,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             catch (Exception ex)
             {
                 Assert.Inconclusive(
-                    $"Could not create partij without adressen in test environment: {ex.Message}. " +
-                    "This scenario is covered by unit tests.");
+                    $"Could not create partij without adressen in test environment: {ex.Message}.");
                 return;
             }
 

--- a/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/DigitaleAdressenFallbackScenarios.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/DigitaleAdressenFallbackScenarios.cs
@@ -1,0 +1,252 @@
+using InterneTaakAfhandeling.EndToEndTest.Infrastructure;
+using ITA.InterneTaakAfhandeling.EndToEndTest.Helpers;
+using Microsoft.Playwright;
+
+namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
+{
+    [TestClass]
+    [DoNotParallelize]
+    public class DigitaleAdressenFallbackScenarios : ITAPlaywrightTest
+    {
+        // Navigation helpers
+
+        private async Task<string> SetupAndNavigateToContactverzoekWithPartij(string onderwerp)
+        {
+            await Step("Setup contactverzoek with partij (betrokkene has no own adressen)");
+
+            // Ensure the test partij has digitale adressen (test env might not have them)
+            var partijUuid = await TestDataHelper.GetPartijUuidByBsnAsync();
+            var existingAdressen = await TestDataHelper.GetPartijDigitaleAdressenAsync(partijUuid);
+
+            if (!existingAdressen.Any(a => a.SoortDigitaalAdres == "email"))
+            {
+                await Step("Creating email on partij (not present in test env)");
+                var emailUuid = await TestDataHelper.CreateDigitaalAdresForPartijAsync(
+                    partijUuid, "klant-test@e2e-ita.nl", "email", "E-mail test");
+                RegisterCleanup(async () => await TestDataHelper.DeleteDigitaalAdresAsync(emailUuid));
+            }
+
+            if (!existingAdressen.Any(a => a.SoortDigitaalAdres == "telefoonnummer"))
+            {
+                await Step("Creating phone on partij (not present in test env)");
+                var phoneUuid = await TestDataHelper.CreateDigitaalAdresForPartijAsync(
+                    partijUuid, "0612345678", "telefoonnummer", "Mobiel test");
+                RegisterCleanup(async () => await TestDataHelper.DeleteDigitaalAdresAsync(phoneUuid));
+            }
+
+            var contactmomentUuid = await TestDataHelper.CreateContactverzoekWithAfdelingMedewerkerAndPartij(onderwerp);
+            RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(contactmomentUuid.ToString()));
+
+            var internetaakUuid = await TestDataHelper.GetInternetaakUuidFromContactmomentAsync(contactmomentUuid);
+            Assert.IsNotNull(internetaakUuid, "Internetaak UUID should be found");
+
+            var internetaak = await TestDataHelper.GetInternetaakByIdAsync(internetaakUuid.Value);
+            Assert.IsNotNull(internetaak.Nummer, "Internetaak nummer should be found");
+
+            await Step($"Navigate to contactverzoek by nummer: {internetaak.Nummer}");
+            await SafeGotoAsync($"/contactverzoek/{internetaak.Nummer}");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Expect(Page.GetContactmomentRegistrerenTab()).ToBeVisibleAsync();
+
+            return internetaak.Nummer!;
+        }
+
+        private async Task SafeGotoAsync(string url)
+        {
+            for (var attempt = 1; attempt <= 3; attempt++)
+            {
+                try
+                {
+                    await Page.GotoAsync(url);
+                    return;
+                }
+                catch (PlaywrightException)
+                {
+                    if (attempt < 3) await Task.Delay(1500);
+                    else throw;
+                }
+            }
+        }
+
+        private async Task AssertContactDetailsWithRetry(Func<Task> assertions)
+        {
+            try
+            {
+                await assertions();
+            }
+            catch (PlaywrightException)
+            {
+                await Step("Retrying after page reload (external API may be slow)");
+                await Page.ReloadAsync(new() { WaitUntil = WaitUntilState.NetworkIdle });
+                await Expect(Page.GetContactmomentRegistrerenTab()).ToBeVisibleAsync();
+                await assertions();
+            }
+        }
+
+        // Test methods
+
+        [TestMethod("Partij-adressen worden getoond bij afwezigheid eigen adressen betrokkene")]
+        public async Task Medewerker_ZietPartijAdressen_WanneerBetrokkeneGeenEigenAdressenHeeft()
+        {
+            var onderwerp = $"E2E_Fallback_PartijAdressen_{DateTime.UtcNow.Ticks}";
+            await SetupAndNavigateToContactverzoekWithPartij(onderwerp);
+
+            await Step("Verify partij e-mailadres is visible (not empty dash)");
+            await AssertContactDetailsWithRetry(async () =>
+            {
+                var emailValue = Page.GetEmailValue();
+                await Expect(emailValue).ToBeVisibleAsync();
+                var emailText = await emailValue.InnerTextAsync();
+                Assert.AreNotEqual("-", emailText.Trim(),
+                    "E-mailadres should show the partij's email, not a dash");
+                Assert.IsTrue(emailText.Contains("@"),
+                    $"E-mailadres should contain an email address, got: '{emailText}'");
+            });
+
+            await Step("Verify partij telefoonnummer is visible (not empty dash)");
+            var phoneValue = Page.GetTelefoonnummerValue();
+            await Expect(phoneValue).ToBeVisibleAsync();
+            var phoneText = await phoneValue.InnerTextAsync();
+            Assert.AreNotEqual("-", phoneText.Trim(),
+                "Telefoonnummer should show the partij's phone number, not a dash");
+        }
+
+        [TestMethod("Eigen adressen betrokkene hebben voorrang boven partij-adressen")]
+        public async Task Medewerker_ZietEigenAdressen_WanneerBetrokkeneEigenAdressenHeeft()
+        {
+            var onderwerp = $"E2E_Fallback_EigenAdressen_{DateTime.UtcNow.Ticks}";
+            var ownEmail = "eigen-test@e2e-ita.nl";
+
+            await Step("Setup contactverzoek with partij AND own digitale adressen on betrokkene");
+            var (contactmomentUuid, _) = await TestDataHelper.CreateContactverzoekWithPartijAndOwnAdressenAsync(
+                onderwerp, ownEmail);
+            RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(contactmomentUuid.ToString()));
+
+            var internetaakUuid = await TestDataHelper.GetInternetaakUuidFromContactmomentAsync(contactmomentUuid);
+            Assert.IsNotNull(internetaakUuid, "Internetaak UUID should be found");
+
+            var internetaak = await TestDataHelper.GetInternetaakByIdAsync(internetaakUuid.Value);
+            Assert.IsNotNull(internetaak.Nummer, "Internetaak nummer should be found");
+
+            await Step($"Navigate to contactverzoek by nummer: {internetaak.Nummer}");
+            await SafeGotoAsync($"/contactverzoek/{internetaak.Nummer}");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Expect(Page.GetContactmomentRegistrerenTab()).ToBeVisibleAsync();
+
+            await Step("Verify only own e-mailadres of betrokkene is shown");
+            await AssertContactDetailsWithRetry(async () =>
+            {
+                var emailValue = Page.GetEmailValue();
+                await Expect(emailValue).ToBeVisibleAsync();
+                await Expect(emailValue).ToHaveTextAsync(ownEmail);
+            });
+        }
+
+        [TestMethod("Lege contactsectie zonder partij-koppeling")]
+        public async Task Medewerker_ZietLegeContactsectie_WanneerGeenPartijEnGeenAdressen()
+        {
+            var onderwerp = $"E2E_Fallback_GeenPartij_{DateTime.UtcNow.Ticks}";
+
+            await Step("Setup contactverzoek without partij (no digitale adressen)");
+            var contactmomentUuid = await TestDataHelper.CreateContactverzoek(onderwerp, attachZaak: false);
+            RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(contactmomentUuid.ToString()));
+
+            var internetaakUuid = await TestDataHelper.GetInternetaakUuidFromContactmomentAsync(contactmomentUuid);
+            Assert.IsNotNull(internetaakUuid, "Internetaak UUID should be found");
+
+            var internetaak = await TestDataHelper.GetInternetaakByIdAsync(internetaakUuid.Value);
+            Assert.IsNotNull(internetaak.Nummer, "Internetaak nummer should be found");
+
+            await Step($"Navigate to contactverzoek by nummer: {internetaak.Nummer}");
+            await SafeGotoAsync($"/contactverzoek/{internetaak.Nummer}");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Expect(Page.GetContactmomentRegistrerenTab()).ToBeVisibleAsync();
+
+            await Step("Verify contactsectie shows dashes (empty state)");
+            await Expect(Page.GetEmailLabel()).ToBeVisibleAsync();
+            await Expect(Page.GetEmailValue()).ToHaveTextAsync("-");
+
+            await Expect(Page.GetTelefoonnummerLabel()).ToBeVisibleAsync();
+            await Expect(Page.GetTelefoonnummerValue()).ToHaveTextAsync("-");
+        }
+
+        [TestMethod("Lege contactsectie wanneer partij geen adressen heeft")]
+        public async Task Medewerker_ZietLegeContactsectie_WanneerPartijGeenAdressenHeeft()
+        {
+            // This scenario requires a partij without digitale adressen in the test environment.
+            // The unit tests (InternetaakDetailsServiceFallbackTests.Get_ReturnsEmptyAdressen_WhenPartijHasNoAdressen)
+            // cover the server-side behavior. This E2E test validates the full stack.
+            //
+            // Setup: uses a partij that exists in OpenKlant but has no digitale adressen.
+            // If no such partij is available, this test should be marked Inconclusive.
+
+            var onderwerp = $"E2E_Fallback_PartijZonderAdressen_{DateTime.UtcNow.Ticks}";
+
+            await Step("Create a partij without digitale adressen");
+            string? partijUuid;
+            try
+            {
+                partijUuid = await TestDataHelper.CreatePartijWithoutAdressenAsync();
+                RegisterCleanup(async () => await TestDataHelper.DeletePartijAsync(partijUuid));
+            }
+            catch (Exception ex)
+            {
+                Assert.Inconclusive(
+                    $"Could not create partij without adressen in test environment: {ex.Message}. " +
+                    "This scenario is covered by unit tests.");
+                return;
+            }
+
+            await Step("Setup contactverzoek with addressless partij");
+            var contactmomentUuid = await TestDataHelper.CreateContactverzoekWithSpecificPartijAsync(
+                onderwerp, partijUuid);
+            RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(contactmomentUuid.ToString()));
+
+            var internetaakUuid = await TestDataHelper.GetInternetaakUuidFromContactmomentAsync(contactmomentUuid);
+            Assert.IsNotNull(internetaakUuid, "Internetaak UUID should be found");
+
+            var internetaak = await TestDataHelper.GetInternetaakByIdAsync(internetaakUuid.Value);
+            Assert.IsNotNull(internetaak.Nummer, "Internetaak nummer should be found");
+
+            await Step($"Navigate to contactverzoek by nummer: {internetaak.Nummer}");
+            await SafeGotoAsync($"/contactverzoek/{internetaak.Nummer}");
+            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Expect(Page.GetContactmomentRegistrerenTab()).ToBeVisibleAsync();
+
+            await Step("Verify contactsectie shows dashes (partij has no adressen)");
+            await AssertContactDetailsWithRetry(async () =>
+            {
+                await Expect(Page.GetEmailValue()).ToHaveTextAsync("-");
+                await Expect(Page.GetTelefoonnummerValue()).ToHaveTextAsync("-");
+            });
+        }
+
+        [TestMethod("Geen herkomst-indicatie zichtbaar bij partij-adressen")]
+        public async Task Medewerker_ZietGeenHerkomstIndicatie_WanneerPartijAdressenGetoond()
+        {
+            var onderwerp = $"E2E_Fallback_GeenHerkomst_{DateTime.UtcNow.Ticks}";
+            await SetupAndNavigateToContactverzoekWithPartij(onderwerp);
+
+            await Step("Verify no source indication is visible (no 'partij' or 'bron' label)");
+            await AssertContactDetailsWithRetry(async () =>
+            {
+                // The contact section should show email and phone without any indication
+                // that the data comes from the partij rather than the betrokkene.
+                var contactSection = Page.Locator("div.ita-data-list__group").First;
+                var sectionText = await contactSection.InnerTextAsync();
+
+                Assert.IsFalse(sectionText.Contains("partij", StringComparison.OrdinalIgnoreCase),
+                    $"Contact section should not contain 'partij' source indication. Text: '{sectionText}'");
+                Assert.IsFalse(sectionText.Contains("bron", StringComparison.OrdinalIgnoreCase),
+                    $"Contact section should not contain 'bron' source indication. Text: '{sectionText}'");
+                Assert.IsFalse(sectionText.Contains("herkomst", StringComparison.OrdinalIgnoreCase),
+                    $"Contact section should not contain 'herkomst' source indication. Text: '{sectionText}'");
+
+                // Verify the standard field labels are present (Klantnaam, E-mailadres, Telefoonnummer)
+                await Expect(Page.GetKlantnaamLabel()).ToBeVisibleAsync();
+                await Expect(Page.GetEmailLabel()).ToBeVisibleAsync();
+                await Expect(Page.GetTelefoonnummerLabel()).ToBeVisibleAsync();
+            });
+        }
+    }
+}

--- a/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/DigitaleAdressenFallbackScenarios.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/DigitaleAdressenFallbackScenarios.cs
@@ -34,21 +34,14 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
                 RegisterCleanup(async () => await TestDataHelper.DeleteDigitaalAdresAsync(phoneUuid));
             }
 
-            var contactmomentUuid = await TestDataHelper.CreateContactverzoekWithAfdelingMedewerkerAndPartij(onderwerp);
+            var (contactmomentUuid, nummer) = await TestDataHelper.CreateContactverzoekWithAfdelingMedewerkerAndPartij(onderwerp);
             RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(contactmomentUuid.ToString()));
 
-            var internetaakUuid = await TestDataHelper.GetInternetaakUuidFromContactmomentAsync(contactmomentUuid);
-            Assert.IsNotNull(internetaakUuid, "Internetaak UUID should be found");
-
-            var internetaak = await TestDataHelper.GetInternetaakByIdAsync(internetaakUuid.Value);
-            Assert.IsNotNull(internetaak.Nummer, "Internetaak nummer should be found");
-
-            await Step($"Navigate to contactverzoek by nummer: {internetaak.Nummer}");
-            await SafeGotoAsync($"/contactverzoek/{internetaak.Nummer}");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Step($"Navigate to contactverzoek by nummer: {nummer}");
+            await SafeGotoAsync($"/contactverzoek/{nummer}");
             await Expect(Page.GetContactmomentRegistrerenTab()).ToBeVisibleAsync();
 
-            return internetaak.Nummer!;
+            return nummer;
         }
 
         private async Task SafeGotoAsync(string url)
@@ -77,7 +70,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             catch (PlaywrightException)
             {
                 await Step("Retrying after page reload (external API may be slow)");
-                await Page.ReloadAsync(new() { WaitUntil = WaitUntilState.NetworkIdle });
+                await Page.ReloadAsync(new() { WaitUntil = WaitUntilState.DOMContentLoaded });
                 await Expect(Page.GetContactmomentRegistrerenTab()).ToBeVisibleAsync();
                 await assertions();
             }
@@ -130,7 +123,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
 
             await Step($"Navigate to contactverzoek by nummer: {internetaak.Nummer}");
             await SafeGotoAsync($"/contactverzoek/{internetaak.Nummer}");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
             await Expect(Page.GetContactmomentRegistrerenTab()).ToBeVisibleAsync();
 
             await Step("Verify only own e-mailadres of betrokkene is shown");
@@ -159,7 +151,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
 
             await Step($"Navigate to contactverzoek by nummer: {internetaak.Nummer}");
             await SafeGotoAsync($"/contactverzoek/{internetaak.Nummer}");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
             await Expect(Page.GetContactmomentRegistrerenTab()).ToBeVisibleAsync();
 
             await Step("Verify contactsectie shows dashes (empty state)");
@@ -210,7 +201,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
 
             await Step($"Navigate to contactverzoek by nummer: {internetaak.Nummer}");
             await SafeGotoAsync($"/contactverzoek/{internetaak.Nummer}");
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
             await Expect(Page.GetContactmomentRegistrerenTab()).ToBeVisibleAsync();
 
             await Step("Verify contactsectie shows dashes (partij has no adressen)");

--- a/InterneTaakAfhandeling.EndToEndTest/Infrastructure/TestDataHelper.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Infrastructure/TestDataHelper.cs
@@ -851,8 +851,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
             string ownEmail,
             string bsn = TestDataConstants.Partijen.TestBsn)
         {
-            await CleanupExistingContactmomenten(onderwerp);
-
             var partij = await GetPartijByBsn(bsn);
             var contactmoment = await CreateContactmoment(onderwerp,
                 "This is a test contact request created during an end-to-end test run.",
@@ -874,15 +872,14 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
             var medewerkerActor = await GetOrCreateMedewerkerActor("icatt-integratie-test@icatt.nl");
 
             var nummer = GenerateUniqueInternetaakNummer();
-            await CreateInternetaakIfNotExists(
+            await CreateInternetaak(
                 nummer,
                 contactmoment.Uuid,
                 new List<Guid>
                 {
                     Guid.Parse(medewerkerActor.Uuid),
                     Guid.Parse(afdelingActor.Uuid)
-                },
-                isExplicitNummer: true);
+                });
 
             return (contactmoment.Uuid, betrokkene.Uuid);
         }
@@ -944,8 +941,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
         /// </summary>
         public async Task<Guid> CreateContactverzoekWithSpecificPartijAsync(string onderwerp, string partijUuid)
         {
-            await CleanupExistingContactmomenten(onderwerp);
-
             var contactmoment = await CreateContactmoment(onderwerp,
                 "This is a test contact request created during an end-to-end test run.",
                 klantnaam: null);
@@ -959,15 +954,14 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
             var medewerkerActor = await GetOrCreateMedewerkerActor("icatt-integratie-test@icatt.nl");
 
             var nummer = GenerateUniqueInternetaakNummer();
-            await CreateInternetaakIfNotExists(
+            await CreateInternetaak(
                 nummer,
                 contactmoment.Uuid,
                 new List<Guid>
                 {
                     Guid.Parse(medewerkerActor.Uuid),
                     Guid.Parse(afdelingActor.Uuid)
-                },
-                isExplicitNummer: true);
+                });
 
             return contactmoment.Uuid;
         }

--- a/InterneTaakAfhandeling.EndToEndTest/Infrastructure/TestDataHelper.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Infrastructure/TestDataHelper.cs
@@ -844,9 +844,9 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
 
         /// <summary>
         /// Creates a contactverzoek with a partij and betrokkene's own digitale adressen.
-        /// Returns (contactmomentUuid, betrokkeneUuid) for assertions and cleanup.
+        /// Returns (contactmomentUuid, betrokkeneUuid, digitaalAdresUuid) for assertions and cleanup.
         /// </summary>
-        public async Task<(Guid contactmomentUuid, string betrokkeneUuid)> CreateContactverzoekWithPartijAndOwnAdressenAsync(
+        public async Task<(Guid contactmomentUuid, string betrokkeneUuid, string digitaalAdresUuid)> CreateContactverzoekWithPartijAndOwnAdressenAsync(
             string onderwerp,
             string ownEmail,
             string bsn = TestDataConstants.Partijen.TestBsn)
@@ -859,7 +859,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
             var betrokkene = await AttachPartijToContactmoment(Guid.Parse(partij.Uuid), contactmoment.Uuid);
 
             // Create own digitale adres on the betrokkene
-            await CreateDigitaalAdresForBetrokkeneAsync(
+            var digitaalAdresUuid = await CreateDigitaalAdresForBetrokkeneAsync(
                 betrokkene.Uuid,
                 ownEmail,
                 "email",
@@ -881,7 +881,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
                     Guid.Parse(afdelingActor.Uuid)
                 });
 
-            return (contactmoment.Uuid, betrokkene.Uuid);
+            return (contactmoment.Uuid, betrokkene.Uuid, digitaalAdresUuid);
         }
 
         /// <summary>
@@ -894,7 +894,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
             {
                 digitaleAdressen = Array.Empty<object>(),
                 voorkeursDigitaalAdres = (object?)null,
-                rpipiereesvertegenwoordigerVan = Array.Empty<object>(),
                 partijIdentificatoren = Array.Empty<object>(),
                 soortPartij = "persoon",
                 indicatieActief = true,

--- a/InterneTaakAfhandeling.EndToEndTest/Infrastructure/TestDataHelper.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Infrastructure/TestDataHelper.cs
@@ -9,6 +9,7 @@ using InterneTaakAfhandeling.Common.Services.Zgw;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Net.Http.Headers;
+using System.Net.Http.Json;
 
 namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
 {
@@ -17,6 +18,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
         private OpenKlantApiClient OpenKlantApiClient { get; }
         private ObjectApiClient ObjectApiClient { get; }
         private ZakenApiClient ZakenApiClient { get; }
+        private HttpClient OpenKlantHttpClient { get; }
         private string Username { get; }
         private ILogger<TestDataHelper> Logger { get; }
 
@@ -40,11 +42,19 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
             Logger = loggerFactory.CreateLogger<TestDataHelper>();
 
             OpenKlantApiClient = CreateOpenKlantApiClient(openKlantBaseUrl, openKlantApiKey, loggerFactory);
+            OpenKlantHttpClient = CreateOpenKlantHttpClient(openKlantBaseUrl, openKlantApiKey);
             ObjectApiClient = CreateObjectApiClient(objectenApiBaseUrl, objectenApiKey, loggerFactory, l, a, g, m);
             ZakenApiClient = CreateZakenApiClient(zakenApiBaseUrl, zakenApiKey, zakenApiClientId, loggerFactory);
         }
 
         // Client Creation
+
+        private static HttpClient CreateOpenKlantHttpClient(string baseUrl, string apiKey)
+        {
+            var httpClient = new HttpClient { BaseAddress = new Uri(baseUrl) };
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Token", apiKey);
+            return httpClient;
+        }
 
         private static OpenKlantApiClient CreateOpenKlantApiClient(
             string baseUrl, 
@@ -736,6 +746,230 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
                     onderwerpobject.Uuid, onderwerpobject.Onderwerpobjectidentificator?.ObjectId);
                 return null;
             }
+        }
+
+        // Digitale Adressen Operations
+
+        /// <summary>
+        /// Creates a digitale adres linked to a betrokkene via the OpenKlant API.
+        /// Returns the UUID of the created digitale adres for cleanup.
+        /// </summary>
+        public async Task<string> CreateDigitaalAdresForBetrokkeneAsync(
+            string betrokkeneUuid,
+            string adres,
+            string soortDigitaalAdres,
+            string omschrijving = "")
+        {
+            var request = new
+            {
+                verstrektDoorBetrokkene = new { uuid = betrokkeneUuid },
+                verstrektDoorPartij = (object?)null,
+                adres,
+                soortDigitaalAdres,
+                omschrijving
+            };
+
+            var response = await OpenKlantHttpClient.PostAsJsonAsync("digitaleadressen", request);
+            response.EnsureSuccessStatusCode();
+
+            var result = await response.Content.ReadFromJsonAsync<DigitaleAdres>();
+            Logger.LogInformation("Created digitale adres {Uuid} ({SoortDigitaalAdres}: {Adres}) for betrokkene {BetrokkeneUuid}",
+                result!.Uuid, soortDigitaalAdres, adres, betrokkeneUuid);
+
+            return result.Uuid;
+        }
+
+        /// <summary>
+        /// Creates a digitale adres linked to a partij via the OpenKlant API.
+        /// Returns the UUID of the created digitale adres for cleanup.
+        /// </summary>
+        public async Task<string> CreateDigitaalAdresForPartijAsync(
+            string partijUuid,
+            string adres,
+            string soortDigitaalAdres,
+            string omschrijving = "")
+        {
+            var request = new
+            {
+                verstrektDoorBetrokkene = (object?)null,
+                verstrektDoorPartij = new { uuid = partijUuid },
+                adres,
+                soortDigitaalAdres,
+                omschrijving
+            };
+
+            var response = await OpenKlantHttpClient.PostAsJsonAsync("digitaleadressen", request);
+            response.EnsureSuccessStatusCode();
+
+            var result = await response.Content.ReadFromJsonAsync<DigitaleAdres>();
+            Logger.LogInformation("Created digitale adres {Uuid} ({SoortDigitaalAdres}: {Adres}) for partij {PartijUuid}",
+                result!.Uuid, soortDigitaalAdres, adres, partijUuid);
+
+            return result.Uuid;
+        }
+
+        /// <summary>
+        /// Looks up a partij by BSN and returns the UUID.
+        /// </summary>
+        public async Task<string> GetPartijUuidByBsnAsync(string bsn = TestDataConstants.Partijen.TestBsn)
+        {
+            var partij = await GetPartijByBsn(bsn);
+            return partij.Uuid;
+        }
+
+        /// <summary>
+        /// Returns existing digitale adressen for a partij.
+        /// </summary>
+        public Task<List<DigitaleAdres>> GetPartijDigitaleAdressenAsync(string partijUuid)
+        {
+            return OpenKlantApiClient.GetPartijDigitaleAdressenAsync(partijUuid);
+        }
+
+        /// <summary>
+        /// Deletes a digitale adres from the OpenKlant API.
+        /// </summary>
+        public async Task DeleteDigitaalAdresAsync(string uuid)
+        {
+            try
+            {
+                var response = await OpenKlantHttpClient.DeleteAsync($"digitaleadressen/{uuid}");
+                response.EnsureSuccessStatusCode();
+                Logger.LogInformation("Deleted digitale adres {Uuid}", uuid);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(ex, "Failed to delete digitale adres {Uuid}", uuid);
+            }
+        }
+
+        /// <summary>
+        /// Creates a contactverzoek with a partij and betrokkene's own digitale adressen.
+        /// Returns (contactmomentUuid, betrokkeneUuid) for assertions and cleanup.
+        /// </summary>
+        public async Task<(Guid contactmomentUuid, string betrokkeneUuid)> CreateContactverzoekWithPartijAndOwnAdressenAsync(
+            string onderwerp,
+            string ownEmail,
+            string bsn = TestDataConstants.Partijen.TestBsn)
+        {
+            await CleanupExistingContactmomenten(onderwerp);
+
+            var partij = await GetPartijByBsn(bsn);
+            var contactmoment = await CreateContactmoment(onderwerp,
+                "This is a test contact request created during an end-to-end test run.",
+                partij.Naam);
+
+            var betrokkene = await AttachPartijToContactmoment(Guid.Parse(partij.Uuid), contactmoment.Uuid);
+
+            // Create own digitale adres on the betrokkene
+            await CreateDigitaalAdresForBetrokkeneAsync(
+                betrokkene.Uuid,
+                ownEmail,
+                "email",
+                "Eigen e-mail");
+
+            var submitterActor = await GetOrCreateSubmitterActor();
+            await ConnectActorToContactmoment(submitterActor, contactmoment.Uuid);
+
+            var afdelingActor = await GetOrCreateAfdelingActor("Burgerzaken_ibz");
+            var medewerkerActor = await GetOrCreateMedewerkerActor("icatt-integratie-test@icatt.nl");
+
+            var nummer = GenerateUniqueInternetaakNummer();
+            await CreateInternetaakIfNotExists(
+                nummer,
+                contactmoment.Uuid,
+                new List<Guid>
+                {
+                    Guid.Parse(medewerkerActor.Uuid),
+                    Guid.Parse(afdelingActor.Uuid)
+                },
+                isExplicitNummer: true);
+
+            return (contactmoment.Uuid, betrokkene.Uuid);
+        }
+
+        /// <summary>
+        /// Creates a minimal partij without digitale adressen via the OpenKlant API.
+        /// Returns the UUID of the created partij for cleanup.
+        /// </summary>
+        public async Task<string> CreatePartijWithoutAdressenAsync()
+        {
+            var request = new
+            {
+                digitaleAdressen = Array.Empty<object>(),
+                voorkeursDigitaalAdres = (object?)null,
+                rpipiereesvertegenwoordigerVan = Array.Empty<object>(),
+                partijIdentificatoren = Array.Empty<object>(),
+                soortPartij = "persoon",
+                indicatieActief = true,
+                indicatieGeheimhouding = false,
+                voorkeurstaal = "nl",
+                bezoekadres = (object?)null,
+                correspondentieadres = (object?)null
+            };
+
+            var response = await OpenKlantHttpClient.PostAsJsonAsync("partijen", request);
+            response.EnsureSuccessStatusCode();
+
+            var result = await response.Content.ReadFromJsonAsync<Common.Services.OpenKlantApi.Models.Partij>();
+            Logger.LogInformation("Created partij without adressen: {Uuid}", result!.Uuid);
+            return result.Uuid;
+        }
+
+        /// <summary>
+        /// Deletes a partij from the OpenKlant API.
+        /// </summary>
+        public async Task DeletePartijAsync(string uuid)
+        {
+            try
+            {
+                var response = await OpenKlantHttpClient.DeleteAsync($"partijen/{uuid}");
+                if (response.IsSuccessStatusCode)
+                {
+                    Logger.LogInformation("Deleted partij {Uuid}", uuid);
+                }
+                else
+                {
+                    Logger.LogWarning("Failed to delete partij {Uuid}: {StatusCode}", uuid, response.StatusCode);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(ex, "Failed to delete partij {Uuid}", uuid);
+            }
+        }
+
+        /// <summary>
+        /// Creates a contactverzoek with a specific partij UUID (without BSN lookup).
+        /// Used for testing scenarios where the partij has specific characteristics.
+        /// </summary>
+        public async Task<Guid> CreateContactverzoekWithSpecificPartijAsync(string onderwerp, string partijUuid)
+        {
+            await CleanupExistingContactmomenten(onderwerp);
+
+            var contactmoment = await CreateContactmoment(onderwerp,
+                "This is a test contact request created during an end-to-end test run.",
+                klantnaam: null);
+
+            await AttachPartijToContactmoment(Guid.Parse(partijUuid), contactmoment.Uuid);
+
+            var submitterActor = await GetOrCreateSubmitterActor();
+            await ConnectActorToContactmoment(submitterActor, contactmoment.Uuid);
+
+            var afdelingActor = await GetOrCreateAfdelingActor("Burgerzaken_ibz");
+            var medewerkerActor = await GetOrCreateMedewerkerActor("icatt-integratie-test@icatt.nl");
+
+            var nummer = GenerateUniqueInternetaakNummer();
+            await CreateInternetaakIfNotExists(
+                nummer,
+                contactmoment.Uuid,
+                new List<Guid>
+                {
+                    Guid.Parse(medewerkerActor.Uuid),
+                    Guid.Parse(afdelingActor.Uuid)
+                },
+                isExplicitNummer: true);
+
+            return contactmoment.Uuid;
         }
 
     }


### PR DESCRIPTION
## Summary

Verifies that the partij digitale adressen fallback logic (implemented in #445 and #446) works correctly in the deployed test environment. Ensures that when a betrokkene has no own digital addresses, the system falls back to the linked partij's addresses — and that own addresses always take priority.

Part of Feature #367.

## Changes

- **New test class `DigitaleAdressenFallbackScenarios`**: 4 E2E scenarios covering partij fallback, own-address priority, empty state (no partij), and empty state (partij without addresses)
- **TestDataHelper extensions**: new methods for creating contactverzoeken with specific partij configurations, managing digitale adressen on betrokkenen and partijen, and creating/deleting partijen without addresses
- **Infrastructure alignment**: adapted to use unique internetaakNummer pattern and removed NetworkIdle waits (consistent with fix/e2e-test-flakiness-2 base)

## Test plan

- [x] Partij-adressen getoond bij afwezigheid eigen adressen betrokkene
- [x] Eigen adressen betrokkene hebben voorrang
- [x] Lege contactsectie zonder adressen (betrokkene niet gekoppeld aan partij)
- [x] Lege contactsectie met partij zonder adressen
- [x] Geen herkomst-indicatie zichtbaar

## Related

Closes #447