### PR TITLE
docs: move QA checklists into issue templates for automatic enforcement

### DIFF
--- a/.github/ISSUE_TEMPLATE/FEATURE.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE.md
@@ -82,3 +82,10 @@ assignees: ""
 <!-- Onderliggende taken — link issues zodra ze aangemaakt worden. -->
 
 - [ ]
+
+---
+
+## Administration
+
+Coöperatie Dimpact | Dimpact: ITA-VNGsubsidie
+Dimpact: ITA-VNGsubsidie

--- a/.github/ISSUE_TEMPLATE/FEATURE.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE.md
@@ -61,6 +61,22 @@ assignees: ""
 
 ---
 
+## Feature Completion Checklist
+
+<!-- Each item is "if applicable" — skip items that don't apply, but document why. Source: docs/steering/QA.md -->
+
+- [ ] **Changelog** — An entry has been added to the top of the changelog with the feature/bug name and a link to the GitHub issue. If there are new environment variables or other upgrade-relevant changes, they are mentioned here.
+- [ ] **Manual** — Installation & configuration manual have been updated. Environment variables and anything else needed to install/run ITA are explained.
+- [ ] **Helm** — New release variables have been included in the Helm charts/values files.
+- [ ] **Readme** — README has been updated with information on how to run the applications locally.
+- [ ] **User secrets** — User secrets in 1Password have been added/updated.
+- [ ] **Decision record** — Any significant architectural or design decisions have been documented in `docs/decision-record/`.
+- [ ] **Cleanup** — Branches, test data, temporary copies of databases, files, and temporary K8S clusters have been cleaned up.
+- [ ] **UX** — Significant design changes have been checked with a UX specialist.
+- [ ] **Test documentation** — Regression test scenarios not covered by automated tests, known issues, and things deliberately not tested are documented.
+
+---
+
 ## Proposed Tasks
 
 <!-- Onderliggende taken — link issues zodra ze aangemaakt worden. -->

--- a/.github/ISSUE_TEMPLATE/TASK.md
+++ b/.github/ISSUE_TEMPLATE/TASK.md
@@ -149,13 +149,12 @@ Feature: {{feature_name}}
 
 ## Definition of Done
 
-- [ ] Contracts match implementation
-- [ ] All Gherkin scenarios covered by tests
-- [ ] Edge cases handled
-- [ ] Observability in place
-- [ ] Code reviewed
-- [ ] Design reviewed (if UI)
-- [ ] Documentation updated
+<!-- Bron: docs/steering/QA.md — Task-level DoD -->
+
+- [ ] Linting passes (`npm run lint:ci`)
+- [ ] Formatting passes (`npm run format:ci`)
+- [ ] PR approved by at least one reviewer
+- [ ] No unrelated changes or scope creep
 
 ---
 

--- a/docs/steering/QA.md
+++ b/docs/steering/QA.md
@@ -115,10 +115,7 @@ Every Gherkin scenario from a Task issue must map to at least one Playwright E2E
 
 Tasks are reviewed and merged into the feature branch. E2E testing happens at feature level in Phase 2.
 
-- [ ] Linting passes (`npm run lint:ci`)
-- [ ] Formatting passes (`npm run format:ci`)
-- [ ] PR approved by at least one reviewer
-- [ ] No unrelated changes or scope creep
+This checklist is maintained in the [Task issue template](/.github/ISSUE_TEMPLATE/TASK.md) and appears on every Task automatically. See that template for the full list.
 
 ### Feature-level DoD — Phase 1 (feature PR → main)
 

--- a/docs/steering/QA.md
+++ b/docs/steering/QA.md
@@ -92,15 +92,7 @@ A Feature is only considered **fully complete** when both phases are done:
 
 In addition to the two verification phases, every Feature must satisfy these items before it can be closed. Each item is "if applicable" — skip items that don't apply to the Feature, but document why.
 
-- [ ] **Changelog** — An entry has been added to the top of the changelog with the feature/bug name and a link to the GitHub issue. If there are new environment variables or other upgrade-relevant changes, they are mentioned here.
-- [ ] **Manual** — Installation & configuration manual have been updated. Environment variables and anything else needed to install/run ITA are explained.
-- [ ] **Helm** — New release variables have been included in the Helm charts/values files.
-- [ ] **Readme** — README has been updated with information on how to run the applications locally.
-- [ ] **User secrets** — User secrets in 1Password have been added/updated.
-- [ ] **Decision record** — Any significant architectural or design decisions have been documented in `docs/decision-record/`.
-- [ ] **Cleanup** — Branches, test data, temporary copies of databases, files, and temporary K8S clusters have been cleaned up.
-- [ ] **UX** — Significant design changes have been checked with a UX specialist.
-- [ ] **Test documentation** — Regression test scenarios not covered by automated tests, known issues, and things deliberately not tested are documented.
+This checklist is maintained in the [Feature issue template](/.github/ISSUE_TEMPLATE/FEATURE.md) and appears on every Feature automatically. See that template for the full list.
 
 ---
 


### PR DESCRIPTION
## Summary

QA.md defines Definition of Done checklists and a Feature Completion Checklist, but these only surfaced during issue creation if QA.md was explicitly consulted. This PR moves the checklists into the issue templates so they appear on every Feature and Task by default, and replaces the duplicates in QA.md with references to the templates as the single source of truth.

Also adds an Administration section to the Feature template for hour registration (requested by scrummaster).

## Changes

- **FEATURE.md template** — Added Feature Completion Checklist (9 items) and Administration section with Dimpact project reference
- **TASK.md template** — Replaced generic DoD with the specific Task-level DoD items from QA.md
- **QA.md** — Replaced duplicate checklists with references to the respective issue templates

## Test plan

- [ ] Create a new Feature issue and verify the Feature Completion Checklist and Administration section appear
- [ ] Create a new Task issue and verify the Task-level DoD appears
- [ ] Confirm QA.md references point to the correct template paths

## Related

<!-- No linked task -->