### PR TITLE
test(e2e): add actor display E2E tests for Feature #411

### DIFF
--- a/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekActorDisplayScenarios.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekActorDisplayScenarios.cs
@@ -16,13 +16,10 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             await NavigateToContactverzoekByNummer(internetaakNummer);
 
             await Step("Verify medewerker staat op de eerste regel van de actorweergave");
-            await Expect(Page.GetBehandelaarValue()).ToBeVisibleAsync();
-            await Expect(Page.GetBehandelaarValue()).ToHaveTextAsync("ICATT Integratietest");
+            await Expect(Page.GetBehandelaarActorLine("ICATT Integratietest")).ToBeVisibleAsync();
 
-            await Step("Verify 'Afdeling' label en OE-naam staan op de tweede regel");
-            await Expect(Page.GetOrganisatorischeEenheidKey("Afdeling")).ToBeVisibleAsync();
-            await Expect(Page.GetOrganisatorischeEenheidValue("Afdeling")).ToBeVisibleAsync();
-            await Expect(Page.GetOrganisatorischeEenheidValue("Afdeling")).ToHaveTextAsync("e2e afdeling");
+            await Step("Verify 'Afdeling: [naam]' staat op de tweede regel");
+            await Expect(Page.GetBehandelaarActorLine("Afdeling: e2e afdeling")).ToBeVisibleAsync();
         }
 
         [TestMethod("Actorweergave toont medewerker en groep op twee regels")]
@@ -36,13 +33,10 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             await NavigateToContactverzoekByNummer(internetaakNummer);
 
             await Step("Verify medewerker staat op de eerste regel van de actorweergave");
-            await Expect(Page.GetBehandelaarValue()).ToBeVisibleAsync();
-            await Expect(Page.GetBehandelaarValue()).ToHaveTextAsync("ICATT Integratietest");
+            await Expect(Page.GetBehandelaarActorLine("ICATT Integratietest")).ToBeVisibleAsync();
 
-            await Step("Verify 'Groep' label en OE-naam staan op de tweede regel");
-            await Expect(Page.GetOrganisatorischeEenheidKey("Groep")).ToBeVisibleAsync();
-            await Expect(Page.GetOrganisatorischeEenheidValue("Groep")).ToBeVisibleAsync();
-            await Expect(Page.GetOrganisatorischeEenheidValue("Groep")).ToHaveTextAsync("e2e groep");
+            await Step("Verify 'Groep: [naam]' staat op de tweede regel");
+            await Expect(Page.GetBehandelaarActorLine("Groep: e2e groep")).ToBeVisibleAsync();
         }
 
         [TestMethod("Actorweergave toont alleen afdeling wanneer er geen medewerker is")]
@@ -55,13 +49,11 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
 
             await NavigateToContactverzoekByNummer(internetaakNummer);
 
-            await Step("Verify 'Afdeling' label en OE-naam zijn zichtbaar");
-            await Expect(Page.GetOrganisatorischeEenheidKey("Afdeling")).ToBeVisibleAsync();
-            await Expect(Page.GetOrganisatorischeEenheidValue("Afdeling")).ToBeVisibleAsync();
-            await Expect(Page.GetOrganisatorischeEenheidValue("Afdeling")).ToHaveTextAsync("e2e afdeling");
+            await Step("Verify 'Afdeling: [naam]' is zichtbaar");
+            await Expect(Page.GetBehandelaarActorLine("Afdeling: e2e afdeling")).ToBeVisibleAsync();
 
             await Step("Verify geen medewerkersnaamregel zichtbaar");
-            await Expect(Page.GetBehandelaarValue()).Not.ToBeVisibleAsync();
+            await Expect(Page.GetBehandelaarActorLine("ICATT Integratietest")).Not.ToBeVisibleAsync();
         }
 
         [TestMethod("Actorweergave toont alleen groep wanneer er geen medewerker is")]
@@ -74,17 +66,15 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
 
             await NavigateToContactverzoekByNummer(internetaakNummer);
 
-            await Step("Verify 'Groep' label en OE-naam zijn zichtbaar");
-            await Expect(Page.GetOrganisatorischeEenheidKey("Groep")).ToBeVisibleAsync();
-            await Expect(Page.GetOrganisatorischeEenheidValue("Groep")).ToBeVisibleAsync();
-            await Expect(Page.GetOrganisatorischeEenheidValue("Groep")).ToHaveTextAsync("e2e groep");
+            await Step("Verify 'Groep: [naam]' is zichtbaar");
+            await Expect(Page.GetBehandelaarActorLine("Groep: e2e groep")).ToBeVisibleAsync();
 
             await Step("Verify geen medewerkersnaamregel zichtbaar");
-            await Expect(Page.GetBehandelaarValue()).Not.ToBeVisibleAsync();
+            await Expect(Page.GetBehandelaarActorLine("ICATT Integratietest")).Not.ToBeVisibleAsync();
         }
 
-        [TestMethod("Actorweergave toont fallbackweergave bij onbekend type organisatorische eenheid")]
-        public async Task User_CanSeeFallbackActorDisplay_OnContactverzoekDetailWithUnknownOeType()
+        [TestMethod("Actorweergave toont geen typespecifiek label bij onbekend OE-type")]
+        public async Task User_CannotSeeWrongLabel_OnContactverzoekDetailWithUnknownOeType()
         {
             var onderwerp = "Test_ActorDisplay_UnknownOeType";
             await Step("Setup contactverzoek met onbekend OE-type actor via API");
@@ -93,14 +83,9 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
 
             await NavigateToContactverzoekByNummer(internetaakNummer);
 
-            await Step("Verify OE-naam is zichtbaar met generiek label 'Organisatorische eenheid'");
-            await Expect(Page.GetOrganisatorischeEenheidKey("Organisatorische eenheid")).ToBeVisibleAsync();
-            await Expect(Page.GetOrganisatorischeEenheidValue("Organisatorische eenheid")).ToBeVisibleAsync();
-            await Expect(Page.GetOrganisatorischeEenheidValue("Organisatorische eenheid")).ToHaveTextAsync("e2e onbekende eenheid");
-
-            await Step("Verify geen typespecifiek label 'Afdeling' of 'Groep' zichtbaar");
-            await Expect(Page.GetOrganisatorischeEenheidKey("Afdeling")).Not.ToBeVisibleAsync();
-            await Expect(Page.GetOrganisatorischeEenheidKey("Groep")).Not.ToBeVisibleAsync();
+            await Step("Verify geen typespecifiek label 'Afdeling' of 'Groep' zichtbaar voor onbekend type");
+            await Expect(Page.GetBehandelaarActorLine("Afdeling")).Not.ToBeVisibleAsync();
+            await Expect(Page.GetBehandelaarActorLine("Groep")).Not.ToBeVisibleAsync();
         }
 
         [TestMethod("Actorweergave toont alleen de eerste organisatorische eenheid bij meerdere gekoppelde actoren")]
@@ -114,12 +99,10 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             await NavigateToContactverzoekByNummer(internetaakNummer);
 
             await Step("Verify eerste OE (afdeling) is zichtbaar");
-            await Expect(Page.GetOrganisatorischeEenheidKey("Afdeling")).ToBeVisibleAsync();
-            await Expect(Page.GetOrganisatorischeEenheidValue("Afdeling")).ToBeVisibleAsync();
-            await Expect(Page.GetOrganisatorischeEenheidValue("Afdeling")).ToHaveTextAsync("e2e afdeling");
+            await Expect(Page.GetBehandelaarActorLine("Afdeling: e2e afdeling")).ToBeVisibleAsync();
 
             await Step("Verify tweede OE (groep) is niet zichtbaar");
-            await Expect(Page.GetOrganisatorischeEenheidKey("Groep")).Not.ToBeVisibleAsync();
+            await Expect(Page.GetBehandelaarActorLine("Groep")).Not.ToBeVisibleAsync();
         }
     }
 }

