### PR TITLE
feat(urgentie): calculate and display urgency status labels

### DIFF
--- a/InterneTaakAfhandeling.Web.Client/src/components/UrgentieBadge.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/UrgentieBadge.vue
@@ -11,6 +11,7 @@ import { BadgeStatus as UtrechtBadgeStatus } from "@utrecht/component-library-vu
 export interface UrgentieInfo {
   status: "binnen_termijn" | "bijna_verlopen" | "verlopen";
   streefdatum: string;
+  resterendeUren: number;
 }
 
 const props = defineProps<{ urgentie: UrgentieInfo | null | undefined }>();
@@ -29,27 +30,24 @@ const badgeStatus = computed(() => {
 });
 
 const label = computed(() => {
-  if (!props.urgentie?.streefdatum) return "";
+  if (!props.urgentie) return "";
 
-  const streefdatum = new Date(props.urgentie.streefdatum);
-  const now = new Date();
-  const diffMs = streefdatum.getTime() - now.getTime();
-  const diffHours = Math.round(diffMs / (1000 * 60 * 60));
+  const uren = props.urgentie.resterendeUren;
 
-  if (diffHours > 0) {
-    if (diffHours > 48) {
-      const days = Math.round(diffHours / 24);
+  if (uren > 0) {
+    if (uren > 48) {
+      const days = Math.round(uren / 24);
       return `nog ${days}d`;
     }
-    return `nog ${diffHours}u`;
+    return `nog ${uren}u`;
   }
 
-  const verlopenHours = Math.abs(diffHours);
-  if (verlopenHours > 48) {
-    const days = Math.round(verlopenHours / 24);
+  const verlopenUren = Math.abs(uren);
+  if (verlopenUren > 48) {
+    const days = Math.round(verlopenUren / 24);
     return `${days}d verlopen`;
   }
-  return `${verlopenHours}u verlopen`;
+  return `${verlopenUren}u verlopen`;
 });
 </script>
 

--- a/InterneTaakAfhandeling.Web.Client/src/components/UrgentieBadge.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/UrgentieBadge.vue
@@ -1,0 +1,64 @@
+<template>
+  <utrecht-badge-status v-if="urgentie" :status="badgeStatus">
+    {{ label }}
+  </utrecht-badge-status>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { BadgeStatus as UtrechtBadgeStatus } from "@utrecht/component-library-vue";
+
+export interface UrgentieInfo {
+  status: "binnen_termijn" | "bijna_verlopen" | "verlopen";
+  streefdatum: string;
+}
+
+const props = defineProps<{ urgentie: UrgentieInfo | null | undefined }>();
+
+const badgeStatus = computed(() => {
+  switch (props.urgentie?.status) {
+    case "binnen_termijn":
+      return "success";
+    case "bijna_verlopen":
+      return "warning";
+    case "verlopen":
+      return "error";
+    default:
+      return undefined;
+  }
+});
+
+const label = computed(() => {
+  if (!props.urgentie?.streefdatum) return "";
+
+  const streefdatum = new Date(props.urgentie.streefdatum);
+  const now = new Date();
+  const diffMs = streefdatum.getTime() - now.getTime();
+  const diffHours = Math.round(diffMs / (1000 * 60 * 60));
+
+  if (diffHours > 0) {
+    if (diffHours > 48) {
+      const days = Math.round(diffHours / 24);
+      return `nog ${days}d`;
+    }
+    return `nog ${diffHours}u`;
+  }
+
+  const verlopenHours = Math.abs(diffHours);
+  if (verlopenHours > 48) {
+    const days = Math.round(verlopenHours / 24);
+    return `${days}d verlopen`;
+  }
+  return `${verlopenHours}u verlopen`;
+});
+</script>
+
+<style lang="scss" scoped>
+.utrecht-badge-status {
+  --utrecht-badge-border-radius: 0.5ch;
+  --utrecht-badge-font-size: 0.75rem;
+  --utrecht-badge-font-weight: normal;
+  --utrecht-badge-padding-block: 1ex;
+  --utrecht-badge-padding-inline: 1ch;
+}
+</style>

--- a/InterneTaakAfhandeling.Web.Client/src/components/UrgentieBadge.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/UrgentieBadge.vue
@@ -6,6 +6,7 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
+import { BadgeStatus as UtrechtBadgeStatus } from "@utrecht/component-library-vue";
 import type { UrgentieInfo } from "@/types/internetaken";
 
 const props = defineProps<{ urgentie: UrgentieInfo | null | undefined }>();

--- a/InterneTaakAfhandeling.Web.Client/src/components/UrgentieBadge.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/UrgentieBadge.vue
@@ -43,6 +43,7 @@ const label = computed(() => {
   }
 
   const verlopenUren = Math.abs(uren);
+  if (verlopenUren === 0) return "<1u verlopen";
   if (verlopenUren > 48) {
     const days = Math.round(verlopenUren / 24);
     return `${days}d verlopen`;

--- a/InterneTaakAfhandeling.Web.Client/src/components/UrgentieBadge.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/UrgentieBadge.vue
@@ -6,13 +6,7 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import { BadgeStatus as UtrechtBadgeStatus } from "@utrecht/component-library-vue";
-
-export interface UrgentieInfo {
-  status: "binnen_termijn" | "bijna_verlopen" | "verlopen";
-  streefdatum: string;
-  resterendeUren: number;
-}
+import type { UrgentieInfo } from "@/types/internetaken";
 
 const props = defineProps<{ urgentie: UrgentieInfo | null | undefined }>();
 
@@ -36,7 +30,7 @@ const label = computed(() => {
 
   if (uren > 0) {
     if (uren > 48) {
-      const days = Math.round(uren / 24);
+      const days = Math.ceil(uren / 24);
       return `nog ${days}d`;
     }
     return `nog ${uren}u`;
@@ -45,7 +39,7 @@ const label = computed(() => {
   const verlopenUren = Math.abs(uren);
   if (verlopenUren === 0) return "<1u verlopen";
   if (verlopenUren > 48) {
-    const days = Math.round(verlopenUren / 24);
+    const days = Math.ceil(verlopenUren / 24);
     return `${days}d verlopen`;
   }
   return `${verlopenUren}u verlopen`;

--- a/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/AllInterneTakenTable.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/AllInterneTakenTable.vue
@@ -8,6 +8,7 @@
         <utrecht-table-header-cell scope="col">Datum</utrecht-table-header-cell>
         <utrecht-table-header-cell scope="col">Klantnaam</utrecht-table-header-cell>
         <utrecht-table-header-cell scope="col">Onderwerp / vraag</utrecht-table-header-cell>
+        <utrecht-table-header-cell scope="col">Urgentie</utrecht-table-header-cell>
         <utrecht-table-header-cell scope="col">Afdeling</utrecht-table-header-cell>
         <utrecht-table-header-cell scope="col">Behandelaar</utrecht-table-header-cell>
         <utrecht-table-header-cell scope="col">Details</utrecht-table-header-cell>
@@ -16,7 +17,7 @@
 
     <utrecht-table-body>
       <utrecht-table-row v-if="interneTaken.length === 0">
-        <utrecht-table-cell colspan="6">Geen contactverzoeken gevonden</utrecht-table-cell>
+        <utrecht-table-cell colspan="7">Geen contactverzoeken gevonden</utrecht-table-cell>
       </utrecht-table-row>
 
       <utrecht-table-row v-for="taak in interneTaken" :key="taak.uuid">
@@ -31,6 +32,9 @@
           :title="taak.onderwerp || taak.gevraagdeHandeling || ''"
         >
           {{ taak.onderwerp || taak.gevraagdeHandeling || "-" }}
+        </utrecht-table-cell>
+        <utrecht-table-cell>
+          <urgentie-badge :urgentie="taak.urgentie" />
         </utrecht-table-cell>
         <utrecht-table-cell class="text-truncate" :title="taak.afdelingNaam || ''">
           {{ taak.afdelingNaam || "-" }}
@@ -48,6 +52,8 @@
 
 <script setup lang="ts">
 import DateTimeOrNvt from "../DateTimeOrNvt.vue";
+import UrgentieBadge, { type UrgentieInfo } from "../UrgentieBadge.vue";
+
 defineProps<{ interneTaken: InterneTaakOverviewItem[] }>();
 
 export interface InterneTaakOverviewItem {
@@ -64,6 +70,7 @@ export interface InterneTaakOverviewItem {
   behandelaarNaam?: string;
   heeftBehandelaar: boolean;
   contactmomentNummer?: string;
+  urgentie?: UrgentieInfo | null;
 }
 </script>
 

--- a/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/AllInterneTakenTable.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/AllInterneTakenTable.vue
@@ -52,7 +52,8 @@
 
 <script setup lang="ts">
 import DateTimeOrNvt from "../DateTimeOrNvt.vue";
-import UrgentieBadge, { type UrgentieInfo } from "../UrgentieBadge.vue";
+import UrgentieBadge from "../UrgentieBadge.vue";
+import type { UrgentieInfo } from "@/types/internetaken";
 
 defineProps<{ interneTaken: InterneTaakOverviewItem[] }>();
 

--- a/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/MyInterneTakenTable.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/MyInterneTakenTable.vue
@@ -39,20 +39,9 @@
 </template>
 
 <script setup lang="ts">
-import type { Internetaken } from "@/types/internetaken";
+import type { MyInterneTaakOverviewItem } from "@/types/internetaken";
 import DateTimeOrNvt from "../DateTimeOrNvt.vue";
-import UrgentieBadge, { type UrgentieInfo } from "../UrgentieBadge.vue";
-
-export interface MyInterneTaakOverviewItem {
-  uuid: string;
-  nummer?: string;
-  gevraagdeHandeling?: string;
-  status?: string;
-  toegewezenOp?: string;
-  afgehandeldOp?: string;
-  aanleidinggevendKlantcontact?: Internetaken["aanleidinggevendKlantcontact"];
-  urgentie?: UrgentieInfo | null;
-}
+import UrgentieBadge from "../UrgentieBadge.vue";
 
 defineProps<{ interneTaken: MyInterneTaakOverviewItem[] }>();
 </script>

--- a/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/MyInterneTakenTable.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/MyInterneTakenTable.vue
@@ -5,13 +5,14 @@
         <utrecht-table-header-cell scope="col">Datum</utrecht-table-header-cell>
         <utrecht-table-header-cell scope="col">Klantnaam</utrecht-table-header-cell>
         <utrecht-table-header-cell scope="col">Onderwerp / vraag</utrecht-table-header-cell>
+        <utrecht-table-header-cell scope="col">Urgentie</utrecht-table-header-cell>
         <utrecht-table-header-cell scope="col">Details</utrecht-table-header-cell>
       </utrecht-table-row>
     </utrecht-table-header>
 
     <utrecht-table-body>
       <utrecht-table-row v-if="interneTaken.length === 0">
-        <utrecht-table-cell colspan="4">Geen interne taken gevonden</utrecht-table-cell>
+        <utrecht-table-cell colspan="5">Geen interne taken gevonden</utrecht-table-cell>
       </utrecht-table-row>
 
       <utrecht-table-row v-for="taak in interneTaken" :key="taak.uuid">
@@ -25,6 +26,9 @@
         }}</utrecht-table-cell>
         <utrecht-table-cell>{{ taak.aanleidinggevendKlantcontact?.onderwerp }}</utrecht-table-cell>
         <utrecht-table-cell>
+          <urgentie-badge :urgentie="taak.urgentie" />
+        </utrecht-table-cell>
+        <utrecht-table-cell>
           <router-link :to="`/contactmoment/${taak?.aanleidinggevendKlantcontact?.nummer}`"
             >Klik hier</router-link
           >
@@ -37,5 +41,18 @@
 <script setup lang="ts">
 import type { Internetaken } from "@/types/internetaken";
 import DateTimeOrNvt from "../DateTimeOrNvt.vue";
-defineProps<{ interneTaken: Internetaken[] }>();
+import UrgentieBadge, { type UrgentieInfo } from "../UrgentieBadge.vue";
+
+export interface MyInterneTaakOverviewItem {
+  uuid: string;
+  nummer?: string;
+  gevraagdeHandeling?: string;
+  status?: string;
+  toegewezenOp?: string;
+  afgehandeldOp?: string;
+  aanleidinggevendKlantcontact?: Internetaken["aanleidinggevendKlantcontact"];
+  urgentie?: UrgentieInfo | null;
+}
+
+defineProps<{ interneTaken: MyInterneTaakOverviewItem[] }>();
 </script>

--- a/InterneTaakAfhandeling.Web.Client/src/services/userService.ts
+++ b/InterneTaakAfhandeling.Web.Client/src/services/userService.ts
@@ -1,5 +1,5 @@
 import { get, post } from "@/utils/fetchWrapper";
-import type { MyInterneTaakOverviewItem } from "@/components/interne-taken-tables/MyInterneTakenTable.vue";
+import type { MyInterneTaakOverviewItem } from "@/types/internetaken";
 
 export const userService = {
   getAssignedInternetaken: (): Promise<MyInterneTaakOverviewItem[]> => {

--- a/InterneTaakAfhandeling.Web.Client/src/services/userService.ts
+++ b/InterneTaakAfhandeling.Web.Client/src/services/userService.ts
@@ -1,14 +1,14 @@
 import { get, post } from "@/utils/fetchWrapper";
-import type { Internetaken } from "@/types/internetaken";
+import type { MyInterneTaakOverviewItem } from "@/components/interne-taken-tables/MyInterneTakenTable.vue";
 
 export const userService = {
-  getAssignedInternetaken: (): Promise<Internetaken[]> => {
-    return get<Internetaken[]>("/api/internetaken/aan-mij-toegewezen?afgerond=false");
+  getAssignedInternetaken: (): Promise<MyInterneTaakOverviewItem[]> => {
+    return get<MyInterneTaakOverviewItem[]>("/api/internetaken/aan-mij-toegewezen?afgerond=false");
   },
   assignInternetakenToSelf: (id: string): Promise<boolean> => {
     return post<boolean>(`/api/internetaken/${id}/aan-mij-toewijzen`, {});
   },
-  getAssignedAndFinishedInternetaken: (): Promise<Internetaken[]> => {
-    return get<Internetaken[]>("/api/internetaken/aan-mij-toegewezen?afgerond=true");
+  getAssignedAndFinishedInternetaken: (): Promise<MyInterneTaakOverviewItem[]> => {
+    return get<MyInterneTaakOverviewItem[]>("/api/internetaken/aan-mij-toegewezen?afgerond=true");
   }
 };

--- a/InterneTaakAfhandeling.Web.Client/src/types/internetaken.ts
+++ b/InterneTaakAfhandeling.Web.Client/src/types/internetaken.ts
@@ -335,3 +335,20 @@ export interface ForwardKlantContactResponse {
   internetaak: Internetaken;
   notificationResult: string;
 }
+
+export interface UrgentieInfo {
+  status: "binnen_termijn" | "bijna_verlopen" | "verlopen";
+  streefdatum: string;
+  resterendeUren: number;
+}
+
+export interface MyInterneTaakOverviewItem {
+  uuid: string;
+  nummer?: string;
+  gevraagdeHandeling?: string;
+  status?: string;
+  toegewezenOp?: string;
+  afgehandeldOp?: string;
+  aanleidinggevendKlantcontact?: Internetaken["aanleidinggevendKlantcontact"];
+  urgentie?: UrgentieInfo | null;
+}

--- a/InterneTaakAfhandeling.Web.Client/src/views/DashboardView.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/views/DashboardView.vue
@@ -27,9 +27,8 @@
 
 <script setup lang="ts">
 import { onMounted, ref } from "vue";
-import MyInterneTakenTable, {
-  type MyInterneTaakOverviewItem
-} from "@/components/interne-taken-tables/MyInterneTakenTable.vue";
+import MyInterneTakenTable from "@/components/interne-taken-tables/MyInterneTakenTable.vue";
+import type { MyInterneTaakOverviewItem } from "@/types/internetaken";
 import SimpleSpinner from "@/components/SimpleSpinner.vue";
 import ScrollContainer from "@/components/ScrollContainer.vue";
 import { userService } from "@/services/userService";

--- a/InterneTaakAfhandeling.Web.Client/src/views/DashboardView.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/views/DashboardView.vue
@@ -27,16 +27,17 @@
 
 <script setup lang="ts">
 import { onMounted, ref } from "vue";
-import MyInterneTakenTable from "@/components/interne-taken-tables/MyInterneTakenTable.vue";
+import MyInterneTakenTable, {
+  type MyInterneTaakOverviewItem
+} from "@/components/interne-taken-tables/MyInterneTakenTable.vue";
 import SimpleSpinner from "@/components/SimpleSpinner.vue";
 import ScrollContainer from "@/components/ScrollContainer.vue";
 import { userService } from "@/services/userService";
-import type { Internetaken } from "@/types/internetaken";
 import { useRoute } from "vue-router";
 
 const route = useRoute();
 
-const assignedInternetaken = ref<Internetaken[]>([]);
+const assignedInternetaken = ref<MyInterneTaakOverviewItem[]>([]);
 const isLoading = ref(false);
 const error = ref<string | null>(null);
 

--- a/InterneTaakAfhandeling.Web.Client/src/views/HistorieView.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/views/HistorieView.vue
@@ -27,9 +27,8 @@
 
 <script setup lang="ts">
 import { onMounted, ref } from "vue";
-import MyInterneTakenTable, {
-  type MyInterneTaakOverviewItem
-} from "@/components/interne-taken-tables/MyInterneTakenTable.vue";
+import MyInterneTakenTable from "@/components/interne-taken-tables/MyInterneTakenTable.vue";
+import type { MyInterneTaakOverviewItem } from "@/types/internetaken";
 import SimpleSpinner from "@/components/SimpleSpinner.vue";
 import ScrollContainer from "@/components/ScrollContainer.vue";
 import { userService } from "@/services/userService";

--- a/InterneTaakAfhandeling.Web.Client/src/views/HistorieView.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/views/HistorieView.vue
@@ -27,16 +27,17 @@
 
 <script setup lang="ts">
 import { onMounted, ref } from "vue";
-import MyInterneTakenTable from "@/components/interne-taken-tables/MyInterneTakenTable.vue";
+import MyInterneTakenTable, {
+  type MyInterneTaakOverviewItem
+} from "@/components/interne-taken-tables/MyInterneTakenTable.vue";
 import SimpleSpinner from "@/components/SimpleSpinner.vue";
 import ScrollContainer from "@/components/ScrollContainer.vue";
 import { userService } from "@/services/userService";
-import type { Internetaken } from "@/types/internetaken";
 import { useRoute } from "vue-router";
 
 const route = useRoute();
 
-const assignedInternetaken = ref<Internetaken[]>([]);
+const assignedInternetaken = ref<MyInterneTaakOverviewItem[]>([]);
 const isLoading = ref(false);
 const error = ref<string | null>(null);
 

--- a/InterneTaakAfhandeling.Web.Server/Config/ServiceCollectionExtensions.cs
+++ b/InterneTaakAfhandeling.Web.Server/Config/ServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ using InterneTaakAfhandeling.Web.Server.Features.InterneTakenOverzicht;
 using InterneTaakAfhandeling.Web.Server.Features.KlantContact;
 using InterneTaakAfhandeling.Web.Server.Features.MyInterneTakenOverview;
 using InterneTaakAfhandeling.Web.Server.Features.ReopenContactRequest;
+using InterneTaakAfhandeling.Web.Server.Features.Urgentie;
 using InterneTaakAfhandeling.Web.Server.Middleware;
 using InterneTaakAfhandeling.Web.Server.Services;
 using InterneTaakAfhandeling.Web.Server.Guards;
@@ -65,6 +66,7 @@ namespace InterneTaakAfhandeling.Web.Server.Config
             services.AddScoped<IInternetaakGuardService, InternetaakGuardService>();
             services.AddScoped<IReopenContactRequestService, ReopenContactRequestService>();
             services.AddScoped<IMyInterneTakenOverviewService, MyInterneTakenOverviewService>();
+            services.AddSingleton<IUrgentieBerekenService, UrgentieBerekenService>();
             services.AddSmtpClients(configuration);
             
             services.AddDbContext<ApplicationDbContext>(options =>

--- a/InterneTaakAfhandeling.Web.Server/Config/ServiceCollectionExtensions.cs
+++ b/InterneTaakAfhandeling.Web.Server/Config/ServiceCollectionExtensions.cs
@@ -66,7 +66,8 @@ namespace InterneTaakAfhandeling.Web.Server.Config
             services.AddScoped<IInternetaakGuardService, InternetaakGuardService>();
             services.AddScoped<IReopenContactRequestService, ReopenContactRequestService>();
             services.AddScoped<IMyInterneTakenOverviewService, MyInterneTakenOverviewService>();
-            services.AddSingleton<IUrgentieBerekenService, UrgentieBerekenService>();
+            services.Configure<UrgentieOptions>(configuration.GetSection(UrgentieOptions.SectionName));
+            services.AddScoped<IUrgentieBerekenService, UrgentieBerekenService>();
             services.AddSmtpClients(configuration);
             
             services.AddDbContext<ApplicationDbContext>(options =>

--- a/InterneTaakAfhandeling.Web.Server/Features/InterneTakenOverzicht/InterneTakenOverzichtModel.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/InterneTakenOverzicht/InterneTakenOverzichtModel.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using InterneTaakAfhandeling.Web.Server.Features.Urgentie;
 
 namespace InterneTaakAfhandeling.Web.Server.Features.InterneTakenOverzicht;
 
@@ -42,4 +43,6 @@ public class InterneTaakOverzichtItem
     public string? BehandelaarNaam { get; set; }
 
     public string? ContactmomentNummer { get; set; }
+
+    public UrgentieInfo? Urgentie { get; set; }
 }

--- a/InterneTaakAfhandeling.Web.Server/Features/InterneTakenOverzicht/InterneTakenOverzichtService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/InterneTakenOverzicht/InterneTakenOverzichtService.cs
@@ -1,5 +1,6 @@
 ﻿using InterneTaakAfhandeling.Common.Services.OpenKlantApi;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
+using InterneTaakAfhandeling.Web.Server.Features.Urgentie;
 using System;
 
 namespace InterneTaakAfhandeling.Web.Server.Features.InterneTakenOverzicht
@@ -12,13 +13,16 @@ namespace InterneTaakAfhandeling.Web.Server.Features.InterneTakenOverzicht
     public class InterneTakenOverzichtService : IInterneTakenOverzichtService
     {
         private readonly IOpenKlantApiClient _openKlantApiClient;
+        private readonly IUrgentieBerekenService _urgentieBerekenService;
         private readonly ILogger<InterneTakenOverzichtService> _logger;
 
         public InterneTakenOverzichtService(
             IOpenKlantApiClient openKlantApiClient,
+            IUrgentieBerekenService urgentieBerekenService,
             ILogger<InterneTakenOverzichtService> logger)
         {
             _openKlantApiClient = openKlantApiClient ?? throw new ArgumentNullException(nameof(openKlantApiClient));
+            _urgentieBerekenService = urgentieBerekenService ?? throw new ArgumentNullException(nameof(urgentieBerekenService));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
@@ -55,6 +59,9 @@ namespace InterneTaakAfhandeling.Web.Server.Features.InterneTakenOverzicht
 
             //behandelaar en afdelingnaam toevoegen 
             await LoadActorInfoAsync(internetaak, item);
+
+            //urgentie berekenen op basis van ContactDatum
+            item.Urgentie = _urgentieBerekenService.Bereken(item.ContactDatum);
 
             return item;
         }

--- a/InterneTaakAfhandeling.Web.Server/Features/MyInterneTakenOverview/MyInterneTaakOverviewModel.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/MyInterneTakenOverview/MyInterneTaakOverviewModel.cs
@@ -1,0 +1,16 @@
+using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
+using InterneTaakAfhandeling.Web.Server.Features.Urgentie;
+
+namespace InterneTaakAfhandeling.Web.Server.Features.MyInterneTakenOverview;
+
+public class MyInterneTaakOverviewItem
+{
+    public string Uuid { get; init; } = string.Empty;
+    public string? Nummer { get; init; }
+    public string? GevraagdeHandeling { get; init; }
+    public string? Status { get; init; }
+    public DateTimeOffset? ToegewezenOp { get; init; }
+    public DateTimeOffset? AfgehandeldOp { get; init; }
+    public Klantcontact? AanleidinggevendKlantcontact { get; init; }
+    public UrgentieInfo? Urgentie { get; init; }
+}

--- a/InterneTaakAfhandeling.Web.Server/Features/MyInterneTakenOverview/MyInterneTakenOverviewController.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/MyInterneTakenOverview/MyInterneTakenOverviewController.cs
@@ -13,12 +13,12 @@ namespace InterneTaakAfhandeling.Web.Server.Features.MyInterneTakenOverview
         private readonly IMyInterneTakenOverviewService _myInterneTakenOverviewService = myInterneTakenOverviewService ?? throw new ArgumentNullException(nameof(myInterneTakenOverviewService));
 
 
-        [ProducesResponseType(typeof(List<InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models.Internetaak>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(List<MyInterneTaakOverviewItem>), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
         [HttpGet("aan-mij-toegewezen")]
         public async Task<IActionResult> GetInternetaken([FromQuery] bool afgerond)
         {
-            var result = await myInterneTakenOverviewService.GetInterneTakenByAssignedUser(user, afgerond);
+            var result = await _myInterneTakenOverviewService.GetInterneTakenByAssignedUser(user, afgerond);
             return Ok(result);
         }
 

--- a/InterneTaakAfhandeling.Web.Server/Features/MyInterneTakenOverview/MyInterneTakenOverviewService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/MyInterneTakenOverview/MyInterneTakenOverviewService.cs
@@ -3,19 +3,23 @@ using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
 using InterneTaakAfhandeling.Common.Services;
 using InterneTaakAfhandeling.Web.Server.Authentication;
 using InterneTaakAfhandeling.Web.Server.Features.Internetaken;
+using InterneTaakAfhandeling.Web.Server.Features.Urgentie;
 
 namespace InterneTaakAfhandeling.Web.Server.Features.MyInterneTakenOverview
 {
     public interface IMyInterneTakenOverviewService
     {
-        Task<IReadOnlyList<Internetaak>> GetInterneTakenByAssignedUser(ITAUser user, bool afgerond);
+        Task<IReadOnlyList<MyInterneTaakOverviewItem>> GetInterneTakenByAssignedUser(ITAUser user, bool afgerond);
     }
-    public class MyInterneTakenOverviewService(IOpenKlantApiClient openKlantApiClient) : IMyInterneTakenOverviewService
+    public class MyInterneTakenOverviewService(
+        IOpenKlantApiClient openKlantApiClient,
+        IUrgentieBerekenService urgentieBerekenService) : IMyInterneTakenOverviewService
     {
         private readonly IOpenKlantApiClient _openKlantApiClient = openKlantApiClient;
+        private readonly IUrgentieBerekenService _urgentieBerekenService = urgentieBerekenService;
 
 
-        public async Task<IReadOnlyList<Internetaak>> GetInterneTakenByAssignedUser(ITAUser user, bool afgerond)
+        public async Task<IReadOnlyList<MyInterneTaakOverviewItem>> GetInterneTakenByAssignedUser(ITAUser user, bool afgerond)
         {
             var actorIds = await GetActorIds(user);
 
@@ -33,7 +37,27 @@ namespace InterneTaakAfhandeling.Web.Server.Features.MyInterneTakenOverview
 
             var results = await Task.WhenAll(internetakenTasks);
 
-            return [.. results.SelectMany(x => x).OrderByDescending(x => x.ToegewezenOp)];
+            return [.. results
+                .SelectMany(x => x)
+                .OrderByDescending(x => x.ToegewezenOp)
+                .Select(MapToOverviewItem)];
+        }
+
+        private MyInterneTaakOverviewItem MapToOverviewItem(Internetaak internetaak)
+        {
+            var contactDatum = internetaak.AanleidinggevendKlantcontact?.PlaatsgevondenOp;
+
+            return new MyInterneTaakOverviewItem
+            {
+                Uuid = internetaak.Uuid,
+                Nummer = internetaak.Nummer,
+                GevraagdeHandeling = internetaak.GevraagdeHandeling,
+                Status = internetaak.Status,
+                ToegewezenOp = internetaak.ToegewezenOp,
+                AfgehandeldOp = internetaak.AfgehandeldOp,
+                AanleidinggevendKlantcontact = internetaak.AanleidinggevendKlantcontact,
+                Urgentie = _urgentieBerekenService.Bereken(contactDatum)
+            };
         }
 
         private async Task<IReadOnlyList<string>> GetActorIds(ITAUser user)

--- a/InterneTaakAfhandeling.Web.Server/Features/Urgentie/IUrgentieBerekenService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/Urgentie/IUrgentieBerekenService.cs
@@ -1,0 +1,6 @@
+namespace InterneTaakAfhandeling.Web.Server.Features.Urgentie;
+
+public interface IUrgentieBerekenService
+{
+    UrgentieInfo? Bereken(DateTimeOffset? contactDatum);
+}

--- a/InterneTaakAfhandeling.Web.Server/Features/Urgentie/UrgentieBerekenService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/Urgentie/UrgentieBerekenService.cs
@@ -1,10 +1,12 @@
+using Microsoft.Extensions.Options;
+
 namespace InterneTaakAfhandeling.Web.Server.Features.Urgentie;
 
-public class UrgentieBerekenService(ILogger<UrgentieBerekenService> logger) : IUrgentieBerekenService
+public class UrgentieBerekenService(
+    IOptions<UrgentieOptions> options,
+    ILogger<UrgentieBerekenService> logger) : IUrgentieBerekenService
 {
-    private static readonly TimeSpan Afhandeltermijn = TimeSpan.FromHours(48);
-    private static readonly TimeSpan BijnaVerlopenDrempel = TimeSpan.FromHours(6);
-
+    private readonly UrgentieOptions _options = options.Value;
     private readonly ILogger<UrgentieBerekenService> _logger = logger;
 
     public UrgentieInfo? Bereken(DateTimeOffset? contactDatum)
@@ -15,13 +17,14 @@ public class UrgentieBerekenService(ILogger<UrgentieBerekenService> logger) : IU
             return null;
         }
 
-        var streefdatum = contactDatum.Value + Afhandeltermijn;
-        var resterend = streefdatum - DateTimeOffset.UtcNow;
+        var afhandeltermijn = TimeSpan.FromHours(_options.AfhandeltermijnUren);
+        var streefdatum = AddWeekdayHours(contactDatum.Value, afhandeltermijn);
+        var resterendeWerkdagUren = BerekenResterendeWerkdagUren(DateTimeOffset.UtcNow, streefdatum);
 
-        var status = resterend switch
+        var status = resterendeWerkdagUren switch
         {
-            { TotalHours: <= 0 } => UrgentieStatus.Verlopen,
-            { TotalHours: <= 6 } => UrgentieStatus.BijnaVerlopen,
+            <= 0 => UrgentieStatus.Verlopen,
+            var u when u <= _options.BijnaVerlopenDrempelUren => UrgentieStatus.BijnaVerlopen,
             _ => UrgentieStatus.BinnenTermijn
         };
 
@@ -34,7 +37,95 @@ public class UrgentieBerekenService(ILogger<UrgentieBerekenService> logger) : IU
                 UrgentieStatus.Verlopen => "verlopen",
                 _ => "binnen_termijn"
             },
-            Streefdatum = streefdatum
+            Streefdatum = streefdatum,
+            ResterendeUren = Math.Round(resterendeWerkdagUren)
         };
+    }
+
+    /// <summary>
+    /// Adds the given number of hours to a start time, skipping weekends entirely (24/7 on weekdays).
+    /// </summary>
+    internal static DateTimeOffset AddWeekdayHours(DateTimeOffset start, TimeSpan hoursToAdd)
+    {
+        var current = start;
+        var remainingHours = hoursToAdd.TotalHours;
+
+        while (remainingHours > 0)
+        {
+            if (IsWeekend(current))
+            {
+                current = SkipToNextWeekday(current);
+                continue;
+            }
+
+            var endOfDay = current.Date.AddDays(1);
+            var hoursLeftInDay = (endOfDay - current).TotalHours;
+
+            if (remainingHours <= hoursLeftInDay)
+            {
+                current = current.AddHours(remainingHours);
+                remainingHours = 0;
+            }
+            else
+            {
+                remainingHours -= hoursLeftInDay;
+                current = new DateTimeOffset(endOfDay, current.Offset);
+            }
+        }
+
+        return current;
+    }
+
+    /// <summary>
+    /// Calculates the number of weekday hours (excluding Saturday/Sunday) between now and the streefdatum.
+    /// Returns negative values when the streefdatum has passed.
+    /// </summary>
+    internal static double BerekenResterendeWerkdagUren(DateTimeOffset now, DateTimeOffset streefdatum)
+    {
+        if (now >= streefdatum)
+        {
+            return -BerekenWerkdagUrenTussen(streefdatum, now);
+        }
+
+        return BerekenWerkdagUrenTussen(now, streefdatum);
+    }
+
+    private static double BerekenWerkdagUrenTussen(DateTimeOffset start, DateTimeOffset end)
+    {
+        var current = start;
+        var totalHours = 0.0;
+
+        while (current < end)
+        {
+            if (IsWeekend(current))
+            {
+                current = SkipToNextWeekday(current);
+                continue;
+            }
+
+            var endOfDay = current.Date.AddDays(1);
+            var dayEnd = endOfDay < end
+                ? new DateTimeOffset(endOfDay, current.Offset)
+                : end;
+
+            totalHours += (dayEnd - current).TotalHours;
+            current = new DateTimeOffset(endOfDay, current.Offset);
+        }
+
+        return totalHours;
+    }
+
+    private static bool IsWeekend(DateTimeOffset date) =>
+        date.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday;
+
+    private static DateTimeOffset SkipToNextWeekday(DateTimeOffset date)
+    {
+        var next = date.Date.AddDays(1);
+        while (next.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday)
+        {
+            next = next.AddDays(1);
+        }
+
+        return new DateTimeOffset(next, date.Offset);
     }
 }

--- a/InterneTaakAfhandeling.Web.Server/Features/Urgentie/UrgentieBerekenService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/Urgentie/UrgentieBerekenService.cs
@@ -60,7 +60,7 @@ public class UrgentieBerekenService(
                 continue;
             }
 
-            var endOfDay = current.Date.AddDays(1);
+            var endOfDay = new DateTimeOffset(current.Date.AddDays(1), current.Offset);
             var hoursLeftInDay = (endOfDay - current).TotalHours;
 
             if (remainingHours <= hoursLeftInDay)
@@ -71,7 +71,7 @@ public class UrgentieBerekenService(
             else
             {
                 remainingHours -= hoursLeftInDay;
-                current = new DateTimeOffset(endOfDay, current.Offset);
+                current = endOfDay;
             }
         }
 
@@ -105,13 +105,11 @@ public class UrgentieBerekenService(
                 continue;
             }
 
-            var endOfDay = current.Date.AddDays(1);
-            var dayEnd = endOfDay < end
-                ? new DateTimeOffset(endOfDay, current.Offset)
-                : end;
+            var endOfDay = new DateTimeOffset(current.Date.AddDays(1), current.Offset);
+            var dayEnd = endOfDay < end ? endOfDay : end;
 
             totalHours += (dayEnd - current).TotalHours;
-            current = new DateTimeOffset(endOfDay, current.Offset);
+            current = endOfDay;
         }
 
         return totalHours;

--- a/InterneTaakAfhandeling.Web.Server/Features/Urgentie/UrgentieBerekenService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/Urgentie/UrgentieBerekenService.cs
@@ -1,0 +1,40 @@
+namespace InterneTaakAfhandeling.Web.Server.Features.Urgentie;
+
+public class UrgentieBerekenService(ILogger<UrgentieBerekenService> logger) : IUrgentieBerekenService
+{
+    private static readonly TimeSpan Afhandeltermijn = TimeSpan.FromHours(48);
+    private static readonly TimeSpan BijnaVerlopenDrempel = TimeSpan.FromHours(6);
+
+    private readonly ILogger<UrgentieBerekenService> _logger = logger;
+
+    public UrgentieInfo? Bereken(DateTimeOffset? contactDatum)
+    {
+        if (contactDatum is null)
+        {
+            _logger.LogWarning("Urgentieberekening overgeslagen: ContactDatum is null");
+            return null;
+        }
+
+        var streefdatum = contactDatum.Value + Afhandeltermijn;
+        var resterend = streefdatum - DateTimeOffset.UtcNow;
+
+        var status = resterend switch
+        {
+            { TotalHours: <= 0 } => UrgentieStatus.Verlopen,
+            { TotalHours: <= 6 } => UrgentieStatus.BijnaVerlopen,
+            _ => UrgentieStatus.BinnenTermijn
+        };
+
+        return new UrgentieInfo
+        {
+            Status = status switch
+            {
+                UrgentieStatus.BinnenTermijn => "binnen_termijn",
+                UrgentieStatus.BijnaVerlopen => "bijna_verlopen",
+                UrgentieStatus.Verlopen => "verlopen",
+                _ => "binnen_termijn"
+            },
+            Streefdatum = streefdatum
+        };
+    }
+}

--- a/InterneTaakAfhandeling.Web.Server/Features/Urgentie/UrgentieBerekenService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/Urgentie/UrgentieBerekenService.cs
@@ -38,7 +38,9 @@ public class UrgentieBerekenService(
                 _ => "binnen_termijn"
             },
             Streefdatum = streefdatum,
-            ResterendeUren = Math.Round(resterendeWerkdagUren)
+            ResterendeUren = resterendeWerkdagUren >= 0
+                ? Math.Ceiling(resterendeWerkdagUren)
+                : -Math.Ceiling(Math.Abs(resterendeWerkdagUren))
         };
     }
 

--- a/InterneTaakAfhandeling.Web.Server/Features/Urgentie/UrgentieModel.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/Urgentie/UrgentieModel.cs
@@ -1,0 +1,14 @@
+namespace InterneTaakAfhandeling.Web.Server.Features.Urgentie;
+
+public enum UrgentieStatus
+{
+    BinnenTermijn,
+    BijnaVerlopen,
+    Verlopen
+}
+
+public class UrgentieInfo
+{
+    public required string Status { get; init; }
+    public required DateTimeOffset Streefdatum { get; init; }
+}

--- a/InterneTaakAfhandeling.Web.Server/Features/Urgentie/UrgentieModel.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/Urgentie/UrgentieModel.cs
@@ -11,4 +11,5 @@ public class UrgentieInfo
 {
     public required string Status { get; init; }
     public required DateTimeOffset Streefdatum { get; init; }
+    public required double ResterendeUren { get; init; }
 }

--- a/InterneTaakAfhandeling.Web.Server/Features/Urgentie/UrgentieOptions.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/Urgentie/UrgentieOptions.cs
@@ -1,0 +1,9 @@
+namespace InterneTaakAfhandeling.Web.Server.Features.Urgentie;
+
+public class UrgentieOptions
+{
+    public const string SectionName = "Urgentie";
+
+    public double AfhandeltermijnUren { get; set; } = 48;
+    public double BijnaVerlopenDrempelUren { get; set; } = 6;
+}

--- a/InterneTaakAfhandeling.Web.Server/appsettings.json
+++ b/InterneTaakAfhandeling.Web.Server/appsettings.json
@@ -9,6 +9,10 @@
     }
   },
   "AllowedHosts": "*",
+  "Urgentie": {
+    "AfhandeltermijnUren": 48,
+    "BijnaVerlopenDrempelUren": 6
+  },
   "RESOURCES": {
     "THEME_NAAM": "",
     "LOGO_URL": "",


### PR DESCRIPTION
## Summary

Enables Coördinatoren and Behandelaars to see at a glance how much time remains (or has elapsed) relative to the afhandeltermijn for each contactverzoek on the werklijst. This serves Feature #402's goal of making urgency visible so workload can be monitored and managed.

The backend calculates a `streefdatum` (ContactDatum + afhandeltermijn) and determines urgency status (binnen_termijn / bijna_verlopen / verlopen) using threshold logic. The frontend renders an `UrgentieBadge` component with color-coded labels (green/orange/red) and accessible text.

## Changes

- **Urgentie calculation service** — New `IUrgentieBerekenService` + `UrgentieBerekenService` with configurable afhandeltermijn, weekend-exclusion logic, and ceiling-based time rounding to avoid "0u" edge case
- **API response enrichment** — Both overview endpoints now include `urgentie.status` and `urgentie.streefdatum` fields
- **Frontend UrgentieBadge** — New Vue component that formats relative time and selects badge color based on status; integrated into both `AllInterneTakenTable` and `MyInterneTakenTable`
- **Configuration** — Afhandeltermijn added to `appsettings.json` (hardcoded default, prepared for #479)

## Test plan

- [ ] Contactverzoek binnen afhandeltermijn toont groen label
- [ ] Contactverzoek bijna verlopen toont oranje label
- [ ] Contactverzoek verlopen toont rood label
- [ ] Urgentielabel is toegankelijk zonder kleur
- [ ] Drempelwaarde voor bijna-verlopen is 6 uur
- [ ] Urgentielabel zichtbaar op beide werklijstweergaven
- [ ] Edge case: ceiling-afronding voorkomt "0u" label

> ℹ️ E2E tests for these scenarios will be written in Phase 2 (post-deploy), per QA.md two-phase workflow.

## Related

Closes #498