### PR TITLE
feat(werklijst): add clickable rows with navigation and a11y support

### DIFF
--- a/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekScenarios.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekScenarios.cs
@@ -667,7 +667,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
 
             await Step("Given user is on Historie - When user clicks on a contactverzoek from the list");
             var contactverzoekRow = Page.Locator("table tbody tr").Filter(new() { HasText = testOnderwerp }).First;
-            var detailsLink = contactverzoekRow.GetByRole(AriaRole.Link).Filter(new() { HasText = "Klik hier" });
+            var detailsLink = contactverzoekRow.GetByRole(AriaRole.Link).Filter(new() { HasText = "→" });
             await detailsLink.ClickAsync();
 
             await Step("Then the detail screen of the contact request shows read-only mode for closed contactverzoek");
@@ -1183,7 +1183,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.Dashboard
             await Step("Find the closed contactverzoek in the history list and click through");
             await Expect(Page.Locator($"text={onderwerp}")).ToBeVisibleAsync();
             var contactverzoekRow = Page.Locator("table tbody tr").Filter(new() { HasText = onderwerp }).First;
-            await contactverzoekRow.GetByRole(AriaRole.Link).Filter(new() { HasText = "Klik hier" }).ClickAsync();
+            await contactverzoekRow.GetByRole(AriaRole.Link).Filter(new() { HasText = "→" }).ClickAsync();
 
             await Step("Verify all action controls are hidden");
             await Expect(Page.GetAfgehandeldMessage()).ToBeVisibleAsync();

--- a/InterneTaakAfhandeling.EndToEndTest/Infrastructure/Locators.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Infrastructure/Locators.cs
@@ -8,7 +8,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
         public static ILocator GetDetailsLink(this IPage page, string onderwerp)
         {
             var testRow = page.GetByRole(AriaRole.Row).Filter(new() { HasText = onderwerp }).First;
-            return testRow.GetByRole(AriaRole.Link).Filter(new() { HasText = "Klik hier" });
+            return testRow.GetByRole(AriaRole.Link).Filter(new() { HasText = "→" });
         }
 
         // Contactverzoek Details locators

--- a/InterneTaakAfhandeling.Web.Client/src/assets/main.scss
+++ b/InterneTaakAfhandeling.Web.Client/src/assets/main.scss
@@ -74,4 +74,20 @@
     overflow: hidden;
     text-overflow: ellipsis;
   }
+
+  .clickable-row {
+    cursor: pointer;
+
+    &:hover {
+      background-color: var(--ita-color-secondary);
+    }
+  }
+
+  .details-cell {
+    text-align: center;
+  }
+
+  .details-link {
+    text-decoration: none;
+  }
 }

--- a/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/AllInterneTakenTable.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/AllInterneTakenTable.vue
@@ -12,7 +12,9 @@
         <utrecht-table-header-cell scope="col">Afdeling</utrecht-table-header-cell>
         <utrecht-table-header-cell scope="col">Behandelaar</utrecht-table-header-cell>
         <utrecht-table-header-cell scope="col">Klantcontactnummer</utrecht-table-header-cell>
-        <utrecht-table-header-cell scope="col">Details</utrecht-table-header-cell>
+        <utrecht-table-header-cell scope="col" class="details-cell"
+          >Details</utrecht-table-header-cell
+        >
       </utrecht-table-row>
     </utrecht-table-header>
 
@@ -21,7 +23,13 @@
         <utrecht-table-cell colspan="8">Geen contactverzoeken gevonden</utrecht-table-cell>
       </utrecht-table-row>
 
-      <utrecht-table-row v-for="taak in interneTaken" :key="taak.uuid">
+      <utrecht-table-row
+        v-for="taak in interneTaken"
+        :key="taak.uuid"
+        class="clickable-row"
+        @mousedown="onRowMouseDown"
+        @click="navigateOnRowClick($event, `/contactmoment/${taak.contactmomentNummer}`)"
+      >
         <utrecht-table-cell class="ita-no-wrap">
           <date-time-or-nvt :date="taak.contactDatum || taak.toegewezenOp" />
         </utrecht-table-cell>
