### PR TITLE
test(contactverzoek): verify afdeling/groep access control

### DIFF
--- a/InterneTaakAfhandeling.EndToEndTest/AlleContactverzoeken/AlleContactverzoekenAccessScenarios.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/AlleContactverzoeken/AlleContactverzoekenAccessScenarios.cs
@@ -65,11 +65,12 @@ namespace InterneTaakAfhandeling.EndToEndTest.AlleContactverzoeken
         //   Playwright tests only what is rendered in the browser. SMTP-delivered e-mail
         //   content is not accessible and cannot be asserted.
 
-        // TODO: Requires a non-admin test user account to be configured in the test infrastructure.
-        // The current ITAPlaywrightTest base class only supports a single authenticated user (Beheerder).
+        // TODO: Uncomment when non-admin test user account is configured (see AuthenticateAsNonAdminAsync in ITAPlaywrightTest).
         // [TestMethod("Medewerker zonder beheerderrol wordt geblokkeerd bij directe URL")]
         // public async Task NietBeheerder_WordtGeblokkeerd_BijDirecteUrlAlleContactverzoeken()
         // {
+        //     await AuthenticateAsNonAdminAsync();
+        //
         //     await Step("Navigate directly to /alle-contactverzoeken as non-admin");
         //     await Page.GotoAsync("/alle-contactverzoeken");
         //     await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);

--- a/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekToegangsbeperkingenScenarios.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekToegangsbeperkingenScenarios.cs
@@ -1,0 +1,37 @@
+using System;
+using InterneTaakAfhandeling.EndToEndTest.Infrastructure;
+using Microsoft.Playwright;
+
+namespace InterneTaakAfhandeling.EndToEndTest.Contactverzoek
+{
+    // Feature #514 — Toegang tot Contactverzoeken beperkt tot eigen afdeling/groep
+    // Task #544 — Phase 2 E2E-verificatie (implementatie is al gemerged, zie ITA-514)
+    [TestClass]
+    [DoNotParallelize]
+    public class ContactverzoekToegangsbeperkingenScenarios : ITAPlaywrightTest
+    {
+        // The only afdeling confirmed present in the test objectenregister today (used
+        // throughout TestDataHelper).
+        private const string BestaandeAfdeling = "Burgerzaken_ibz";
+
+        [TestMethod("Beheerder kan Contactverzoek van elke afdeling inzien")]
+        public async Task Beheerder_CanAccessContactverzoek_VanAndereAfdeling()
+        {
+            // Any afdeling proves the point here — the beheerder-exception in
+            // ContactverzoekAutorisatieGuardService bypasses the afdeling/groep check entirely,
+            // so we use the one afdeling confirmed to exist in the test objectenregister.
+            await Step("Given een Contactverzoek toegewezen aan afdeling 'Burgerzaken_ibz'");
+            var onderwerp = $"Test_Toegang_Beheerder_{Guid.NewGuid().ToString()[..8]}";
+            var (contactmomentUuid, klantcontactNummer, _) = await TestDataHelper.CreateContactverzoekWithAfdelingOnlyAndContactDatum(
+                onderwerp, DateTime.UtcNow, BestaandeAfdeling);
+            RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(contactmomentUuid.ToString()));
+
+            await Step("When de beheerder het Contactverzoek opent via de detail-URL");
+            await Page.GotoAsync($"/contactmoment/{klantcontactNummer}");
+
+            await Step("Then wordt de Contactverzoek-detailpagina getoond met inhoudelijke gegevens");
+            await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = $"Contactverzoek {klantcontactNummer}" })).ToBeVisibleAsync();
+            await Expect(Page.Locator($"text={onderwerp}")).ToBeVisibleAsync();
+        }
+    }
+}

--- a/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekToegangsbeperkingenScenarios.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekToegangsbeperkingenScenarios.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.RegularExpressions;
 using InterneTaakAfhandeling.EndToEndTest.Infrastructure;
 using Microsoft.Playwright;
 
