### PR TITLE
feat(werklijst): kolommen Afdeling en Klantcontactnummer toevoegen

### DIFF
--- a/InterneTaakAfhandeling.Web.Client/src/assets/main.scss
+++ b/InterneTaakAfhandeling.Web.Client/src/assets/main.scss
@@ -67,4 +67,11 @@
     align-items: center;
     min-height: 200px;
   }
+
+  .text-truncate {
+    max-width: 200px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }

--- a/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/AllInterneTakenTable.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/AllInterneTakenTable.vue
@@ -11,13 +11,14 @@
         <utrecht-table-header-cell scope="col">Urgentie</utrecht-table-header-cell>
         <utrecht-table-header-cell scope="col">Afdeling</utrecht-table-header-cell>
         <utrecht-table-header-cell scope="col">Behandelaar</utrecht-table-header-cell>
+        <utrecht-table-header-cell scope="col">Klantcontactnummer</utrecht-table-header-cell>
         <utrecht-table-header-cell scope="col">Details</utrecht-table-header-cell>
       </utrecht-table-row>
     </utrecht-table-header>
 
     <utrecht-table-body>
       <utrecht-table-row v-if="interneTaken.length === 0">
-        <utrecht-table-cell colspan="7">Geen contactverzoeken gevonden</utrecht-table-cell>
+        <utrecht-table-cell colspan="8">Geen contactverzoeken gevonden</utrecht-table-cell>
       </utrecht-table-row>
 
       <utrecht-table-row v-for="taak in interneTaken" :key="taak.uuid">
@@ -41,6 +42,9 @@
         </utrecht-table-cell>
         <utrecht-table-cell class="text-truncate" :title="taak.behandelaarNaam || ''">
           {{ taak.behandelaarNaam || "-" }}
+        </utrecht-table-cell>
+        <utrecht-table-cell>
+          {{ taak.contactmomentNummer || "-" }}
         </utrecht-table-cell>
         <utrecht-table-cell>
           <router-link :to="`/contactmoment/${taak.contactmomentNummer}`">Klik hier</router-link>

--- a/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/AllInterneTakenTable.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/AllInterneTakenTable.vue
@@ -78,12 +78,3 @@ export interface InterneTaakOverviewItem {
   urgentie?: UrgentieInfo | null;
 }
 </script>