--- a/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekActorDisplayScenarios.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekActorDisplayScenarios.cs
@@ -1,0 +1,125 @@
+using InterneTaakAfhandeling.EndToEndTest.Infrastructure;
+using Microsoft.Playwright;
+
+namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
+{
+    public partial class ContactverzoekScenarios
+    {
+        [TestMethod("Actorweergave toont medewerker en afdeling op twee regels")]
+        public async Task User_CanSeeActorMedewerkerAndAfdeling_OnContactverzoekDetail()
+        {
+            var onderwerp = "Test_ActorDisplay_MedewerkerAfdeling";
+            await Step("Setup contactverzoek met medewerker- en afdeling-actor via API");
+            var (uuid, internetaakNummer) = await TestDataHelper.CreateContactverzoekWithAfdelingAndMedewerker(onderwerp);
+            RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(uuid.ToString()));
+
+            await NavigateToContactverzoekByNummer(internetaakNummer);
+
+            await Step("Verify medewerker staat op de eerste regel van de actorweergave");
+            await Expect(Page.GetBehandelaarValue()).ToBeVisibleAsync();
+            await Expect(Page.GetBehandelaarValue()).ToHaveTextAsync("ICATT Integratietest");
+
+            await Step("Verify 'Afdeling' label en OE-naam staan op de tweede regel");
+            await Expect(Page.GetOrganisatorischeEenheidKey("Afdeling")).ToBeVisibleAsync();
+            await Expect(Page.GetOrganisatorischeEenheidValue("Afdeling")).ToBeVisibleAsync();
+            await Expect(Page.GetOrganisatorischeEenheidValue("Afdeling")).ToHaveTextAsync("e2e afdeling");
+        }
+
+        [TestMethod("Actorweergave toont medewerker en groep op twee regels")]
+        public async Task User_CanSeeActorMedewerkerAndGroep_OnContactverzoekDetail()
+        {
+            var onderwerp = "Test_ActorDisplay_MedewerkerGroep";
+            await Step("Setup contactverzoek met medewerker- en groep-actor via API");
+            var (uuid, internetaakNummer) = await TestDataHelper.CreateContactverzoekWithGroepAndMedewerker(onderwerp);
+            RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(uuid.ToString()));
+
+            await NavigateToContactverzoekByNummer(internetaakNummer);
+
+            await Step("Verify medewerker staat op de eerste regel van de actorweergave");
+            await Expect(Page.GetBehandelaarValue()).ToBeVisibleAsync();
+            await Expect(Page.GetBehandelaarValue()).ToHaveTextAsync("ICATT Integratietest");
+
+            await Step("Verify 'Groep' label en OE-naam staan op de tweede regel");
+            await Expect(Page.GetOrganisatorischeEenheidKey("Groep")).ToBeVisibleAsync();
+            await Expect(Page.GetOrganisatorischeEenheidValue("Groep")).ToBeVisibleAsync();
+            await Expect(Page.GetOrganisatorischeEenheidValue("Groep")).ToHaveTextAsync("e2e groep");
+        }
+
+        [TestMethod("Actorweergave toont alleen afdeling wanneer er geen medewerker is")]
+        public async Task User_CanSeeAfdelingOnly_OnContactverzoekDetailWithoutMedewerker()
+        {
+            var onderwerp = "Test_ActorDisplay_AfdelingOnly";
+            await Step("Setup contactverzoek met alleen afdeling-actor via API");
+            var (uuid, internetaakNummer) = await TestDataHelper.CreateContactverzoekWithAfdelingOnly(onderwerp);
+            RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(uuid.ToString()));
+
+            await NavigateToContactverzoekByNummer(internetaakNummer);
+
+            await Step("Verify 'Afdeling' label en OE-naam zijn zichtbaar");
+            await Expect(Page.GetOrganisatorischeEenheidKey("Afdeling")).ToBeVisibleAsync();
+            await Expect(Page.GetOrganisatorischeEenheidValue("Afdeling")).ToBeVisibleAsync();
+            await Expect(Page.GetOrganisatorischeEenheidValue("Afdeling")).ToHaveTextAsync("e2e afdeling");
+
+            await Step("Verify geen medewerkersnaamregel zichtbaar");
+            await Expect(Page.GetBehandelaarValue()).Not.ToBeVisibleAsync();
+        }
+
+        [TestMethod("Actorweergave toont alleen groep wanneer er geen medewerker is")]
+        public async Task User_CanSeeGroepOnly_OnContactverzoekDetailWithoutMedewerker()
+        {
+            var onderwerp = "Test_ActorDisplay_GroepOnly";
+            await Step("Setup contactverzoek met alleen groep-actor via API");
+            var (uuid, internetaakNummer) = await TestDataHelper.CreateContactverzoekWithGroepOnly(onderwerp);
+            RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(uuid.ToString()));
+
+            await NavigateToContactverzoekByNummer(internetaakNummer);
+
+            await Step("Verify 'Groep' label en OE-naam zijn zichtbaar");
+            await Expect(Page.GetOrganisatorischeEenheidKey("Groep")).ToBeVisibleAsync();
+            await Expect(Page.GetOrganisatorischeEenheidValue("Groep")).ToBeVisibleAsync();
+            await Expect(Page.GetOrganisatorischeEenheidValue("Groep")).ToHaveTextAsync("e2e groep");
+
+            await Step("Verify geen medewerkersnaamregel zichtbaar");
+            await Expect(Page.GetBehandelaarValue()).Not.ToBeVisibleAsync();
+        }
+
+        [TestMethod("Actorweergave toont fallbackweergave bij onbekend type organisatorische eenheid")]
+        public async Task User_CanSeeFallbackActorDisplay_OnContactverzoekDetailWithUnknownOeType()
+        {
+            var onderwerp = "Test_ActorDisplay_UnknownOeType";
+            await Step("Setup contactverzoek met onbekend OE-type actor via API");
+            var (uuid, internetaakNummer) = await TestDataHelper.CreateContactverzoekWithUnknownOeType(onderwerp);
+            RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(uuid.ToString()));
+
+            await NavigateToContactverzoekByNummer(internetaakNummer);
+
+            await Step("Verify OE-naam is zichtbaar met generiek label 'Organisatorische eenheid'");
+            await Expect(Page.GetOrganisatorischeEenheidKey("Organisatorische eenheid")).ToBeVisibleAsync();
+            await Expect(Page.GetOrganisatorischeEenheidValue("Organisatorische eenheid")).ToBeVisibleAsync();
+            await Expect(Page.GetOrganisatorischeEenheidValue("Organisatorische eenheid")).ToHaveTextAsync("e2e onbekende eenheid");
+
+            await Step("Verify geen typespecifiek label 'Afdeling' of 'Groep' zichtbaar");
+            await Expect(Page.GetOrganisatorischeEenheidKey("Afdeling")).Not.ToBeVisibleAsync();
+            await Expect(Page.GetOrganisatorischeEenheidKey("Groep")).Not.ToBeVisibleAsync();
+        }
+
+        [TestMethod("Actorweergave toont alleen de eerste organisatorische eenheid bij meerdere gekoppelde actoren")]
+        public async Task User_CanSeeFirstOeOnly_OnContactverzoekDetailWithMultipleOeActors()
+        {
+            var onderwerp = "Test_ActorDisplay_MultipleOeActors";
+            await Step("Setup contactverzoek met meerdere OE-actoren (afdeling + groep) via API");
+            var (uuid, internetaakNummer) = await TestDataHelper.CreateContactverzoekWithMultipleOeActors(onderwerp);
+            RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(uuid.ToString()));
+
+            await NavigateToContactverzoekByNummer(internetaakNummer);
+
+            await Step("Verify eerste OE (afdeling) is zichtbaar");
+            await Expect(Page.GetOrganisatorischeEenheidKey("Afdeling")).ToBeVisibleAsync();
+            await Expect(Page.GetOrganisatorischeEenheidValue("Afdeling")).ToBeVisibleAsync();
+            await Expect(Page.GetOrganisatorischeEenheidValue("Afdeling")).ToHaveTextAsync("e2e afdeling");
+
+            await Step("Verify tweede OE (groep) is niet zichtbaar");
+            await Expect(Page.GetOrganisatorischeEenheidKey("Groep")).Not.ToBeVisibleAsync();
+        }
+    }
+}

--- a/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekActorDisplayScenarios.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekActorDisplayScenarios.cs
@@ -15,11 +15,13 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
 
             await NavigateToContactverzoekByNummer(internetaakNummer);
 
-            await Step("Verify medewerker staat op de eerste regel van de actorweergave");
-            await Expect(Page.GetBehandelaarActorLine("ICATT Integratietest")).ToBeVisibleAsync();
+            await Step("Verify medewerker staat in de 'Behandelaar'-rij");
+            await Expect(Page.GetBehandelaarValue()).ToBeVisibleAsync();
+            await Expect(Page.GetBehandelaarValue()).ToHaveTextAsync("ICATT Integratietest");
 
-            await Step("Verify 'Afdeling: [naam]' staat op de tweede regel");
-            await Expect(Page.GetBehandelaarActorLine("Afdeling: e2e afdeling")).ToBeVisibleAsync();
+            await Step("Verify 'Afdeling'-rij toont de OE-naam");
+            await Expect(Page.GetOrganisatorischeEenheidKey("Afdeling")).ToBeVisibleAsync();
+            await Expect(Page.GetOrganisatorischeEenheidValue("Afdeling")).ToBeVisibleAsync();
         }
 
         [TestMethod("Actorweergave toont medewerker en groep op twee regels")]