@@ -11,8 +12,12 @@ namespace InterneTaakAfhandeling.EndToEndTest.Contactverzoek
     public class ContactverzoekToegangsbeperkingenScenarios : ITAPlaywrightTest
     {
         // The only afdeling confirmed present in the test objectenregister today (used
-        // throughout TestDataHelper).
+        // throughout TestDataHelper). "Financien_ibz" below is a placeholder for the second,
+        // distinct afdeling the Gherkin scenarios need — not yet confirmed to exist.
         private const string BestaandeAfdeling = "Burgerzaken_ibz";
+        private const string AndereAfdelingPlaceholder = "Financien_ibz";
+        private const string GeenToegangMelding = "Je hebt geen toegang tot dit contactverzoek";
+        private const string NietGevondenMelding = "Dit contactverzoek bestaat niet of is niet meer beschikbaar";
 
         [TestMethod("Beheerder kan Contactverzoek van elke afdeling inzien")]
         public async Task Beheerder_CanAccessContactverzoek_VanAndereAfdeling()
@@ -32,6 +37,139 @@ namespace InterneTaakAfhandeling.EndToEndTest.Contactverzoek
             await Step("Then wordt de Contactverzoek-detailpagina getoond met inhoudelijke gegevens");
             await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = $"Contactverzoek {klantcontactNummer}" })).ToBeVisibleAsync();
             await Expect(Page.Locator($"text={onderwerp}")).ToBeVisibleAsync();