@@ -46,8 +54,14 @@
         <utrecht-table-cell>
           {{ taak.contactmomentNummer || "-" }}
         </utrecht-table-cell>
-        <utrecht-table-cell>
-          <router-link :to="`/contactmoment/${taak.contactmomentNummer}`">Klik hier</router-link>
+        <utrecht-table-cell class="details-cell">
+          <router-link
+            :to="`/contactmoment/${taak.contactmomentNummer}`"
+            :aria-label="`Open contactverzoek ${taak.klantNaam || taak.onderwerp || taak.contactmomentNummer || ''}`"
+            class="details-link"
+            @click.stop
+            >→</router-link
+          >
         </utrecht-table-cell>
       </utrecht-table-row>
     </utrecht-table-body>
@@ -55,11 +69,14 @@
 </template>
 
 <script setup lang="ts">
+import { useRowNavigation } from "@/composables/use-row-navigation";
 import DateTimeOrNvt from "../DateTimeOrNvt.vue";
 import UrgentieBadge from "../UrgentieBadge.vue";
 import type { UrgentieInfo } from "@/types/internetaken";
 
 defineProps<{ interneTaken: InterneTaakOverviewItem[] }>();
+
+const { onRowMouseDown, navigateOnRowClick } = useRowNavigation();
 
 export interface InterneTaakOverviewItem {
   uuid: string;

--- a/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/AllInterneTakenTable.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/AllInterneTakenTable.vue
@@ -26,9 +26,12 @@
       <utrecht-table-row
         v-for="taak in interneTaken"
         :key="taak.uuid"
-        class="clickable-row"
+        :class="{ 'clickable-row': taak.contactmomentNummer }"
         @mousedown="onRowMouseDown"
-        @click="navigateOnRowClick($event, `/contactmoment/${taak.contactmomentNummer}`)"
+        @click="
+          taak.contactmomentNummer &&
+          navigateOnRowClick($event, `/contactmoment/${taak.contactmomentNummer}`)
+        "
       >
         <utrecht-table-cell class="ita-no-wrap">
           <date-time-or-nvt :date="taak.contactDatum || taak.toegewezenOp" />
@@ -56,12 +59,14 @@
         </utrecht-table-cell>
         <utrecht-table-cell class="details-cell">
           <router-link
+            v-if="taak.contactmomentNummer"
             :to="`/contactmoment/${taak.contactmomentNummer}`"
-            :aria-label="`Open contactverzoek ${taak.klantNaam || taak.onderwerp || taak.contactmomentNummer || ''}`"
+            :aria-label="`Open contactverzoek ${taak.klantNaam || taak.onderwerp || taak.contactmomentNummer}`"
             class="details-link"
             @click.stop
             >→</router-link
           >
+          <span v-else>-</span>
         </utrecht-table-cell>
       </utrecht-table-row>
     </utrecht-table-body>

--- a/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/MyInterneTakenTable.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/MyInterneTakenTable.vue
@@ -22,10 +22,11 @@
       <utrecht-table-row
         v-for="taak in interneTaken"
         :key="taak.uuid"
-        class="clickable-row"
+        :class="{ 'clickable-row': taak.aanleidinggevendKlantcontact?.nummer }"
         @mousedown="onRowMouseDown"
         @click="
-          navigateOnRowClick($event, `/contactmoment/${taak?.aanleidinggevendKlantcontact?.nummer}`)
+          taak.aanleidinggevendKlantcontact?.nummer &&
+          navigateOnRowClick($event, `/contactmoment/${taak.aanleidinggevendKlantcontact.nummer}`)
         "
       >
         <utrecht-table-cell class="ita-no-wrap">
@@ -48,12 +49,14 @@
         </utrecht-table-cell>
         <utrecht-table-cell class="details-cell">
           <router-link
-            :to="`/contactmoment/${taak?.aanleidinggevendKlantcontact?.nummer}`"
-            :aria-label="`Open contactverzoek ${taak.aanleidinggevendKlantcontact?._expand?.hadBetrokkenen?.map((x) => x.volledigeNaam).find(Boolean) || taak.aanleidinggevendKlantcontact?.onderwerp || taak.aanleidinggevendKlantcontact?.nummer || ''}`"
+            v-if="taak.aanleidinggevendKlantcontact?.nummer"
+            :to="`/contactmoment/${taak.aanleidinggevendKlantcontact.nummer}`"
+            :aria-label="`Open contactverzoek ${getKlantLabel(taak)}`"
             class="details-link"
             @click.stop
             >→</router-link
           >
+          <span v-else>-</span>
         </utrecht-table-cell>
       </utrecht-table-row>
     </utrecht-table-body>
@@ -69,4 +72,14 @@ import UrgentieBadge from "../UrgentieBadge.vue";
 defineProps<{ interneTaken: MyInterneTaakOverviewItem[] }>();
 
 const { onRowMouseDown, navigateOnRowClick } = useRowNavigation();
+
+function getKlantLabel(taak: MyInterneTaakOverviewItem): string {
+  const contact = taak.aanleidinggevendKlantcontact;
+  return (
+    contact?._expand?.hadBetrokkenen?.map((x) => x.volledigeNaam).find(Boolean) ||
+    contact?.onderwerp ||
+    contact?.nummer ||
+    ""
+  );
+}
 </script>

--- a/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/MyInterneTakenTable.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/interne-taken-tables/MyInterneTakenTable.vue
@@ -8,7 +8,9 @@
         <utrecht-table-header-cell scope="col">Urgentie</utrecht-table-header-cell>
         <utrecht-table-header-cell scope="col">Afdeling</utrecht-table-header-cell>
         <utrecht-table-header-cell scope="col">Klantcontactnummer</utrecht-table-header-cell>
-        <utrecht-table-header-cell scope="col">Details</utrecht-table-header-cell>
+        <utrecht-table-header-cell scope="col" class="details-cell"
+          >Details</utrecht-table-header-cell
+        >
       </utrecht-table-row>
     </utrecht-table-header>
 
@@ -17,7 +19,15 @@
         <utrecht-table-cell colspan="7">Geen interne taken gevonden</utrecht-table-cell>
       </utrecht-table-row>
 
-      <utrecht-table-row v-for="taak in interneTaken" :key="taak.uuid">
+      <utrecht-table-row
+        v-for="taak in interneTaken"
+        :key="taak.uuid"
+        class="clickable-row"
+        @mousedown="onRowMouseDown"
+        @click="
+          navigateOnRowClick($event, `/contactmoment/${taak?.aanleidinggevendKlantcontact?.nummer}`)
+        "
+      >
         <utrecht-table-cell class="ita-no-wrap">
           <date-time-or-nvt :date="taak.aanleidinggevendKlantcontact?.plaatsgevondenOp" />
         </utrecht-table-cell>
@@ -36,9 +46,13 @@
         <utrecht-table-cell>
           {{ taak.aanleidinggevendKlantcontact?.nummer || "-" }}
         </utrecht-table-cell>
-        <utrecht-table-cell>
-          <router-link :to="`/contactmoment/${taak?.aanleidinggevendKlantcontact?.nummer}`"
-            >Klik hier</router-link
+        <utrecht-table-cell class="details-cell">
+          <router-link
+            :to="`/contactmoment/${taak?.aanleidinggevendKlantcontact?.nummer}`"
+            :aria-label="`Open contactverzoek ${taak.aanleidinggevendKlantcontact?._expand?.hadBetrokkenen?.map((x) => x.volledigeNaam).find(Boolean) || taak.aanleidinggevendKlantcontact?.onderwerp || taak.aanleidinggevendKlantcontact?.nummer || ''}`"
+            class="details-link"
+            @click.stop
+            >→</router-link
           >
         </utrecht-table-cell>
       </utrecht-table-row>
@@ -47,9 +61,12 @@
 </template>
 
 <script setup lang="ts">
+import { useRowNavigation } from "@/composables/use-row-navigation";
 import type { MyInterneTaakOverviewItem } from "@/types/internetaken";
 import DateTimeOrNvt from "../DateTimeOrNvt.vue";
 import UrgentieBadge from "../UrgentieBadge.vue";
 
 defineProps<{ interneTaken: MyInterneTaakOverviewItem[] }>();
+
+const { onRowMouseDown, navigateOnRowClick } = useRowNavigation();
 </script>

--- a/InterneTaakAfhandeling.Web.Client/src/composables/use-row-navigation.ts
+++ b/InterneTaakAfhandeling.Web.Client/src/composables/use-row-navigation.ts
@@ -4,12 +4,11 @@ export function useRowNavigation() {
   const router = useRouter();
 
   // Track where the press started so click can tell a drag from a tap.
-  let x = 0,
-    y = 0;
+  // null = no recorded start, so skip the drag check (e.g. touch/pointer).
+  let start: { x: number; y: number } | null = null;
 
   const onRowMouseDown = (e: MouseEvent) => {
-    x = e.clientX;
-    y = e.clientY;
+    start = { x: e.clientX, y: e.clientY };
   };
 
   const navigateOnRowClick = (e: MouseEvent, path: string) => {
@@ -17,7 +16,12 @@ export function useRowNavigation() {
     if ((e.target as HTMLElement).closest("a")) return;
 
     // Skip nav if the user was drag-selecting text (pointer moved >5px).
-    if (Math.abs(e.clientX - x) > 5 || Math.abs(e.clientY - y) > 5) return;
+    if (start) {
+      const dx = Math.abs(e.clientX - start.x);
+      const dy = Math.abs(e.clientY - start.y);
+      start = null;
+      if (dx > 5 || dy > 5) return;
+    }
 
     router.push(path);
   };

--- a/InterneTaakAfhandeling.Web.Client/src/composables/use-row-navigation.ts
+++ b/InterneTaakAfhandeling.Web.Client/src/composables/use-row-navigation.ts
@@ -1,0 +1,26 @@
+import { useRouter } from "vue-router";
+
+export function useRowNavigation() {
+  const router = useRouter();
+
+  // Track where the press started so click can tell a drag from a tap.
+  let x = 0,
+    y = 0;
+
+  const onRowMouseDown = (e: MouseEvent) => {
+    x = e.clientX;
+    y = e.clientY;
+  };
+
+  const navigateOnRowClick = (e: MouseEvent, path: string) => {
+    // Let clicks on links behave as links, not row navigation.
+    if ((e.target as HTMLElement).closest("a")) return;
+
+    // Skip nav if the user was drag-selecting text (pointer moved >5px).
+    if (Math.abs(e.clientX - x) > 5 || Math.abs(e.clientY - y) > 5) return;
+
+    router.push(path);
+  };
+
+  return { onRowMouseDown, navigateOnRowClick };
+}


### PR DESCRIPTION
## Summary

Make the entire row of a contactverzoek clickable to navigate to its detail page, replacing "Klik hier" with a centered "→" arrow. Adds hover feedback and follows WCAG 2.1 a11y guidelines.

### Changes

- **`use-row-navigation.ts`** — New composable with drag-detection guard (prevents navigation during text selection)
- **`main.scss`** — Global utility classes for clickable rows, centered details cell, and no-underline link
- **`AllInterneTakenTable.vue`** / **`MyInterneTakenTable.vue`** — Clickable rows with `@mousedown` + `@click`, "→" link with descriptive `aria-label`
- **`Locators.cs`** / **`ContactverzoekScenarios.cs`** — E2E test locator updates

### A11y

- `<router-link>` preserved as keyboard-focusable link with `aria-label`
- No ARIA roles added to `<tr>` — table semantics preserved
- Hover effect via CSS only (pointer + background)

Closes #503