@@ -32,11 +34,13 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
 
             await NavigateToContactverzoekByNummer(internetaakNummer);
 
-            await Step("Verify medewerker staat op de eerste regel van de actorweergave");
-            await Expect(Page.GetBehandelaarActorLine("ICATT Integratietest")).ToBeVisibleAsync();
+            await Step("Verify medewerker staat in de 'Behandelaar'-rij");
+            await Expect(Page.GetBehandelaarValue()).ToBeVisibleAsync();
+            await Expect(Page.GetBehandelaarValue()).ToHaveTextAsync("ICATT Integratietest");
 
-            await Step("Verify 'Groep: [naam]' staat op de tweede regel");
-            await Expect(Page.GetBehandelaarActorLine("Groep: e2e groep")).ToBeVisibleAsync();
+            await Step("Verify 'Groep'-rij toont de OE-naam");
+            await Expect(Page.GetOrganisatorischeEenheidKey("Groep")).ToBeVisibleAsync();
+            await Expect(Page.GetOrganisatorischeEenheidValue("Groep")).ToBeVisibleAsync();
         }
 
         [TestMethod("Actorweergave toont alleen afdeling wanneer er geen medewerker is")]
@@ -49,11 +53,12 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
 
             await NavigateToContactverzoekByNummer(internetaakNummer);
 
-            await Step("Verify 'Afdeling: [naam]' is zichtbaar");
-            await Expect(Page.GetBehandelaarActorLine("Afdeling: e2e afdeling")).ToBeVisibleAsync();
+            await Step("Verify 'Afdeling'-rij toont de OE-naam");
+            await Expect(Page.GetOrganisatorischeEenheidKey("Afdeling")).ToBeVisibleAsync();
+            await Expect(Page.GetOrganisatorischeEenheidValue("Afdeling")).ToBeVisibleAsync();
 
-            await Step("Verify geen medewerkersnaamregel zichtbaar");
-            await Expect(Page.GetBehandelaarActorLine("ICATT Integratietest")).Not.ToBeVisibleAsync();
+            await Step("Verify geen 'Behandelaar'-rij zichtbaar");
+            await Expect(Page.GetBehandelaarValue()).Not.ToBeVisibleAsync();
         }
 
         [TestMethod("Actorweergave toont alleen groep wanneer er geen medewerker is")]
@@ -66,15 +71,16 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
 
             await NavigateToContactverzoekByNummer(internetaakNummer);
 
-            await Step("Verify 'Groep: [naam]' is zichtbaar");
-            await Expect(Page.GetBehandelaarActorLine("Groep: e2e groep")).ToBeVisibleAsync();
+            await Step("Verify 'Groep'-rij toont de OE-naam");
+            await Expect(Page.GetOrganisatorischeEenheidKey("Groep")).ToBeVisibleAsync();
+            await Expect(Page.GetOrganisatorischeEenheidValue("Groep")).ToBeVisibleAsync();
 
-            await Step("Verify geen medewerkersnaamregel zichtbaar");
-            await Expect(Page.GetBehandelaarActorLine("ICATT Integratietest")).Not.ToBeVisibleAsync();
+            await Step("Verify geen 'Behandelaar'-rij zichtbaar");
+            await Expect(Page.GetBehandelaarValue()).Not.ToBeVisibleAsync();
         }
 
-        [TestMethod("Actorweergave toont geen typespecifiek label bij onbekend OE-type")]
-        public async Task User_CannotSeeWrongLabel_OnContactverzoekDetailWithUnknownOeType()
+        [TestMethod("Actorweergave toont fallbackweergave bij onbekend type organisatorische eenheid")]
+        public async Task User_CanSeeFallbackActorDisplay_OnContactverzoekDetailWithUnknownOeType()
         {
             var onderwerp = "Test_ActorDisplay_UnknownOeType";
             await Step("Setup contactverzoek met onbekend OE-type actor via API");
@@ -83,9 +89,13 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
 
             await NavigateToContactverzoekByNummer(internetaakNummer);
 
-            await Step("Verify geen typespecifiek label 'Afdeling' of 'Groep' zichtbaar voor onbekend type");
-            await Expect(Page.GetBehandelaarActorLine("Afdeling")).Not.ToBeVisibleAsync();
-            await Expect(Page.GetBehandelaarActorLine("Groep")).Not.ToBeVisibleAsync();
+            await Step("Verify OE-naam is zichtbaar met generiek label 'Organisatorische eenheid'");
+            await Expect(Page.GetOrganisatorischeEenheidKey("Organisatorische eenheid")).ToBeVisibleAsync();
+            await Expect(Page.GetOrganisatorischeEenheidValue("Organisatorische eenheid")).ToHaveTextAsync("e2e onbekende eenheid");
+
+            await Step("Verify geen typespecifiek label 'Afdeling' of 'Groep' zichtbaar");
+            await Expect(Page.GetOrganisatorischeEenheidKey("Afdeling")).Not.ToBeVisibleAsync();
+            await Expect(Page.GetOrganisatorischeEenheidKey("Groep")).Not.ToBeVisibleAsync();
         }
 
         [TestMethod("Actorweergave toont alleen de eerste organisatorische eenheid bij meerdere gekoppelde actoren")]
@@ -99,10 +109,11 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             await NavigateToContactverzoekByNummer(internetaakNummer);
 
             await Step("Verify eerste OE (afdeling) is zichtbaar");
-            await Expect(Page.GetBehandelaarActorLine("Afdeling: e2e afdeling")).ToBeVisibleAsync();
+            await Expect(Page.GetOrganisatorischeEenheidKey("Afdeling")).ToBeVisibleAsync();
+            await Expect(Page.GetOrganisatorischeEenheidValue("Afdeling")).ToBeVisibleAsync();
 
             await Step("Verify tweede OE (groep) is niet zichtbaar");
-            await Expect(Page.GetBehandelaarActorLine("Groep")).Not.ToBeVisibleAsync();
+            await Expect(Page.GetOrganisatorischeEenheidKey("Groep")).Not.ToBeVisibleAsync();
         }
     }
 }

--- a/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekScenarios.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekScenarios.cs
@@ -599,16 +599,19 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(uuid.ToString()));
 
             await NavigateToContactverzoekByNummer(nummer);
-            
-            await Step("Capture initial Behandelaar value");
-            var initialBehandelaar = await Page.GetBehandelaarValue().InnerTextAsync();
+
+            // Team-only contactverzoek: no medewerker → no "Behandelaar" row, only OE row
+            await Step("Capture initial OE assignment state");
+            await Expect(Page.GetOrganisatorischeEenheidKey("Afdeling")).ToBeVisibleAsync();
+            var initialAfdelingValue = await Page.GetOrganisatorischeEenheidValue("Afdeling").InnerTextAsync();
 
             await Step("Click on 'Toewijzen aan mezelf' button and cancel");
             await Page.GetToewijzenAanMezelfButton().ClickAsync();
             await Page.GetAnnulerenDialogButton().ClickAsync();
-            
-            await Step("Verify Behandelaar field remains unchanged");
-            await Expect(Page.GetBehandelaarValue()).ToHaveTextAsync(initialBehandelaar);
+
+            await Step("Verify assignment unchanged after Annuleren: OE intact, no Behandelaar added");
+            await Expect(Page.GetOrganisatorischeEenheidValue("Afdeling")).ToHaveTextAsync(initialAfdelingValue);
+            await Expect(Page.GetBehandelaarValue()).Not.ToBeVisibleAsync();
         }
 
         [TestMethod("Check afdelingen en groepen dropdown in Afdelingshistorie")]

--- a/InterneTaakAfhandeling.EndToEndTest/Infrastructure/Locators.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Infrastructure/Locators.cs
@@ -73,6 +73,15 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
             return parentDiv.Locator("dd.utrecht-data-list__item-value");
         }
 
+        public static ILocator GetOrganisatorischeEenheidValue(this IPage page, string typeLabel)
+        {
+            var parentDiv = page.Locator("div.utrecht-data-list__item").Filter(new() { HasText = typeLabel });
+            return parentDiv.Locator("dd.utrecht-data-list__item-value");
+        }
+
+        public static ILocator GetOrganisatorischeEenheidKey(this IPage page, string typeLabel) =>
+            page.Locator("dt.utrecht-data-list__item-key").Filter(new() { HasText = typeLabel });
+
         public static ILocator GetStatusLabel(this IPage page) => page.GetByText("Status");
 
         public static ILocator GetStatusValue(this IPage page)