+        }
+
+        // Onderstaande 5 scenario's vereisen een non-admin behandelaar-testaccount dat nog niet
+        // bestaat in de test-infrastructuur (zelfde blokkade als de bestaande TODO's in
+        // AlleContactverzoekenAccessScenarios.cs / AlleContactverzoekenNavigatieScenarios.cs).
+        // Ze zijn volledig geïmplementeerd en compileren, maar staan op [Ignore] tot:
+        //   1. TestSettings:TEST_USERNAME_NON_ADMIN / TEST_PASSWORD_NON_ADMIN / TEST_TOTP_SECRET_NON_ADMIN
+        //      zijn geconfigureerd via dotnet user-secrets voor een Azure AD-account zonder de
+        //      FunctioneelBeheerder-rol;
+        //   2. dat account een medewerker-actor heeft gekoppeld aan afdeling "Burgerzaken_ibz";
+        //   3. een tweede, andere afdelingsnaam bevestigd bestaat in het testregister (hier
+        //      gebruikt als placeholder "Financien_ibz").
+        // Zie Task #544 (Technical Approach) voor details. Verwijder [Ignore] zodra opgelost.
+
+        [Ignore("Vereist non-admin behandelaar-testaccount — zie class-level comment (Task #544).")]
+        [TestMethod("Behandelaar kan Contactverzoek van eigen afdeling inzien")]
+        public async Task Behandelaar_CanAccessContactverzoek_VanEigenAfdeling()
+        {
+            await HandleAuthenticationAsync(
+                Configuration["TestSettings:TEST_USERNAME_NON_ADMIN"],
+                Configuration["TestSettings:TEST_PASSWORD_NON_ADMIN"]);
+
+            await Step("Given een Contactverzoek toegewezen aan de eigen afdeling van de behandelaar");
+            var onderwerp = $"Test_Toegang_EigenAfdeling_{Guid.NewGuid().ToString()[..8]}";
+            var (contactmomentUuid, klantcontactNummer, _) = await TestDataHelper.CreateContactverzoekWithAfdelingOnlyAndContactDatum(
+                onderwerp, DateTime.UtcNow, BestaandeAfdeling);
+            RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(contactmomentUuid.ToString()));
+
+            await Step("When de behandelaar het Contactverzoek opent via de detail-URL");
+            await Page.GotoAsync($"/contactmoment/{klantcontactNummer}");
+
+            await Step("Then wordt de Contactverzoek-detailpagina getoond met inhoudelijke gegevens");
+            await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = $"Contactverzoek {klantcontactNummer}" })).ToBeVisibleAsync();
+            await Expect(Page.Locator($"text={onderwerp}")).ToBeVisibleAsync();
+        }
+
+        [Ignore("Vereist non-admin behandelaar-testaccount — zie class-level comment (Task #544).")]
+        [TestMethod("Behandelaar kan Contactverzoek van andere afdeling niet inzien")]
+        public async Task Behandelaar_CanNotAccessContactverzoek_VanAndereAfdeling()
+        {
+            await HandleAuthenticationAsync(
+                Configuration["TestSettings:TEST_USERNAME_NON_ADMIN"],
+                Configuration["TestSettings:TEST_PASSWORD_NON_ADMIN"]);
+
+            await Step("Given een Contactverzoek toegewezen aan een andere afdeling dan de behandelaar");
+            var onderwerp = $"Test_GeenToegang_AndereAfdeling_{Guid.NewGuid().ToString()[..8]}";
+            var (contactmomentUuid, klantcontactNummer, _) = await TestDataHelper.CreateContactverzoekWithAfdelingOnlyAndContactDatum(
+                onderwerp, DateTime.UtcNow, AndereAfdelingPlaceholder);
+            RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(contactmomentUuid.ToString()));
+
+            await Step("When de behandelaar het Contactverzoek opent via de detail-URL");
+            await Page.GotoAsync($"/contactmoment/{klantcontactNummer}");
+
+            await Step("Then wordt de melding 'Je hebt geen toegang tot dit contactverzoek' getoond");
+            await Expect(Page.GetGeenToegangAlert()).ToBeVisibleAsync();
+
+            await Step("And zijn er geen inhoudelijke gegevens zichtbaar");
+            await Expect(Page.Locator($"text={onderwerp}")).Not.ToBeVisibleAsync();
+        }
+
+        [Ignore("Vereist non-admin behandelaar-testaccount — zie class-level comment (Task #544).")]
+        [TestMethod("Geen-toegang-melding is onderscheiden van niet-gevonden")]
+        public async Task GeenToegangMelding_IsOnderscheidenVanNietGevonden()
+        {
+            await HandleAuthenticationAsync(
+                Configuration["TestSettings:TEST_USERNAME_NON_ADMIN"],
+                Configuration["TestSettings:TEST_PASSWORD_NON_ADMIN"]);
+
+            await Step("Given een Contactverzoek toegewezen aan een andere afdeling dan de behandelaar");
+            var onderwerp = $"Test_GeenToegang_VsNietGevonden_{Guid.NewGuid().ToString()[..8]}";
+            var (contactmomentUuid, klantcontactNummer, _) = await TestDataHelper.CreateContactverzoekWithAfdelingOnlyAndContactDatum(
+                onderwerp, DateTime.UtcNow, AndereAfdelingPlaceholder);
+            RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(contactmomentUuid.ToString()));
+
+            await Step("When de behandelaar het Contactverzoek opent via de detail-URL");
+            await Page.GotoAsync($"/contactmoment/{klantcontactNummer}");
+
+            await Step("Then wordt de geen-toegang-melding getoond, niet de niet-gevonden-melding");
+            await Expect(Page.GetGeenToegangAlert()).ToBeVisibleAsync();
+            await Expect(Page.GetByText(NietGevondenMelding)).Not.ToBeVisibleAsync();
+        }
+
+        [Ignore("Vereist non-admin behandelaar-testaccount — zie class-level comment (Task #544).")]
+        [TestMethod("Geen inhoudelijke gegevens in API-response bij geen toegang")]
+        public async Task ApiResponse_BevatGeenInhoudelijkeGegevens_BijGeenToegang()
+        {
+            await HandleAuthenticationAsync(
+                Configuration["TestSettings:TEST_USERNAME_NON_ADMIN"],
+                Configuration["TestSettings:TEST_PASSWORD_NON_ADMIN"]);
+
+            await Step("Given een Contactverzoek toegewezen aan een andere afdeling dan de behandelaar");
+            var onderwerp = $"Test_ApiGeenToegang_{Guid.NewGuid().ToString()[..8]}";
+            var (contactmomentUuid, klantcontactNummer, afdelingNaam) = await TestDataHelper.CreateContactverzoekWithAfdelingOnlyAndContactDatum(
+                onderwerp, DateTime.UtcNow, AndereAfdelingPlaceholder);
+            RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(contactmomentUuid.ToString()));
+
+            await Step("When de API-call naar het by-klantcontact-endpoint wordt gedaan");
+            var response = await Page.Context.APIRequest.GetAsync(
+                $"/api/internetaken/by-klantcontact/{Uri.EscapeDataString(klantcontactNummer)}");
+
+            await Step("Then is de HTTP-statuscode 403");
+            Assert.AreEqual(403, response.Status, "Expected HTTP 403 when behandelaar has no access to the contactverzoek");
+
+            await Step("And bevat de response body geen inhoudelijke gegevens");
+            var body = await response.TextAsync();
+            Assert.IsTrue(body.Contains(GeenToegangMelding), "Response body should contain the geen-toegang message");
+            Assert.IsFalse(body.Contains(onderwerp), "Response body should not leak the onderwerp");
+            Assert.IsFalse(body.Contains(afdelingNaam), "Response body should not leak the afdelingnaam");
+            Assert.IsFalse(body.Contains(klantcontactNummer), "Response body should not leak the klantcontactnummer");
+            Assert.IsFalse(body.Contains(contactmomentUuid.ToString()), "Response body should not leak the contactmoment UUID");
+        }
+
+        [Ignore("Vereist non-admin behandelaar-testaccount — zie class-level comment (Task #544).")]
+        [TestMethod("Directe URL-navigatie respecteert autorisatie")]
+        public async Task DirecteUrlNavigatie_RespecteertAutorisatie()
+        {
+            await HandleAuthenticationAsync(
+                Configuration["TestSettings:TEST_USERNAME_NON_ADMIN"],
+                Configuration["TestSettings:TEST_PASSWORD_NON_ADMIN"]);
+
+            await Step("Given een Contactverzoek toegewezen aan een andere afdeling dan de behandelaar");
+            var onderwerp = $"Test_DirecteUrl_{Guid.NewGuid().ToString()[..8]}";
+            var (contactmomentUuid, klantcontactNummer, _) = await TestDataHelper.CreateContactverzoekWithAfdelingOnlyAndContactDatum(
+                onderwerp, DateTime.UtcNow, AndereAfdelingPlaceholder);
+            RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(contactmomentUuid.ToString()));
+
+            await Step("When de gebruiker handmatig navigeert naar de directe URL");
+            var directUrl = $"/contactmoment/{klantcontactNummer}";
+            await Page.GotoAsync(directUrl);
+
+            await Step("Then wordt de geen-toegang-melding getoond en wordt niet doorgestuurd");
+            await Expect(Page.GetGeenToegangAlert()).ToBeVisibleAsync();
+            await Expect(Page).ToHaveURLAsync(new Regex(Regex.Escape(directUrl)));
         }
     }
 }