-
-<style lang="scss" scoped>
-.text-truncate {
-  max-width: 200px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-</style>

--- a/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/MyInterneTakenTable.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/MyInterneTakenTable.vue
@@ -6,13 +6,15 @@
         <utrecht-table-header-cell scope="col">Klantnaam</utrecht-table-header-cell>
         <utrecht-table-header-cell scope="col">Onderwerp / vraag</utrecht-table-header-cell>
         <utrecht-table-header-cell scope="col">Urgentie</utrecht-table-header-cell>
+        <utrecht-table-header-cell scope="col">Afdeling</utrecht-table-header-cell>
+        <utrecht-table-header-cell scope="col">Klantcontactnummer</utrecht-table-header-cell>
         <utrecht-table-header-cell scope="col">Details</utrecht-table-header-cell>
       </utrecht-table-row>
     </utrecht-table-header>
 
     <utrecht-table-body>
       <utrecht-table-row v-if="interneTaken.length === 0">
-        <utrecht-table-cell colspan="5">Geen interne taken gevonden</utrecht-table-cell>
+        <utrecht-table-cell colspan="7">Geen interne taken gevonden</utrecht-table-cell>
       </utrecht-table-row>
 
       <utrecht-table-row v-for="taak in interneTaken" :key="taak.uuid">
@@ -27,6 +29,12 @@
         <utrecht-table-cell>{{ taak.aanleidinggevendKlantcontact?.onderwerp }}</utrecht-table-cell>
         <utrecht-table-cell>
           <urgentie-badge :urgentie="taak.urgentie" />
+        </utrecht-table-cell>
+        <utrecht-table-cell class="text-truncate" :title="taak.afdelingNaam || ''">
+          {{ taak.afdelingNaam || "-" }}
+        </utrecht-table-cell>
+        <utrecht-table-cell>
+          {{ taak.aanleidinggevendKlantcontact?.nummer || "-" }}
         </utrecht-table-cell>
         <utrecht-table-cell>
           <router-link :to="`/contactmoment/${taak?.aanleidinggevendKlantcontact?.nummer}`"
@@ -45,3 +53,12 @@ import UrgentieBadge from "../UrgentieBadge.vue";
 
 defineProps<{ interneTaken: MyInterneTaakOverviewItem[] }>();
 </script>
+
+<style lang="scss" scoped>
+.text-truncate {
+  max-width: 200px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+</style>

--- a/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/MyInterneTakenTable.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/MyInterneTakenTable.vue
@@ -53,12 +53,3 @@ import UrgentieBadge from "../UrgentieBadge.vue";
 
 defineProps<{ interneTaken: MyInterneTaakOverviewItem[] }>();
 </script>
-
-<style lang="scss" scoped>
-.text-truncate {
-  max-width: 200px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-</style>

--- a/InterneTaakAfhandeling.Web.Client/src/types/internetaken.ts
+++ b/InterneTaakAfhandeling.Web.Client/src/types/internetaken.ts
@@ -351,4 +351,5 @@ export interface MyInterneTaakOverviewItem {
   afgehandeldOp?: string;
   aanleidinggevendKlantcontact?: Internetaken["aanleidinggevendKlantcontact"];
   urgentie?: UrgentieInfo | null;
+  afdelingNaam?: string | null;
 }

--- a/InterneTaakAfhandeling.Web.Server/Features/MyInterneTakenOverview/MyInterneTaakOverviewModel.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/MyInterneTakenOverview/MyInterneTaakOverviewModel.cs
@@ -13,4 +13,5 @@ public class MyInterneTaakOverviewItem
     public DateTimeOffset? AfgehandeldOp { get; init; }
     public Klantcontact? AanleidinggevendKlantcontact { get; init; }
     public UrgentieInfo? Urgentie { get; init; }
+    public string? AfdelingNaam { get; init; }
 }

--- a/InterneTaakAfhandeling.Web.Server/Features/MyInterneTakenOverview/MyInterneTakenOverviewService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/MyInterneTakenOverview/MyInterneTakenOverviewService.cs
@@ -13,10 +13,12 @@ namespace InterneTaakAfhandeling.Web.Server.Features.MyInterneTakenOverview
     }
     public class MyInterneTakenOverviewService(
         IOpenKlantApiClient openKlantApiClient,
-        IUrgentieBerekenService urgentieBerekenService) : IMyInterneTakenOverviewService
+        IUrgentieBerekenService urgentieBerekenService,
+        ILogger<MyInterneTakenOverviewService> logger) : IMyInterneTakenOverviewService
     {
         private readonly IOpenKlantApiClient _openKlantApiClient = openKlantApiClient;
         private readonly IUrgentieBerekenService _urgentieBerekenService = urgentieBerekenService;
+        private readonly ILogger<MyInterneTakenOverviewService> _logger = logger;
 
 
         public async Task<IReadOnlyList<MyInterneTaakOverviewItem>> GetInterneTakenByAssignedUser(ITAUser user, bool afgerond)
@@ -91,8 +93,9 @@ namespace InterneTaakAfhandeling.Web.Server.Features.MyInterneTakenOverview
             {
                 return await _openKlantApiClient.GetActorAsync(uuid);
             }
-            catch
+            catch (Exception ex)
             {
+                _logger.LogWarning(ex, "Failed to fetch actor {Uuid}", uuid);
                 return null;
             }
         }

--- a/InterneTaakAfhandeling.Web.Server/Features/MyInterneTakenOverview/MyInterneTakenOverviewService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/MyInterneTakenOverview/MyInterneTakenOverviewService.cs
@@ -37,15 +37,20 @@ namespace InterneTaakAfhandeling.Web.Server.Features.MyInterneTakenOverview
 
             var results = await Task.WhenAll(internetakenTasks);
 