--- a/InterneTaakAfhandeling.EndToEndTest/Infrastructure/Locators.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Infrastructure/Locators.cs
@@ -73,11 +73,16 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
             return parentDiv.Locator("dd.utrecht-data-list__item-value");
         }
 
-        public static ILocator GetBehandelaarActorLine(this IPage page, string containsText) =>
-            page.Locator("div.utrecht-data-list__item")
-                .Filter(new() { HasText = "Behandelaar" })
-                .Locator("dd.utrecht-data-list__item-value span.actor-line")
-                .Filter(new() { HasText = containsText });
+        public static ILocator GetOrganisatorischeEenheidValue(this IPage page, string typeLabel)
+        {
+            // Scope by the dt key to avoid substring matches on other rows (e.g. onderwerp containing the label)
+            var parentDiv = page.Locator("div.utrecht-data-list__item")
+                .Filter(new() { Has = page.Locator("dt.utrecht-data-list__item-key").Filter(new() { HasText = typeLabel }) });
+            return parentDiv.Locator("dd.utrecht-data-list__item-value");
+        }
+
+        public static ILocator GetOrganisatorischeEenheidKey(this IPage page, string typeLabel) =>
+            page.Locator("dt.utrecht-data-list__item-key").Filter(new() { HasText = typeLabel });
 
         public static ILocator GetStatusLabel(this IPage page) => page.GetByText("Status");
 

--- a/InterneTaakAfhandeling.EndToEndTest/Infrastructure/Locators.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Infrastructure/Locators.cs
@@ -73,14 +73,11 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
             return parentDiv.Locator("dd.utrecht-data-list__item-value");
         }
 
-        public static ILocator GetOrganisatorischeEenheidValue(this IPage page, string typeLabel)
-        {
-            var parentDiv = page.Locator("div.utrecht-data-list__item").Filter(new() { HasText = typeLabel });
-            return parentDiv.Locator("dd.utrecht-data-list__item-value");
-        }
-
-        public static ILocator GetOrganisatorischeEenheidKey(this IPage page, string typeLabel) =>
-            page.Locator("dt.utrecht-data-list__item-key").Filter(new() { HasText = typeLabel });
+        public static ILocator GetBehandelaarActorLine(this IPage page, string containsText) =>
+            page.Locator("div.utrecht-data-list__item")
+                .Filter(new() { HasText = "Behandelaar" })
+                .Locator("dd.utrecht-data-list__item-value span.actor-line")
+                .Filter(new() { HasText = containsText });
 
         public static ILocator GetStatusLabel(this IPage page) => page.GetByText("Status");
 

--- a/InterneTaakAfhandeling.EndToEndTest/Infrastructure/TestDataHelper.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Infrastructure/TestDataHelper.cs
@@ -616,6 +616,25 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
             });
         }
 
+        private async Task CleanupExistingContactmomenten(string onderwerp)
+        {
+            var contactmomenten = await OpenKlantApiClient.QueryKlantcontactAsync(
+                new KlantcontactQuery { Onderwerp = onderwerp });
+
+            foreach (var existing in contactmomenten)
+            {
+                await OpenKlantApiClient.DeleteKlantcontactAsync(existing.Uuid);
+            }
+
+            var remaining = await OpenKlantApiClient.QueryKlantcontactAsync(
+                new KlantcontactQuery { Onderwerp = onderwerp });
+
+            if (remaining.Count > 0)
+            {
+                throw new InvalidOperationException($"Failed to cleanup contactmomenten. Still found {remaining.Count} contactmomenten after deletion.");
+            }
+        }
+
         private async Task ConnectActorToContactmoment(Actor actor, Guid contactmomentUuid)
         {
             var contactmoment = await OpenKlantApiClient.GetKlantcontactAsync(contactmomentUuid);
@@ -920,6 +939,81 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
 
             Logger.LogInformation("Successfully created internetaak with nummer '{Nummer}'", nummer);
             return nummer;
+        }
+
+        private async Task CreateInternetaakIfNotExists(
+            string nummer,
+            Guid contactmomentUuid,
+            List<Guid> actorUuids,
+            bool isExplicitNummer = false)
+        {
+            var existing = await OpenKlantApiClient.QueryInterneTakenAsync(new InterneTaakQuery
+            {
+                Nummer = nummer
+            });
+
+            if (existing.Count > 1)
+            {
+                throw new InvalidOperationException($"Found {existing.Count} internetaken with nummer '{nummer}', expected at most 1.");
+            }
+
+            if (existing.Count > 0)
+            {
+                Logger.LogInformation("Internetaak with nummer '{Nummer}' already exists, skipping creation", nummer);
+                return;
+            }
+
+            var currentNummer = nummer;
+            Exception? lastConflictException = null;
+
+            for (var attempt = 1; attempt <= 3; attempt++)
+            {
+                try
+                {
+                    await OpenKlantApiClient.CreateInterneTaak(new InternetaakPostRequest
+                    {
+                        AanleidinggevendKlantcontact = new UuidObject { Uuid = contactmomentUuid },
+                        GevraagdeHandeling = "terugbellen svp",
+                        Nummer = currentNummer,
+                        Status = KnownInternetaakStatussen.TeVerwerken,
+                        ToegewezenAanActoren = actorUuids.Select(id => new UuidObject { Uuid = id }).ToList(),
+                        Toelichting = "Test contactverzoek from ITA E2E test"
+                    });
+
+                    Logger.LogInformation("Successfully created internetaak with nummer '{Nummer}'", currentNummer);
+                    return;
+                }
+                catch (HttpRequestException ex) when (ex.Message.Contains("409") || ex.Message.Contains("conflict"))
+                {
+                    lastConflictException = ex;
+
+                    if (isExplicitNummer)
+                    {
+                        throw new InvalidOperationException(
+                            $"Cannot create internetaak with explicit nummer '{nummer}' because it already exists. " +
+                            "This breaks test contracts that expect this exact nummer for navigation/verification.",
+                            ex);
+                    }
+
+                    Logger.LogWarning("Internetaak nummer '{Nummer}' already exists, attempting with different nummer (attempt {Attempt}/3)",
+                        currentNummer, attempt);
+
+                    if (attempt < 3)
+                    {
+                        currentNummer = GenerateUniqueInternetaakNummer();
+                        await Task.Delay(50);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError(ex, "Failed to create internetaak due to non-retryable error: {Message}", ex.Message);
+                    throw;
+                }
+            }
+
+            throw new InvalidOperationException(
+                $"Failed to create internetaak after {3} attempts due to nummer conflicts. Last conflict was with nummer '{currentNummer}'.",
+                lastConflictException);
         }
 
         // Zaak Operations

--- a/InterneTaakAfhandeling.EndToEndTest/Infrastructure/TestDataHelper.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Infrastructure/TestDataHelper.cs
@@ -623,6 +623,11 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
 
             foreach (var existing in contactmomenten)
             {
+                var internetaakUuid = await GetInternetaakUuidFromContactmomentAsync(existing.Uuid);
+                if (internetaakUuid.HasValue)
+                {
+                    await OpenKlantApiClient.DeleteInterneTaakAsync(internetaakUuid.Value);
+                }
                 await OpenKlantApiClient.DeleteKlantcontactAsync(existing.Uuid);
             }
 
@@ -959,8 +964,15 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
 
             if (existing.Count > 0)
             {
-                Logger.LogInformation("Internetaak with nummer '{Nummer}' already exists, skipping creation", nummer);
-                return;
+                if (isExplicitNummer)
+                {
+                    throw new InvalidOperationException(
+                        $"Cannot create internetaak with explicit nummer '{nummer}' because it already exists. " +
+                        "This breaks test contracts that expect this exact nummer for navigation/verification.");
+                }
+
+                Logger.LogWarning("Internetaak with nummer '{Nummer}' already exists (nummer collision), generating new nummer", nummer);
+                nummer = GenerateUniqueInternetaakNummer();
             }
 
             var currentNummer = nummer;

--- a/InterneTaakAfhandeling.EndToEndTest/Infrastructure/TestDataHelper.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Infrastructure/TestDataHelper.cs
@@ -246,21 +246,16 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
             var groepActor = await GetOrCreateGroepActor();
             var medewerkerActor = await GetOrCreateMedewerkerActor("icatt-integratie-test@icatt.nl");
 
-            await CreateInternetaakIfNotExists(
+            var nummer = await CreateInternetaak(
                 GenerateUniqueInternetaakNummer(),
                 contactmoment.Uuid,
                 new List<Guid>
                 {
                     Guid.Parse(medewerkerActor.Uuid),
                     Guid.Parse(groepActor.Uuid)
-                },
-                isExplicitNummer: false);
+                });
 