--- a/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekToegangsbeperkingenScenarios.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/ContactverzoekToegangsbeperkingenScenarios.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text.RegularExpressions;
+using EndToEndTest.Common.Infrastructure;
 using InterneTaakAfhandeling.EndToEndTest.Infrastructure;
 using Microsoft.Playwright;
 
@@ -18,6 +19,30 @@ namespace InterneTaakAfhandeling.EndToEndTest.Contactverzoek
         private const string AndereAfdelingPlaceholder = "Financien_ibz";
         private const string GeenToegangMelding = "Je hebt geen toegang tot dit contactverzoek";
         private const string NietGevondenMelding = "Dit contactverzoek bestaat niet of is niet meer beschikbaar";
+
+        private static UniqueOtpHelper? s_nonAdminOtpHelper;
+
+        // Shared auth state (auth.json) logs every test in as the default beheerder account, and
+        // AzureAdLoginHelper.LoginAsync() no-ops if a session is already active. Clearing storage
+        // first forces a real Azure AD login as the non-admin account instead of silently staying
+        // logged in as beheerder. Uses its own UniqueOtpHelper because s_uniqueOtpHelper is bound to
+        // TEST_TOTP_SECRET (beheerder's secret), not TEST_TOTP_SECRET_NON_ADMIN.
+        private async Task AuthenticateAsNonAdminAsync()
+        {
+            var username = Configuration["TestSettings:TEST_USERNAME_NON_ADMIN"]
+                ?? throw new InvalidOperationException("Missing TestSettings:TEST_USERNAME_NON_ADMIN (non-admin test account required; see Task #544).");
+            var password = Configuration["TestSettings:TEST_PASSWORD_NON_ADMIN"]
+                ?? throw new InvalidOperationException("Missing TestSettings:TEST_PASSWORD_NON_ADMIN (non-admin test account required; see Task #544).");
+            var totpSecret = Configuration["TestSettings:TEST_TOTP_SECRET_NON_ADMIN"]
+                ?? throw new InvalidOperationException("Missing TestSettings:TEST_TOTP_SECRET_NON_ADMIN (non-admin TOTP required; see Task #544).");
+
+            await Context.ClearCookiesAsync();
+            await Page.EvaluateAsync("() => { localStorage.clear(); sessionStorage.clear(); }");
+
+            s_nonAdminOtpHelper ??= new UniqueOtpHelper(totpSecret);
+            var loginHelper = new AzureAdLoginHelper(Page, username, password, s_nonAdminOtpHelper);
+            await loginHelper.LoginAsync();
+        }
 
         [TestMethod("Beheerder kan Contactverzoek van elke afdeling inzien")]
         public async Task Beheerder_CanAccessContactverzoek_VanAndereAfdeling()