-            return [.. results
+            var internetaken = results
                 .SelectMany(x => x)
                 .OrderByDescending(x => x.ToegewezenOp)
-                .Select(MapToOverviewItem)];
+                .ToList();
+
+            var overviewItems = await Task.WhenAll(internetaken.Select(MapToOverviewItemAsync));
+
+            return [.. overviewItems];
         }
 
-        private MyInterneTaakOverviewItem MapToOverviewItem(Internetaak internetaak)
+        private async Task<MyInterneTaakOverviewItem> MapToOverviewItemAsync(Internetaak internetaak)
         {
             var contactDatum = internetaak.AanleidinggevendKlantcontact?.PlaatsgevondenOp;
+            var afdelingNaam = await GetAfdelingNaamAsync(internetaak);
 
             return new MyInterneTaakOverviewItem
             {
@@ -56,8 +61,40 @@ namespace InterneTaakAfhandeling.Web.Server.Features.MyInterneTakenOverview
                 ToegewezenOp = internetaak.ToegewezenOp,
                 AfgehandeldOp = internetaak.AfgehandeldOp,
                 AanleidinggevendKlantcontact = internetaak.AanleidinggevendKlantcontact,
-                Urgentie = _urgentieBerekenService.Bereken(contactDatum)
+                Urgentie = _urgentieBerekenService.Bereken(contactDatum),
+                AfdelingNaam = afdelingNaam
             };
+        }
+
+        private async Task<string?> GetAfdelingNaamAsync(Internetaak internetaak)
+        {
+            if (internetaak.ToegewezenAanActoren?.Any() != true)
+                return null;
+
+            var actorTasks = internetaak.ToegewezenAanActoren
+                .Where(actorRef => !string.IsNullOrEmpty(actorRef.Uuid))
+                .Select(actorRef => GetActorSafeAsync(actorRef.Uuid));
+
+            var actors = await Task.WhenAll(actorTasks);
+
+            var afdelingActors = actors
+                .Where(a => a?.SoortActor != SoortActor.medewerker && !string.IsNullOrEmpty(a?.Naam))
+                .Select(a => a!.Naam)
+                .ToList();
+
+            return afdelingActors.Count != 0 ? string.Join(", ", afdelingActors) : null;
+        }
+
+        private async Task<Actor?> GetActorSafeAsync(string uuid)
+        {
+            try
+            {
+                return await _openKlantApiClient.GetActorAsync(uuid);
+            }
+            catch
+            {
+                return null;
+            }
         }
 
         private async Task<IReadOnlyList<string>> GetActorIds(ITAUser user)


### PR DESCRIPTION
## Summary

Behandelaars die contactverzoeken voor meerdere afdelingen verwerken hebben zicht nodig op de afdelingsnaam per item. Daarnaast willen zowel Coördinatoren als Behandelaars het klantcontactnummer (contactmomentnummer) zien om contactverzoeken snel te identificeren en refereren. Dit is onderdeel van Feature #402 (werklijst urgentie, sorteren & filteren).

## Changes

- **Backend model uitbreiding**: `AfdelingNaam` veld toegevoegd aan `MyInterneTaakOverviewModel`
- **Backend service uitbreiding**: `MyInterneTakenOverviewService` leidt afdeling-informatie af uit de actor-gegevens van de internetaak (zelfde patroon als `InterneTakenOverzichtService`)
- **Frontend — Mijn werkvoorraad**: kolommen "Afdeling" en "Klantcontactnummer" toegevoegd aan `MyInterneTakenTable.vue`
- **Frontend — Alle contactverzoeken**: kolom "Klantcontactnummer" toegevoegd aan `AllInterneTakenTable.vue`

## Test plan

Per [QA.md Phase 1](docs/steering/QA.md#phase-1-implementation-verification-feature-branch-pre-merge) — verificatie via code inspection. E2E tests volgen in Phase 2 na deploy.

- [ ] Behandelaar ziet kolom Afdeling op Mijn werkvoorraad
- [ ] Klantcontactnummer zichtbaar op Alle contactverzoeken
- [ ] Klantcontactnummer zichtbaar op Mijn werkvoorraad
- [ ] Edge case: contactverzoek zonder afdeling toont lege cel
- [ ] Edge case: klantcontact zonder nummer toont lege cel

## Related

Closes #499