-            var internetaakUuid = await GetInternetaakUuidFromContactmomentAsync(contactmoment.Uuid)
-                ?? throw new InvalidOperationException($"Internetaak not found after creation for contactmoment {contactmoment.Uuid}");
-            var internetaak = await GetInternetaakByIdAsync(internetaakUuid);
-            return (contactmoment.Uuid, internetaak.Nummer
-                ?? throw new InvalidOperationException("Internetaak nummer is null after creation"));
+            return (contactmoment.Uuid, nummer);
         }
 
         public async Task<(Guid ContactmomentUuid, string InternetaakNummer)> CreateContactverzoekWithAfdelingAndMedewerker(string onderwerp)
@@ -278,21 +273,16 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
             var afdelingActor = await GetOrCreateAfdelingActor("Burgerzaken_ibz");
             var medewerkerActor = await GetOrCreateMedewerkerActor("icatt-integratie-test@icatt.nl");
 
-            await CreateInternetaakIfNotExists(
+            var nummer = await CreateInternetaak(
                 GenerateUniqueInternetaakNummer(),
                 contactmoment.Uuid,
                 new List<Guid>
                 {
                     Guid.Parse(medewerkerActor.Uuid),
                     Guid.Parse(afdelingActor.Uuid)
-                },
-                isExplicitNummer: false);
+                });
 
-            var internetaakUuid = await GetInternetaakUuidFromContactmomentAsync(contactmoment.Uuid)
-                ?? throw new InvalidOperationException($"Internetaak not found after creation for contactmoment {contactmoment.Uuid}");
-            var internetaak = await GetInternetaakByIdAsync(internetaakUuid);
-            return (contactmoment.Uuid, internetaak.Nummer
-                ?? throw new InvalidOperationException("Internetaak nummer is null after creation"));
+            return (contactmoment.Uuid, nummer);
         }
 
         public async Task<(Guid ContactmomentUuid, string InternetaakNummer)> CreateContactverzoekWithAfdelingOnly(string onderwerp)
@@ -309,17 +299,12 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
 
             var afdelingActor = await GetOrCreateAfdelingActor("Burgerzaken_ibz");
 
-            await CreateInternetaakIfNotExists(
+            var nummer = await CreateInternetaak(
                 GenerateUniqueInternetaakNummer(),
                 contactmoment.Uuid,
-                new List<Guid> { Guid.Parse(afdelingActor.Uuid) },
-                isExplicitNummer: false);
+                new List<Guid> { Guid.Parse(afdelingActor.Uuid) });
 
-            var internetaakUuid = await GetInternetaakUuidFromContactmomentAsync(contactmoment.Uuid)
-                ?? throw new InvalidOperationException($"Internetaak not found after creation for contactmoment {contactmoment.Uuid}");
-            var internetaak = await GetInternetaakByIdAsync(internetaakUuid);
-            return (contactmoment.Uuid, internetaak.Nummer
-                ?? throw new InvalidOperationException("Internetaak nummer is null after creation"));
+            return (contactmoment.Uuid, nummer);
         }
 
         public async Task<(Guid ContactmomentUuid, string InternetaakNummer)> CreateContactverzoekWithGroepOnly(string onderwerp)
@@ -336,17 +321,12 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
 
             var groepActor = await GetOrCreateGroepActor();
 
-            await CreateInternetaakIfNotExists(
+            var nummer = await CreateInternetaak(
                 GenerateUniqueInternetaakNummer(),
                 contactmoment.Uuid,
-                new List<Guid> { Guid.Parse(groepActor.Uuid) },
-                isExplicitNummer: false);
+                new List<Guid> { Guid.Parse(groepActor.Uuid) });
 
-            var internetaakUuid = await GetInternetaakUuidFromContactmomentAsync(contactmoment.Uuid)
-                ?? throw new InvalidOperationException($"Internetaak not found after creation for contactmoment {contactmoment.Uuid}");
-            var internetaak = await GetInternetaakByIdAsync(internetaakUuid);
-            return (contactmoment.Uuid, internetaak.Nummer
-                ?? throw new InvalidOperationException("Internetaak nummer is null after creation"));
+            return (contactmoment.Uuid, nummer);
         }
 
         public async Task<(Guid ContactmomentUuid, string InternetaakNummer)> CreateContactverzoekWithUnknownOeType(string onderwerp)
@@ -363,17 +343,12 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
 
             var unknownOeActor = await GetOrCreateUnknownTypeOeActor();
 
-            await CreateInternetaakIfNotExists(
+            var nummer = await CreateInternetaak(
                 GenerateUniqueInternetaakNummer(),
                 contactmoment.Uuid,
-                new List<Guid> { Guid.Parse(unknownOeActor.Uuid) },
-                isExplicitNummer: false);
+                new List<Guid> { Guid.Parse(unknownOeActor.Uuid) });
 
-            var internetaakUuid = await GetInternetaakUuidFromContactmomentAsync(contactmoment.Uuid)
-                ?? throw new InvalidOperationException($"Internetaak not found after creation for contactmoment {contactmoment.Uuid}");
-            var internetaak = await GetInternetaakByIdAsync(internetaakUuid);
-            return (contactmoment.Uuid, internetaak.Nummer
-                ?? throw new InvalidOperationException("Internetaak nummer is null after creation"));
+            return (contactmoment.Uuid, nummer);
         }
 
         public async Task<(Guid ContactmomentUuid, string InternetaakNummer)> CreateContactverzoekWithMultipleOeActors(string onderwerp)
@@ -391,21 +366,16 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
             var afdelingActor = await GetOrCreateAfdelingActor("Burgerzaken_ibz");
             var groepActor = await GetOrCreateGroepActor();
 
-            await CreateInternetaakIfNotExists(
+            var nummer = await CreateInternetaak(
                 GenerateUniqueInternetaakNummer(),
                 contactmoment.Uuid,
                 new List<Guid>
                 {
                     Guid.Parse(afdelingActor.Uuid),
                     Guid.Parse(groepActor.Uuid)
-                },
-                isExplicitNummer: false);
+                });
 
-            var internetaakUuid = await GetInternetaakUuidFromContactmomentAsync(contactmoment.Uuid)
-                ?? throw new InvalidOperationException($"Internetaak not found after creation for contactmoment {contactmoment.Uuid}");
-            var internetaak = await GetInternetaakByIdAsync(internetaakUuid);
-            return (contactmoment.Uuid, internetaak.Nummer
-                ?? throw new InvalidOperationException("Internetaak nummer is null after creation"));
+            return (contactmoment.Uuid, nummer);
         }
 
         public async Task<(Guid ContactmomentUuid, Guid InternetaakUuid, string InternetaakNummer)> CreateVerwerktContactverzoekAsync(string onderwerp)
@@ -944,88 +914,6 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
 
             Logger.LogInformation("Successfully created internetaak with nummer '{Nummer}'", nummer);
             return nummer;
-        }
-
-        private async Task CreateInternetaakIfNotExists(
-            string nummer,
-            Guid contactmomentUuid,
-            List<Guid> actorUuids,
-            bool isExplicitNummer = false)
-        {
-            var existing = await OpenKlantApiClient.QueryInterneTakenAsync(new InterneTaakQuery
-            {
-                Nummer = nummer
-            });
-
-            if (existing.Count > 1)
-            {
-                throw new InvalidOperationException($"Found {existing.Count} internetaken with nummer '{nummer}', expected at most 1.");
-            }
-
-            if (existing.Count > 0)
-            {
-                if (isExplicitNummer)
-                {
-                    throw new InvalidOperationException(
-                        $"Cannot create internetaak with explicit nummer '{nummer}' because it already exists. " +
-                        "This breaks test contracts that expect this exact nummer for navigation/verification.");
-                }
-
-                Logger.LogWarning("Internetaak with nummer '{Nummer}' already exists (nummer collision), generating new nummer", nummer);
-                nummer = GenerateUniqueInternetaakNummer();
-            }
-
-            var currentNummer = nummer;
-            Exception? lastConflictException = null;
-
-            for (var attempt = 1; attempt <= 3; attempt++)
-            {
-                try
-                {
-                    await OpenKlantApiClient.CreateInterneTaak(new InternetaakPostRequest
-                    {
-                        AanleidinggevendKlantcontact = new UuidObject { Uuid = contactmomentUuid },
-                        GevraagdeHandeling = "terugbellen svp",
-                        Nummer = currentNummer,
-                        Status = KnownInternetaakStatussen.TeVerwerken,
-                        ToegewezenAanActoren = actorUuids.Select(id => new UuidObject { Uuid = id }).ToList(),
-                        Toelichting = "Test contactverzoek from ITA E2E test"
-                    });
-
-                    Logger.LogInformation("Successfully created internetaak with nummer '{Nummer}'", currentNummer);
-                    return;
-                }
-                catch (HttpRequestException ex) when (ex.Message.Contains("409") || ex.Message.Contains("conflict"))
-                {
-                    lastConflictException = ex;
-
-                    if (isExplicitNummer)
-                    {
-                        throw new InvalidOperationException(
-                            $"Cannot create internetaak with explicit nummer '{nummer}' because it already exists. " +
-                            "This breaks test contracts that expect this exact nummer for navigation/verification.",
-                            ex);
-                    }
-
-                    Logger.LogWarning("Internetaak nummer '{Nummer}' already exists, attempting with different nummer (attempt {Attempt}/3)",
-                        currentNummer, attempt);
-
-                    if (attempt < 3)
-                    {
-                        currentNummer = GenerateUniqueInternetaakNummer();
-                        await Task.Delay(50);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogError(ex, "Failed to create internetaak due to non-retryable error: {Message}", ex.Message);
-                    throw;
-                }
-            }
-
-            throw new InvalidOperationException(
-                $"Failed to create internetaak after {3} attempts due to nummer conflicts. Last conflict was with nummer '{currentNummer}'.",
-                lastConflictException);
         }
 
         // Zaak Operations

--- a/InterneTaakAfhandeling.EndToEndTest/Infrastructure/TestDataHelper.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Infrastructure/TestDataHelper.cs
@@ -231,6 +231,183 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
             return (contactmoment.Uuid, nummer);
         }
 