@@ -55,9 +80,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.Contactverzoek
         [TestMethod("Behandelaar kan Contactverzoek van eigen afdeling inzien")]
         public async Task Behandelaar_CanAccessContactverzoek_VanEigenAfdeling()
         {
-            await HandleAuthenticationAsync(
-                Configuration["TestSettings:TEST_USERNAME_NON_ADMIN"],
-                Configuration["TestSettings:TEST_PASSWORD_NON_ADMIN"]);
+            await AuthenticateAsNonAdminAsync();
 
             await Step("Given een Contactverzoek toegewezen aan de eigen afdeling van de behandelaar");
             var onderwerp = $"Test_Toegang_EigenAfdeling_{Guid.NewGuid().ToString()[..8]}";
@@ -77,9 +100,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.Contactverzoek
         [TestMethod("Behandelaar kan Contactverzoek van andere afdeling niet inzien")]
         public async Task Behandelaar_CanNotAccessContactverzoek_VanAndereAfdeling()
         {
-            await HandleAuthenticationAsync(
-                Configuration["TestSettings:TEST_USERNAME_NON_ADMIN"],
-                Configuration["TestSettings:TEST_PASSWORD_NON_ADMIN"]);
+            await AuthenticateAsNonAdminAsync();
 
             await Step("Given een Contactverzoek toegewezen aan een andere afdeling dan de behandelaar");
             var onderwerp = $"Test_GeenToegang_AndereAfdeling_{Guid.NewGuid().ToString()[..8]}";
@@ -101,9 +122,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.Contactverzoek
         [TestMethod("Geen-toegang-melding is onderscheiden van niet-gevonden")]
         public async Task GeenToegangMelding_IsOnderscheidenVanNietGevonden()
         {
-            await HandleAuthenticationAsync(
-                Configuration["TestSettings:TEST_USERNAME_NON_ADMIN"],
-                Configuration["TestSettings:TEST_PASSWORD_NON_ADMIN"]);
+            await AuthenticateAsNonAdminAsync();
 
             await Step("Given een Contactverzoek toegewezen aan een andere afdeling dan de behandelaar");
             var onderwerp = $"Test_GeenToegang_VsNietGevonden_{Guid.NewGuid().ToString()[..8]}";
@@ -123,9 +142,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.Contactverzoek
         [TestMethod("Geen inhoudelijke gegevens in API-response bij geen toegang")]
         public async Task ApiResponse_BevatGeenInhoudelijkeGegevens_BijGeenToegang()
         {
-            await HandleAuthenticationAsync(
-                Configuration["TestSettings:TEST_USERNAME_NON_ADMIN"],
-                Configuration["TestSettings:TEST_PASSWORD_NON_ADMIN"]);
+            await AuthenticateAsNonAdminAsync();
 
             await Step("Given een Contactverzoek toegewezen aan een andere afdeling dan de behandelaar");
             var onderwerp = $"Test_ApiGeenToegang_{Guid.NewGuid().ToString()[..8]}";
@@ -153,9 +170,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.Contactverzoek
         [TestMethod("Directe URL-navigatie respecteert autorisatie")]
         public async Task DirecteUrlNavigatie_RespecteertAutorisatie()
         {
-            await HandleAuthenticationAsync(
-                Configuration["TestSettings:TEST_USERNAME_NON_ADMIN"],
-                Configuration["TestSettings:TEST_PASSWORD_NON_ADMIN"]);
+            await AuthenticateAsNonAdminAsync();
 
             await Step("Given een Contactverzoek toegewezen aan een andere afdeling dan de behandelaar");
             var onderwerp = $"Test_DirecteUrl_{Guid.NewGuid().ToString()[..8]}";
@@ -170,6 +185,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.Contactverzoek
             await Step("Then wordt de geen-toegang-melding getoond en wordt niet doorgestuurd");
             await Expect(Page.GetGeenToegangAlert()).ToBeVisibleAsync();
             await Expect(Page).ToHaveURLAsync(new Regex(Regex.Escape(directUrl)));
+            Assert.AreEqual(directUrl, new Uri(Page.Url).AbsolutePath, "Expected to stay on the same detail URL path (no redirect).");
         }
     }
 }

--- a/InterneTaakAfhandeling.EndToEndTest/Infrastructure/ITAPlaywrightTest.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Infrastructure/ITAPlaywrightTest.cs
@@ -585,5 +585,28 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
                     $"Error: {ex.Message}", ex);
             }
         }
