### PR TITLE
docs: steering doc refinements (controller responsibility + feature completion checklist)

### DIFF
--- a/docs/steering/QA.md
+++ b/docs/steering/QA.md
@@ -88,6 +88,20 @@ A Feature is only considered **fully complete** when both phases are done:
 1. ✅ Phase 1 — implementation verified and merged to main
 2. ✅ Phase 2 — E2E tests written, passing, and committed
 
+### Feature Completion Checklist
+
+In addition to the two verification phases, every Feature must satisfy these items before it can be closed. Each item is "if applicable" — skip items that don't apply to the Feature, but document why.
+
+- [ ] **Changelog** — An entry has been added to the top of the changelog with the feature/bug name and a link to the GitHub issue. If there are new environment variables or other upgrade-relevant changes, they are mentioned here.
+- [ ] **Manual** — Installation & configuration manual have been updated. Environment variables and anything else needed to install/run ITA are explained.
+- [ ] **Helm** — New release variables have been included in the Helm charts/values files.
+- [ ] **Readme** — README has been updated with information on how to run the applications locally.
+- [ ] **User secrets** — User secrets in 1Password have been added/updated.
+- [ ] **Decision record** — Any significant architectural or design decisions have been documented in `docs/decision-record/`.
+- [ ] **Cleanup** — Branches, test data, temporary copies of databases, files, and temporary K8S clusters have been cleaned up.
+- [ ] **UX** — Significant design changes have been checked with a UX specialist.
+- [ ] **Test documentation** — Regression test scenarios not covered by automated tests, known issues, and things deliberately not tested are documented.
+
 ---
 
 ## Gherkin → Test Mapping

--- a/docs/steering/TECH.md
+++ b/docs/steering/TECH.md
@@ -137,8 +137,7 @@ npm run format:ci    # Prettier check without writing
 - **Nullable:** Enabled project-wide — no suppression without justification
 - **Feature structure:**
   - `{Feature}Controller.cs` — API endpoint (inherits `ControllerBase`)
-  - `I{Feature}Service.cs` + `{Feature}Service.cs` — Business logic
-  - `{Feature}Model.cs` — Request/response DTOs
+  - Additional Service (`I{Feature}Service.cs` + `{Feature}Service.cs`) and Model classes can be added as needed to keep the feature organized and clean.
 - **Controller vs Service responsibility:** In a vertical slice architecture each feature decides what fits best. As a general guideline: services own domain logic (fetching, orchestrating, validating), while presentation mapping (e.g. `ToResponse`-style DTO transformations) often fits naturally in the controller. Neither placement is wrong — choose what keeps the feature simple and readable.
 - **Routing:** `[Route("api/{resource}")]`, lowercase URLs
 - **DI registration:** All services in `Config/ServiceCollectionExtensions.cs` as `AddScoped`

--- a/docs/steering/TECH.md
+++ b/docs/steering/TECH.md
@@ -139,7 +139,7 @@ npm run format:ci    # Prettier check without writing
   - `{Feature}Controller.cs` — API endpoint (inherits `ControllerBase`)
   - `I{Feature}Service.cs` + `{Feature}Service.cs` — Business logic
   - `{Feature}Model.cs` — Request/response DTOs
-- **Controller vs Service responsibility:** The service owns domain logic (fetching, orchestrating, validating). The controller owns the HTTP concern **including presentation mapping** — transforming domain models into response DTOs is a controller responsibility, not business logic. Keep `ToResponse`-style mappers in the controller.
+- **Controller vs Service responsibility:** In a vertical slice architecture each feature decides what fits best. As a general guideline: services own domain logic (fetching, orchestrating, validating), while presentation mapping (e.g. `ToResponse`-style DTO transformations) often fits naturally in the controller. Neither placement is wrong — choose what keeps the feature simple and readable.
 - **Routing:** `[Route("api/{resource}")]`, lowercase URLs
 - **DI registration:** All services in `Config/ServiceCollectionExtensions.cs` as `AddScoped`
 

--- a/docs/steering/TECH.md
+++ b/docs/steering/TECH.md
@@ -139,6 +139,7 @@ npm run format:ci    # Prettier check without writing
   - `{Feature}Controller.cs` — API endpoint (inherits `ControllerBase`)
   - `I{Feature}Service.cs` + `{Feature}Service.cs` — Business logic
   - `{Feature}Model.cs` — Request/response DTOs
+- **Controller vs Service responsibility:** The service owns domain logic (fetching, orchestrating, validating). The controller owns the HTTP concern **including presentation mapping** — transforming domain models into response DTOs is a controller responsibility, not business logic. Keep `ToResponse`-style mappers in the controller.
 - **Routing:** `[Route("api/{resource}")]`, lowercase URLs
 - **DI registration:** All services in `Config/ServiceCollectionExtensions.cs` as `AddScoped`
 


### PR DESCRIPTION
## Summary

Two refinements to the steering docs based on learnings from PR #473 review.

### TECH.md — Controller vs Service responsibility

During the #473 review, the existing role labels ("Controller = endpoint, Service = business logic") were interpreted as meaning all logic must live in the service. But the doc never explicitly stated that — it just labelled the roles. Presentation mapping (domain model → response DTO) is a controller concern. This addition makes that explicit, preventing future reviewers from flagging `ToResponse`-style mappers as misplaced business logic.

### QA.md — Feature Completion Checklist

Adds a checklist of non-code deliverables (changelog, manual, helm, readme, user secrets, decision records, cleanup, UX review, test documentation) that must be satisfied before closing a Feature. Each item is "if applicable."