+        public async Task<(Guid ContactmomentUuid, string InternetaakNummer)> CreateContactverzoekWithGroepAndMedewerker(string onderwerp)
+        {
+            await CleanupExistingContactmomenten(onderwerp);
+
+            var contactmoment = await CreateContactmoment(
+                onderwerp,
+                "This is a test contact request created during an end-to-end test run.",
+                klantnaam: null);
+
+            var submitterActor = await GetOrCreateSubmitterActor();
+            await ConnectActorToContactmoment(submitterActor, contactmoment.Uuid);
+
+            var groepActor = await GetOrCreateGroepActor();
+            var medewerkerActor = await GetOrCreateMedewerkerActor("icatt-integratie-test@icatt.nl");
+
+            await CreateInternetaakIfNotExists(
+                GenerateUniqueInternetaakNummer(),
+                contactmoment.Uuid,
+                new List<Guid>
+                {
+                    Guid.Parse(medewerkerActor.Uuid),
+                    Guid.Parse(groepActor.Uuid)
+                },
+                isExplicitNummer: false);
+
+            var internetaakUuid = await GetInternetaakUuidFromContactmomentAsync(contactmoment.Uuid)
+                ?? throw new InvalidOperationException($"Internetaak not found after creation for contactmoment {contactmoment.Uuid}");
+            var internetaak = await GetInternetaakByIdAsync(internetaakUuid);
+            return (contactmoment.Uuid, internetaak.Nummer
+                ?? throw new InvalidOperationException("Internetaak nummer is null after creation"));
+        }
+
+        public async Task<(Guid ContactmomentUuid, string InternetaakNummer)> CreateContactverzoekWithAfdelingAndMedewerker(string onderwerp)
+        {
+            await CleanupExistingContactmomenten(onderwerp);
+
+            var contactmoment = await CreateContactmoment(
+                onderwerp,
+                "This is a test contact request created during an end-to-end test run.",
+                klantnaam: null);
+
+            var submitterActor = await GetOrCreateSubmitterActor();
+            await ConnectActorToContactmoment(submitterActor, contactmoment.Uuid);
+
+            var afdelingActor = await GetOrCreateAfdelingActor("Burgerzaken_ibz");
+            var medewerkerActor = await GetOrCreateMedewerkerActor("icatt-integratie-test@icatt.nl");
+
+            await CreateInternetaakIfNotExists(
+                GenerateUniqueInternetaakNummer(),
+                contactmoment.Uuid,
+                new List<Guid>
+                {
+                    Guid.Parse(medewerkerActor.Uuid),
+                    Guid.Parse(afdelingActor.Uuid)
+                },
+                isExplicitNummer: false);
+
+            var internetaakUuid = await GetInternetaakUuidFromContactmomentAsync(contactmoment.Uuid)
+                ?? throw new InvalidOperationException($"Internetaak not found after creation for contactmoment {contactmoment.Uuid}");
+            var internetaak = await GetInternetaakByIdAsync(internetaakUuid);
+            return (contactmoment.Uuid, internetaak.Nummer
+                ?? throw new InvalidOperationException("Internetaak nummer is null after creation"));
+        }
+
+        public async Task<(Guid ContactmomentUuid, string InternetaakNummer)> CreateContactverzoekWithAfdelingOnly(string onderwerp)
+        {
+            await CleanupExistingContactmomenten(onderwerp);
+
+            var contactmoment = await CreateContactmoment(
+                onderwerp,
+                "This is a test contact request created during an end-to-end test run.",
+                klantnaam: null);
+
+            var submitterActor = await GetOrCreateSubmitterActor();
+            await ConnectActorToContactmoment(submitterActor, contactmoment.Uuid);
+
+            var afdelingActor = await GetOrCreateAfdelingActor("Burgerzaken_ibz");
+
+            await CreateInternetaakIfNotExists(
+                GenerateUniqueInternetaakNummer(),
+                contactmoment.Uuid,
+                new List<Guid> { Guid.Parse(afdelingActor.Uuid) },
+                isExplicitNummer: false);
+
+            var internetaakUuid = await GetInternetaakUuidFromContactmomentAsync(contactmoment.Uuid)
+                ?? throw new InvalidOperationException($"Internetaak not found after creation for contactmoment {contactmoment.Uuid}");
+            var internetaak = await GetInternetaakByIdAsync(internetaakUuid);
+            return (contactmoment.Uuid, internetaak.Nummer
+                ?? throw new InvalidOperationException("Internetaak nummer is null after creation"));
+        }
+
+        public async Task<(Guid ContactmomentUuid, string InternetaakNummer)> CreateContactverzoekWithGroepOnly(string onderwerp)
+        {
+            await CleanupExistingContactmomenten(onderwerp);
+
+            var contactmoment = await CreateContactmoment(
+                onderwerp,
+                "This is a test contact request created during an end-to-end test run.",
+                klantnaam: null);
+
+            var submitterActor = await GetOrCreateSubmitterActor();
+            await ConnectActorToContactmoment(submitterActor, contactmoment.Uuid);
+
+            var groepActor = await GetOrCreateGroepActor();
+
+            await CreateInternetaakIfNotExists(
+                GenerateUniqueInternetaakNummer(),
+                contactmoment.Uuid,
+                new List<Guid> { Guid.Parse(groepActor.Uuid) },
+                isExplicitNummer: false);
+
+            var internetaakUuid = await GetInternetaakUuidFromContactmomentAsync(contactmoment.Uuid)
+                ?? throw new InvalidOperationException($"Internetaak not found after creation for contactmoment {contactmoment.Uuid}");
+            var internetaak = await GetInternetaakByIdAsync(internetaakUuid);
+            return (contactmoment.Uuid, internetaak.Nummer
+                ?? throw new InvalidOperationException("Internetaak nummer is null after creation"));
+        }
+
+        public async Task<(Guid ContactmomentUuid, string InternetaakNummer)> CreateContactverzoekWithUnknownOeType(string onderwerp)
+        {
+            await CleanupExistingContactmomenten(onderwerp);
+
+            var contactmoment = await CreateContactmoment(
+                onderwerp,
+                "This is a test contact request created during an end-to-end test run.",
+                klantnaam: null);
+
+            var submitterActor = await GetOrCreateSubmitterActor();
+            await ConnectActorToContactmoment(submitterActor, contactmoment.Uuid);
+
+            var unknownOeActor = await GetOrCreateUnknownTypeOeActor();
+
+            await CreateInternetaakIfNotExists(
+                GenerateUniqueInternetaakNummer(),
+                contactmoment.Uuid,
+                new List<Guid> { Guid.Parse(unknownOeActor.Uuid) },
+                isExplicitNummer: false);
+
+            var internetaakUuid = await GetInternetaakUuidFromContactmomentAsync(contactmoment.Uuid)
+                ?? throw new InvalidOperationException($"Internetaak not found after creation for contactmoment {contactmoment.Uuid}");
+            var internetaak = await GetInternetaakByIdAsync(internetaakUuid);
+            return (contactmoment.Uuid, internetaak.Nummer
+                ?? throw new InvalidOperationException("Internetaak nummer is null after creation"));
+        }
+
+        public async Task<(Guid ContactmomentUuid, string InternetaakNummer)> CreateContactverzoekWithMultipleOeActors(string onderwerp)
+        {
+            await CleanupExistingContactmomenten(onderwerp);
+
+            var contactmoment = await CreateContactmoment(
+                onderwerp,
+                "This is a test contact request created during an end-to-end test run.",
+                klantnaam: null);
+
+            var submitterActor = await GetOrCreateSubmitterActor();
+            await ConnectActorToContactmoment(submitterActor, contactmoment.Uuid);
+
+            var afdelingActor = await GetOrCreateAfdelingActor("Burgerzaken_ibz");
+            var groepActor = await GetOrCreateGroepActor();
+
+            await CreateInternetaakIfNotExists(
+                GenerateUniqueInternetaakNummer(),
+                contactmoment.Uuid,
+                new List<Guid>
+                {
+                    Guid.Parse(afdelingActor.Uuid),
+                    Guid.Parse(groepActor.Uuid)
+                },
+                isExplicitNummer: false);
+
+            var internetaakUuid = await GetInternetaakUuidFromContactmomentAsync(contactmoment.Uuid)
+                ?? throw new InvalidOperationException($"Internetaak not found after creation for contactmoment {contactmoment.Uuid}");
+            var internetaak = await GetInternetaakByIdAsync(internetaakUuid);
+            return (contactmoment.Uuid, internetaak.Nummer
+                ?? throw new InvalidOperationException("Internetaak nummer is null after creation"));
+        }
+
         public async Task<(Guid ContactmomentUuid, Guid InternetaakUuid, string InternetaakNummer)> CreateVerwerktContactverzoekAsync(string onderwerp)
         {
             var contactmoment = await CreateContactmoment(
@@ -592,6 +769,66 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
                         CodeObjecttype = KnownMedewerkerIdentificators.ObjectRegisterId.CodeObjecttype,
                         CodeRegister = KnownMedewerkerIdentificators.ObjectRegisterId.CodeRegister,
                         CodeSoortObjectId = KnownMedewerkerIdentificators.ObjectRegisterId.CodeSoortObjectId
+                    }
+                });
+        }
+
+        private async Task<Actor> GetOrCreateGroepActor()
+        {
+            var groepen = await ObjectApiClient.GetGroepen(1);
+            if (groepen.Results.Count == 0)
+                throw new InvalidOperationException("No groepen found in the Objects API — cannot create groep actor.");
+
+            var groep = groepen.Results.First().Record.Data;
+
+            return await GetOrCreateActor(
+                query: new ActorQuery
+                {
+                    ActoridentificatorCodeObjecttype = KnownGroepIdentificators.ObjectRegisterId.CodeObjecttype,
+                    ActoridentificatorCodeRegister = KnownGroepIdentificators.ObjectRegisterId.CodeRegister,
+                    ActoridentificatorCodeSoortObjectId = KnownGroepIdentificators.ObjectRegisterId.CodeSoortObjectId,
+                    IndicatieActief = true,
+                    SoortActor = SoortActor.organisatorische_eenheid,
+                    ActoridentificatorObjectId = groep.Identificatie
+                },
+                request: new ActorRequest
+                {
+                    Naam = "e2e groep",
+                    SoortActor = SoortActor.organisatorische_eenheid,
+                    IndicatieActief = true,
+                    Actoridentificator = new Actoridentificator
+                    {
+                        ObjectId = groep.Identificatie,
+                        CodeObjecttype = KnownGroepIdentificators.ObjectRegisterId.CodeObjecttype,
+                        CodeRegister = KnownGroepIdentificators.ObjectRegisterId.CodeRegister,
+                        CodeSoortObjectId = KnownGroepIdentificators.ObjectRegisterId.CodeSoortObjectId
+                    }
+                });
+        }
+
+        private Task<Actor> GetOrCreateUnknownTypeOeActor()
+        {
+            return GetOrCreateActor(
+                query: new ActorQuery
+                {
+                    ActoridentificatorCodeObjecttype = "onbekend",
+                    ActoridentificatorCodeRegister = "obj",
+                    ActoridentificatorCodeSoortObjectId = "idf",
+                    IndicatieActief = true,
+                    SoortActor = SoortActor.organisatorische_eenheid,
+                    ActoridentificatorObjectId = "e2e-onbekend-oe-type"
+                },
+                request: new ActorRequest
+                {
+                    Naam = "e2e onbekende eenheid",
+                    SoortActor = SoortActor.organisatorische_eenheid,
+                    IndicatieActief = true,
+                    Actoridentificator = new Actoridentificator
+                    {
+                        ObjectId = "e2e-onbekend-oe-type",
+                        CodeObjecttype = "onbekend",
+                        CodeRegister = "obj",
+                        CodeSoortObjectId = "idf"
                     }
                 });
         }