+
+        // TODO: Uncomment when non-admin test user account is configured in the test infrastructure (planned in a few weeks).
+        // /// <summary>
+        // /// Authenticates as a non-admin user using credentials from configuration.
+        // /// Use in an overridden <see cref="TestInitialize"/> before calling <c>base.TestInitialize()</c>
+        // /// to run a test as a medewerker zonder beheerder role.
+        // /// Requires <c>TestSettings:TEST_NONADMIN_USERNAME</c> and <c>TestSettings:TEST_NONADMIN_PASSWORD</c>
+        // /// to be configured.
+        // /// </summary>
+        // protected async Task AuthenticateAsNonAdminAsync()
+        // {
+        //     var username = s_configuration["TestSettings:TEST_NONADMIN_USERNAME"];
+        //     var password = s_configuration["TestSettings:TEST_NONADMIN_PASSWORD"];
+        //
+        //     if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password))
+        //     {
+        //         Assert.Inconclusive(
+        //             "Non-admin test user is not configured. " +
+        //             "Set TestSettings:TEST_NONADMIN_USERNAME and TestSettings:TEST_NONADMIN_PASSWORD to enable this test.");
+        //     }
+        //
+        //     await HandleAuthenticationAsync(username, password);
+        // }
     }
 }

--- a/InterneTaakAfhandeling.EndToEndTest/Infrastructure/Locators.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Infrastructure/Locators.cs
@@ -219,6 +219,10 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
         public static ILocator GetAfgehandeldMessage(this IPage page) =>
             page.GetByText("Dit contactverzoek is afgehandeld en kan niet meer worden gewijzigd.");
 
+        // Feature #514 — geen-toegang error alert on the Contactverzoek detail page
+        public static ILocator GetGeenToegangAlert(this IPage page) =>
+            page.GetByRole(AriaRole.Alert).Filter(new() { HasText = "Je hebt geen toegang tot dit contactverzoek" });
+
         // Heropenen locators
         public static ILocator GetHeropenButton(this IPage page) =>
             page.GetByRole(AriaRole.Button, new() { Name = "Heropenen" });


### PR DESCRIPTION
## Summary

Feature #514 (server-side afdeling/groep authorization on the `by-klantcontact` endpoint) was already implemented and merged to `main` directly, without going through formal Tasks. Task #544 is the Phase 2 E2E verification task (per `docs/steering/QA.md`'s two-phase workflow) that proves the deployed authorization guard actually behaves as specified — a behandelaar can only see Contactverzoeken in their own afdeling/groep, a beheerder is exempt, and denied access never leaks contactverzoek data.

## Changes

- Added `ContactverzoekToegangsbeperkingenScenarios.cs` with one `[TestMethod]` per Gherkin scenario in Task #544 (6 total).
- Added `GetGeenToegangAlert()` to `Locators.cs` for the "Je hebt geen toegang tot dit contactverzoek" alert on the Contactverzoek detail page.
- **1/6 scenarios pass today** (verified against `ita.test.icatt.nl`): Beheerder can access a Contactverzoek regardless of afdeling.
- **5/6 scenarios are implemented but marked `[Ignore]`**: they require a non-admin "behandelaar" Azure AD test account (no `FunctioneelBeheerder` role, tied to a known afdeling) that does not exist yet in the test infrastructure — the same blocker already documented as TODOs in `AlleContactverzoekenAccessScenarios.cs` and `AlleContactverzoekenNavigatieScenarios.cs`. Each `[Ignore]` carries the reason and points back to Task #544, where the exact unblock steps are recorded under "Technical Approach".

## Test plan

- [x] Beheerder kan Contactverzoek van elke afdeling inzien — passing, run against `ita.test.icatt.nl`
- [ ] Behandelaar kan Contactverzoek van eigen afdeling inzien — implemented, blocked on test account
- [ ] Behandelaar kan Contactverzoek van andere afdeling niet inzien — implemented, blocked on test account
- [ ] Geen-toegang-melding is onderscheiden van niet-gevonden — implemented, blocked on test account
- [ ] Geen inhoudelijke gegevens in API-response bij geen toegang — implemented, blocked on test account
- [ ] Directe URL-navigatie respecteert autorisatie — implemented, blocked on test account
- [x] `dotnet build` succeeds with 0 errors
- [x] `npm run lint:ci` / `npm run format:ci` pass (Web.Client baseline, unaffected by this C#-only change)

## Related

Closes #544