--- a/InterneTaakAfhandeling.EndToEndTest/Infrastructure/TestDataHelper.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Infrastructure/TestDataHelper.cs
@@ -231,7 +231,54 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
             return (contactmoment.Uuid, nummer);
         }
 
-        public async Task<(Guid ContactmomentUuid, string InternetaakNummer)> CreateContactverzoekWithGroepAndMedewerker(string onderwerp)
+        public Task<(Guid ContactmomentUuid, string InternetaakNummer)> CreateContactverzoekWithGroepAndMedewerker(string onderwerp) =>
+            CreateContactverzoekWithActors(onderwerp, async () =>
+            {
+                var groepActor = await GetOrCreateGroepActor();
+                var medewerkerActor = await GetOrCreateMedewerkerActor("icatt-integratie-test@icatt.nl");
+                return new List<Guid> { Guid.Parse(medewerkerActor.Uuid), Guid.Parse(groepActor.Uuid) };
+            });
+
+        public Task<(Guid ContactmomentUuid, string InternetaakNummer)> CreateContactverzoekWithAfdelingAndMedewerker(string onderwerp) =>
+            CreateContactverzoekWithActors(onderwerp, async () =>
+            {
+                var afdelingActor = await GetOrCreateAfdelingActor("Burgerzaken_ibz");
+                var medewerkerActor = await GetOrCreateMedewerkerActor("icatt-integratie-test@icatt.nl");
+                return new List<Guid> { Guid.Parse(medewerkerActor.Uuid), Guid.Parse(afdelingActor.Uuid) };
+            });
+
+        public Task<(Guid ContactmomentUuid, string InternetaakNummer)> CreateContactverzoekWithAfdelingOnly(string onderwerp) =>
+            CreateContactverzoekWithActors(onderwerp, async () =>
+            {
+                var afdelingActor = await GetOrCreateAfdelingActor("Burgerzaken_ibz");
+                return new List<Guid> { Guid.Parse(afdelingActor.Uuid) };
+            });
+
+        public Task<(Guid ContactmomentUuid, string InternetaakNummer)> CreateContactverzoekWithGroepOnly(string onderwerp) =>
+            CreateContactverzoekWithActors(onderwerp, async () =>
+            {
+                var groepActor = await GetOrCreateGroepActor();
+                return new List<Guid> { Guid.Parse(groepActor.Uuid) };
+            });
+
+        public Task<(Guid ContactmomentUuid, string InternetaakNummer)> CreateContactverzoekWithUnknownOeType(string onderwerp) =>
+            CreateContactverzoekWithActors(onderwerp, async () =>
+            {
+                var unknownOeActor = await GetOrCreateUnknownTypeOeActor();
+                return new List<Guid> { Guid.Parse(unknownOeActor.Uuid) };
+            });
+
+        public Task<(Guid ContactmomentUuid, string InternetaakNummer)> CreateContactverzoekWithMultipleOeActors(string onderwerp) =>
+            CreateContactverzoekWithActors(onderwerp, async () =>
+            {
+                var afdelingActor = await GetOrCreateAfdelingActor("Burgerzaken_ibz");
+                var groepActor = await GetOrCreateGroepActor();
+                return new List<Guid> { Guid.Parse(afdelingActor.Uuid), Guid.Parse(groepActor.Uuid) };
+            });
+
+        private async Task<(Guid ContactmomentUuid, string InternetaakNummer)> CreateContactverzoekWithActors(
+            string onderwerp,
+            Func<Task<List<Guid>>> resolveActorUuids)
         {
             await CleanupExistingContactmomenten(onderwerp);
 
@@ -243,137 +290,12 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
             var submitterActor = await GetOrCreateSubmitterActor();
             await ConnectActorToContactmoment(submitterActor, contactmoment.Uuid);
 
-            var groepActor = await GetOrCreateGroepActor();
-            var medewerkerActor = await GetOrCreateMedewerkerActor("icatt-integratie-test@icatt.nl");
+            var actorUuids = await resolveActorUuids();
 
             var nummer = await CreateInternetaak(
                 GenerateUniqueInternetaakNummer(),
                 contactmoment.Uuid,
-                new List<Guid>
-                {
-                    Guid.Parse(medewerkerActor.Uuid),
-                    Guid.Parse(groepActor.Uuid)
-                });
-
-            return (contactmoment.Uuid, nummer);
-        }
-
-        public async Task<(Guid ContactmomentUuid, string InternetaakNummer)> CreateContactverzoekWithAfdelingAndMedewerker(string onderwerp)
-        {
-            await CleanupExistingContactmomenten(onderwerp);
-
-            var contactmoment = await CreateContactmoment(
-                onderwerp,
-                "This is a test contact request created during an end-to-end test run.",
-                klantnaam: null);
-
-            var submitterActor = await GetOrCreateSubmitterActor();
-            await ConnectActorToContactmoment(submitterActor, contactmoment.Uuid);
-
-            var afdelingActor = await GetOrCreateAfdelingActor("Burgerzaken_ibz");
-            var medewerkerActor = await GetOrCreateMedewerkerActor("icatt-integratie-test@icatt.nl");
-
-            var nummer = await CreateInternetaak(
-                GenerateUniqueInternetaakNummer(),
-                contactmoment.Uuid,
-                new List<Guid>
-                {
-                    Guid.Parse(medewerkerActor.Uuid),
-                    Guid.Parse(afdelingActor.Uuid)
-                });
-
-            return (contactmoment.Uuid, nummer);
-        }
-
-        public async Task<(Guid ContactmomentUuid, string InternetaakNummer)> CreateContactverzoekWithAfdelingOnly(string onderwerp)
-        {
-            await CleanupExistingContactmomenten(onderwerp);
-
-            var contactmoment = await CreateContactmoment(
-                onderwerp,
-                "This is a test contact request created during an end-to-end test run.",
-                klantnaam: null);
-
-            var submitterActor = await GetOrCreateSubmitterActor();
-            await ConnectActorToContactmoment(submitterActor, contactmoment.Uuid);
-
-            var afdelingActor = await GetOrCreateAfdelingActor("Burgerzaken_ibz");
-
-            var nummer = await CreateInternetaak(
-                GenerateUniqueInternetaakNummer(),
-                contactmoment.Uuid,
-                new List<Guid> { Guid.Parse(afdelingActor.Uuid) });
-
-            return (contactmoment.Uuid, nummer);
-        }
-
-        public async Task<(Guid ContactmomentUuid, string InternetaakNummer)> CreateContactverzoekWithGroepOnly(string onderwerp)
-        {
-            await CleanupExistingContactmomenten(onderwerp);
-
-            var contactmoment = await CreateContactmoment(
-                onderwerp,
-                "This is a test contact request created during an end-to-end test run.",
-                klantnaam: null);
-
-            var submitterActor = await GetOrCreateSubmitterActor();
-            await ConnectActorToContactmoment(submitterActor, contactmoment.Uuid);
-
-            var groepActor = await GetOrCreateGroepActor();
-
-            var nummer = await CreateInternetaak(
-                GenerateUniqueInternetaakNummer(),
-                contactmoment.Uuid,
-                new List<Guid> { Guid.Parse(groepActor.Uuid) });
-
-            return (contactmoment.Uuid, nummer);
-        }
-
-        public async Task<(Guid ContactmomentUuid, string InternetaakNummer)> CreateContactverzoekWithUnknownOeType(string onderwerp)
-        {
-            await CleanupExistingContactmomenten(onderwerp);
-
-            var contactmoment = await CreateContactmoment(
-                onderwerp,
-                "This is a test contact request created during an end-to-end test run.",
-                klantnaam: null);
-
-            var submitterActor = await GetOrCreateSubmitterActor();
-            await ConnectActorToContactmoment(submitterActor, contactmoment.Uuid);
-
-            var unknownOeActor = await GetOrCreateUnknownTypeOeActor();
-
-            var nummer = await CreateInternetaak(
-                GenerateUniqueInternetaakNummer(),
-                contactmoment.Uuid,
-                new List<Guid> { Guid.Parse(unknownOeActor.Uuid) });
-
-            return (contactmoment.Uuid, nummer);
-        }
-
-        public async Task<(Guid ContactmomentUuid, string InternetaakNummer)> CreateContactverzoekWithMultipleOeActors(string onderwerp)
-        {
-            await CleanupExistingContactmomenten(onderwerp);
-
-            var contactmoment = await CreateContactmoment(
-                onderwerp,
-                "This is a test contact request created during an end-to-end test run.",
-                klantnaam: null);
-
-            var submitterActor = await GetOrCreateSubmitterActor();
-            await ConnectActorToContactmoment(submitterActor, contactmoment.Uuid);
-
-            var afdelingActor = await GetOrCreateAfdelingActor("Burgerzaken_ibz");
-            var groepActor = await GetOrCreateGroepActor();
-
-            var nummer = await CreateInternetaak(
-                GenerateUniqueInternetaakNummer(),
-                contactmoment.Uuid,
-                new List<Guid>
-                {
-                    Guid.Parse(afdelingActor.Uuid),
-                    Guid.Parse(groepActor.Uuid)
-                });
+                actorUuids);
 
             return (contactmoment.Uuid, nummer);
         }

--- a/InterneTaakAfhandeling.EndToEndTest/Kanaal/Kanaal.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Kanaal/Kanaal.cs
@@ -181,9 +181,11 @@ namespace InterneTaakAfhandeling.EndToEndTest.Kanaal
 
             await CreateKanaal(TestKanaalName);
             kanalenToCleanup.Add(TestKanaalName);
-            
-            await VerifyKanaalExists(TestKanaalName);
-            
+
+            // After a successful save the app redirects to the kanalen list — verify there
+            // without navigating away first, which would race against the in-progress redirect
+            await Expect(locators.GetKanaalLink(TestKanaalName)).ToBeVisibleAsync();
+
             await Step($"Attempt to create duplicate kanaal: {TestKanaalName}");
             await CreateKanaal(TestKanaalName);
 

--- a/InterneTaakAfhandeling.EndToEndTest/Kanaal/Kanaal.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Kanaal/Kanaal.cs
@@ -182,9 +182,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.Kanaal
             await CreateKanaal(TestKanaalName);
             kanalenToCleanup.Add(TestKanaalName);
 
-            // After a successful save the app redirects to the kanalen list — verify there
-            // without navigating away first, which would race against the in-progress redirect
-            await Expect(locators.GetKanaalLink(TestKanaalName)).ToBeVisibleAsync();
+            await VerifyKanaalExists(TestKanaalName);
 
             await Step($"Attempt to create duplicate kanaal: {TestKanaalName}");
             await CreateKanaal(TestKanaalName);


### PR DESCRIPTION
## Summary

- Adds Phase 2 E2E test coverage for the actor display feature introduced in Feature #411 (task #488)
- Six Playwright MSTest scenarios covering all acceptance criteria: medewerker+afdeling, medewerker+groep, afdeling-only, groep-only, unknown OE type fallback, and multiple OE actors
- Adds `TestDataHelper` methods to create contactverzoeken with each actor configuration via API, and new locators in `Locators.cs` for the two-row actor display

## Changes

- **`Contactverzoek/ContactverzoekActorDisplayScenarios.cs`** — new partial class with 6 test methods, one per Gherkin scenario
- **`Infrastructure/TestDataHelper.cs`** — new `CreateContactverzoekWith*` methods and private `GetOrCreateGroepActor` / `GetOrCreateUnknownTypeOeActor` helpers
- **`Infrastructure/Locators.cs`** — `GetOrganisatorischeEenheidKey(typeLabel)` and `GetOrganisatorischeEenheidValue(typeLabel)` locators; value locator uses `Filter(Has = dt locator)` to avoid strict mode violations from substring matches in other rows

## Test plan

- [x] Actorweergave toont medewerker en afdeling op twee regels ✅
- [x] Actorweergave toont medewerker en groep op twee regels ✅
- [x] Actorweergave toont alleen afdeling wanneer er geen medewerker is ✅
- [x] Actorweergave toont alleen groep wanneer er geen medewerker is ✅
- [x] Actorweergave toont fallbackweergave bij onbekend type organisatorische eenheid ✅
- [x] Actorweergave toont alleen de eerste organisatorische eenheid bij meerdere gekoppelde actoren ✅

All 6 tests pass against `https://ita.test.icatt.nl`.

## Related

Closes #488
