### PR TITLE
Feature/512 betrouwbaar doorsturen afdeling groep medewerker

### DIFF
--- a/InterneTaakAfhandeling.Common/Extensions/SmtpClientExtensions.cs
+++ b/InterneTaakAfhandeling.Common/Extensions/SmtpClientExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using InterneTaakAfhandeling.Common.Services.Emailservices.Content;
+using InterneTaakAfhandeling.Common.Services.Emailservices.Recipients;
 using InterneTaakAfhandeling.Common.Services.Emailservices.SmtpMailService;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,7 +16,7 @@ public static class SmtpClientExtensions
             .Bind(configuration.GetSection("Email:SmtpSettings"));
         services.AddScoped<IEmailService, EmailService>();
         services.AddScoped<IEmailContentService, EmailContentService>();
-        services.AddSingleton<IInterneTaakEmailInputService, InterneTaakEmailInputService>();
+        services.AddSingleton<IActorEmailResolutionService, ActorEmailResolutionService>();
         return services;
     }
 }

--- a/InterneTaakAfhandeling.Common/Services/Emailservices/Content/InterneTaakEmailInputService.cs
+++ b/InterneTaakAfhandeling.Common/Services/Emailservices/Content/InterneTaakEmailInputService.cs
@@ -70,7 +70,7 @@ namespace InterneTaakAfhandeling.Common.Services.Emailservices.Content
 
                     if (objectRecords.Count == 0)
                     {
-                        result.Errors.Add($"Geen afdeling gevonden in overigeobjecten voor actorIdentificator {actorIdentificator.ObjectId}");
+                        result.Errors.Add($"Geen groep gevonden in overigeobjecten voor actorIdentificator {actorIdentificator.ObjectId}");
                         continue;
                     }
 
@@ -123,9 +123,9 @@ namespace InterneTaakAfhandeling.Common.Services.Emailservices.Content
                 }
             }
 
-            // Precedence: een medewerker-e-mail gaat altijd voor de afdelings-/groepsmailbox,
-            // zodat er nooit meer dan één partij een notificatie ontvangt. Resolveert de
-            // medewerker niet naar een geldig adres, dan valt het systeem terug op de groep.
+            // Precedence: a medewerker email always takes priority over the afdeling/groep mailbox,
+            // so that no more than one party ever receives a notification. If the medewerker doesn't
+            // resolve to a valid address, the system falls back to the groep.
             result.FoundEmails.AddRange(medewerkerEmails.Count > 0 ? medewerkerEmails : groepEmails);
 
             return result;

--- a/InterneTaakAfhandeling.Common/Services/Emailservices/Content/InterneTaakEmailInputService.cs
+++ b/InterneTaakAfhandeling.Common/Services/Emailservices/Content/InterneTaakEmailInputService.cs
@@ -18,6 +18,8 @@ namespace InterneTaakAfhandeling.Common.Services.Emailservices.Content
         public async Task<ActorEmailResolutionResult> ResolveActorsEmailAsync(IReadOnlyList<Actor> actors)
         {
             var result = new ActorEmailResolutionResult();
+            var medewerkerEmails = new List<string>();
+            var groepEmails = new List<string>();
 
             foreach (var actor in actors)
             {
@@ -27,7 +29,7 @@ namespace InterneTaakAfhandeling.Common.Services.Emailservices.Content
                 {
                     if (EmailService.IsValidEmail(actorIdentificator.ObjectId))
                     {
-                        result.FoundEmails.Add(actorIdentificator.ObjectId);
+                        medewerkerEmails.Add(actorIdentificator.ObjectId);
                     }
                     else
                     {
@@ -55,7 +57,7 @@ namespace InterneTaakAfhandeling.Common.Services.Emailservices.Content
 
                     if (!string.IsNullOrEmpty(email) && EmailService.IsValidEmail(email))
                     {
-                        result.FoundEmails.Add(email);
+                        groepEmails.Add(email);
                     }
                     else
                     {
@@ -83,7 +85,7 @@ namespace InterneTaakAfhandeling.Common.Services.Emailservices.Content
 
                     if (!string.IsNullOrEmpty(email) && EmailService.IsValidEmail(email))
                     {
-                        result.FoundEmails.Add(email);
+                        groepEmails.Add(email);
                     }
                     else
                     {
@@ -110,7 +112,7 @@ namespace InterneTaakAfhandeling.Common.Services.Emailservices.Content
                     {
                         if (!string.IsNullOrEmpty(x) && EmailService.IsValidEmail(x))
                         {
-                            result.FoundEmails.Add(x);
+                            medewerkerEmails.Add(x);
                         }
                         else
                         {
@@ -120,6 +122,11 @@ namespace InterneTaakAfhandeling.Common.Services.Emailservices.Content
 
                 }
             }
+
+            // Precedence: een medewerker-e-mail gaat altijd voor de afdelings-/groepsmailbox,
+            // zodat er nooit meer dan één partij een notificatie ontvangt. Resolveert de
+            // medewerker niet naar een geldig adres, dan valt het systeem terug op de groep.
+            result.FoundEmails.AddRange(medewerkerEmails.Count > 0 ? medewerkerEmails : groepEmails);
 
             return result;
         }

--- a/InterneTaakAfhandeling.Common/Services/Emailservices/Recipients/ActorEmailResolutionService.cs
+++ b/InterneTaakAfhandeling.Common/Services/Emailservices/Recipients/ActorEmailResolutionService.cs
@@ -1,19 +1,18 @@
-﻿using InterneTaakAfhandeling.Common.Services;
-using InterneTaakAfhandeling.Common.Services.Emailservices.SmtpMailService;
+﻿using InterneTaakAfhandeling.Common.Services.Emailservices.SmtpMailService;
 using InterneTaakAfhandeling.Common.Services.ObjectApi;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
 
-namespace InterneTaakAfhandeling.Common.Services.Emailservices.Content
+namespace InterneTaakAfhandeling.Common.Services.Emailservices.Recipients
 {
-    public interface IInterneTaakEmailInputService
+    public interface IActorEmailResolutionService
     {
         Task<ActorEmailResolutionResult> ResolveActorsEmailAsync(IReadOnlyList<Actor> actors);
     }
 
-    public class InterneTaakEmailInputService(
+    public class ActorEmailResolutionService(
             IObjectApiClient objectApiClient
-            ) : IInterneTaakEmailInputService
+            ) : IActorEmailResolutionService
     {
         public async Task<ActorEmailResolutionResult> ResolveActorsEmailAsync(IReadOnlyList<Actor> actors)
         {

--- a/InterneTaakAfhandeling.Poller/Features/NieuweInternetaakNotificatie/NieuweInternetakenNotifier.cs
+++ b/InterneTaakAfhandeling.Poller/Features/NieuweInternetaakNotificatie/NieuweInternetakenNotifier.cs
@@ -127,7 +127,7 @@ public class InternetakenNotifier : IPollerJob
             }
             else
             {
-                _logger.LogInformation("No actor emails found for internetaken: {Number}, skipping", internetaak.Nummer);
+                _logger.LogWarning("No actor emails found for internetaken: {Number}, skipping", internetaak.Nummer);
                 errorMessage = "No actor emails found";
             }
         }

--- a/InterneTaakAfhandeling.Poller/Features/NieuweInternetaakNotificatie/NieuweInternetakenNotifier.cs
+++ b/InterneTaakAfhandeling.Poller/Features/NieuweInternetaakNotificatie/NieuweInternetakenNotifier.cs
@@ -1,4 +1,5 @@
 ﻿using InterneTaakAfhandeling.Common.Services.Emailservices.Content;
+using InterneTaakAfhandeling.Common.Services.Emailservices.Recipients;
 using InterneTaakAfhandeling.Common.Services.Emailservices.SmtpMailService;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
@@ -18,7 +19,7 @@ public class InternetakenNotifier : IPollerJob
     private readonly string _itaBaseUrl;
     private readonly IEmailContentService _emailContentService;
     private readonly INotifierStateService _notifierStateService;
-    private readonly IInterneTaakEmailInputService _emailInputService;
+    private readonly IActorEmailResolutionService _actorEmailResolutionService;
 
     public InternetakenNotifier(
         IOpenKlantApiClient openKlantApiClient,
@@ -27,7 +28,7 @@ public class InternetakenNotifier : IPollerJob
         ILogger<InternetakenNotifier> logger,
         IEmailContentService emailContentService,
         INotifierStateService notifierStateService,
-        IInterneTaakEmailInputService emailInputService)
+        IActorEmailResolutionService actorEmailResolutionService)
     {
         _openKlantApiClient = openKlantApiClient ?? throw new ArgumentNullException(nameof(openKlantApiClient));
         _emailService = emailService ?? throw new ArgumentNullException(nameof(emailService));
@@ -38,7 +39,7 @@ public class InternetakenNotifier : IPollerJob
             ?? throw new ArgumentException("Ita:BaseUrl configuration is missing");
         _emailContentService = emailContentService ?? throw new ArgumentNullException(nameof(emailContentService));
         _notifierStateService = notifierStateService ?? throw new ArgumentNullException(nameof(notifierStateService));
-        _emailInputService = emailInputService;
+        _actorEmailResolutionService = actorEmailResolutionService;
     }
 
     public async Task ExecuteAsync(CancellationToken cancellationToken = default)
@@ -102,7 +103,7 @@ public class InternetakenNotifier : IPollerJob
             }
 
             var actors = await GetActorsAsync(internetaak);
-            var actorEmailsResult = await _emailInputService.ResolveActorsEmailAsync(actors);
+            var actorEmailsResult = await _actorEmailResolutionService.ResolveActorsEmailAsync(actors);
             var actorEmails = actorEmailsResult.FoundEmails;
 
             foreach (var error in actorEmailsResult.Errors)

--- a/InterneTaakAfhandeling.Poller/Features/VerlopenContactverzoekHerinneringNotificatie/VerlopenInternetakenProcessor.cs
+++ b/InterneTaakAfhandeling.Poller/Features/VerlopenContactverzoekHerinneringNotificatie/VerlopenInternetakenProcessor.cs
@@ -1,5 +1,5 @@
 ﻿using InterneTaakAfhandeling.Common.Helpers;
-using InterneTaakAfhandeling.Common.Services.Emailservices.Content;
+using InterneTaakAfhandeling.Common.Services.Emailservices.Recipients;
 using InterneTaakAfhandeling.Common.Services.Emailservices.SmtpMailService;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi.Models;
@@ -12,7 +12,7 @@ namespace InterneTaakAfhandeling.Poller.Features.VerlopenContactverzoekHerinneri
 public sealed class VerlopenInternetakenProcessor(
     IOpenKlantApiClient openKlantApiClient,
 
-    IInterneTaakEmailInputService emailInputService,
+    IActorEmailResolutionService actorEmailResolutionService,
     VerlopenContactverzoekHerinneringNotificatieTemplateService templateService,
     IEmailService emailService,
     IConfiguration configuration,
@@ -55,7 +55,7 @@ public sealed class VerlopenInternetakenProcessor(
 
         foreach (var (_, entry) in verlopenTakenByActor)
         {
-            var resolveResult = await emailInputService.ResolveActorsEmailAsync([entry.Actor]);
+            var resolveResult = await actorEmailResolutionService.ResolveActorsEmailAsync([entry.Actor]);
 
             foreach (var error in resolveResult.Errors)
             {

--- a/InterneTaakAfhandeling.Web.Client/src/components/contactverzoek-doorsturen/ContactverzoekDoorsturen.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/contactverzoek-doorsturen/ContactverzoekDoorsturen.vue
@@ -71,8 +71,8 @@ type FORWARD_OPTIONS = typeof FORWARD_OPTIONS;
 
 const formRef = useTemplateRef("forwardForm");
 
-const afdelingen = ref<{ label: string; value: string }[]>([]);
-const groepen = ref<{ label: string; value: string }[]>([]);
+const afdelingen = ref<{ label: string; value: string; heeftGroepsmailbox: boolean }[]>([]);
+const groepen = ref<{ label: string; value: string; heeftGroepsmailbox: boolean }[]>([]);
 
 const isLoading = ref(false);
 const isSubmitting = ref(false);
@@ -131,25 +131,33 @@ function sortListByNaam<T extends { naam: string }>(list: T[]): T[] {
 }
 
 const fetchAfdelingen = async () => {
-  const response = await get<{ naam: string; identificatie: string }[]>("/api/afdelingen");
+  const response =
+    await get<{ naam: string; identificatie: string; heeftGroepsmailbox: boolean }[]>(
+      "/api/afdelingen"
+    );
   const sortedResponse = sortListByNaam(response);
   afdelingen.value = [
-    { label: "Selecteer een afdeling", value: "" },
+    { label: "Selecteer een afdeling", value: "", heeftGroepsmailbox: true },
     ...sortedResponse.map((afdeling) => ({
       label: afdeling.naam,
-      value: afdeling.identificatie
+      value: afdeling.identificatie,
+      heeftGroepsmailbox: afdeling.heeftGroepsmailbox
     }))
   ];
 };
 
 const fetchGroepen = async () => {
-  const response = await get<{ naam: string; identificatie: string }[]>("/api/groepen");
+  const response =
+    await get<{ naam: string; identificatie: string; heeftGroepsmailbox: boolean }[]>(
+      "/api/groepen"
+    );
   const sortedResponse = sortListByNaam(response);
   groepen.value = [
-    { label: "Selecteer een groep", value: "" },
+    { label: "Selecteer een groep", value: "", heeftGroepsmailbox: true },
     ...sortedResponse.map((groep) => ({
       label: groep.naam,
-      value: groep.identificatie
+      value: groep.identificatie,
+      heeftGroepsmailbox: groep.heeftGroepsmailbox
     }))
   ];
 };

--- a/InterneTaakAfhandeling.Web.Client/src/components/contactverzoek-doorsturen/ContactverzoekDoorsturenAfdeling.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/contactverzoek-doorsturen/ContactverzoekDoorsturenAfdeling.vue
@@ -26,14 +26,13 @@
         placeholder="Zoek op naam..."
         aria-label="Medewerker zoeken binnen selectie"
       />
-      <utrecht-paragraph v-if="!selectedAfdelingHeeftMailbox">
-        Verplicht: deze afdeling heeft geen groepsmailbox.
-      </utrecht-paragraph>
+      <utrecht-alert type="info" v-if="!selectedAfdelingHeeftMailbox">
+        {{ medewerkerVerplichtToelichting }}
+      </utrecht-alert>
     </utrecht-form-field>
     <utrecht-form-field v-else-if="!selectedAfdelingHeeftMailbox">
       <utrecht-alert type="warning">
-        Deze afdeling heeft geen groepsmailbox en er zijn geen medewerkers beschikbaar om te
-        koppelen. Kies een andere afdeling of neem contact op met functioneel beheer.
+        {{ geenMedewerkerBeschikbaarMelding }}
       </utrecht-alert>
     </utrecht-form-field>
     <input v-if="selectedMedewerker" type="hidden" name="medewerker" :value="selectedMedewerker" />
@@ -47,6 +46,11 @@ import { computed, ref } from "vue";
 import UtrechtCombobox from "../UtrechtCombobox.vue";
 import SmallSpinner from "@/components/SmallSpinner.vue";
 import UtrechtAlert from "@/components/UtrechtAlert.vue";
+import {
+  getMedewerkerLabel,
+  getMedewerkerVerplichtToelichting,
+  getGeenMedewerkerBeschikbaarMelding
+} from "@/constants/medewerkerVerplichtTeksten";
 
 const props = defineProps<{
   afdelingen: Array<{ label: string; value: string; heeftGroepsmailbox: boolean }>;
@@ -60,9 +64,13 @@ const afdelingLabel = computed(() => afdelingMatch.value?.label);
 const selectedAfdelingHeeftMailbox = computed(
   () => afdelingMatch.value?.heeftGroepsmailbox ?? true
 );
-const medewerkerLabel = computed(() =>
-  selectedAfdelingHeeftMailbox.value ? "Medewerker (optioneel)" : "Medewerker"
-);
+// Refactor: this computed-on-computed-on-computed chain exists only to toggle an
+// "(optioneel)" label, which no other optional field in this form shows. That inconsistency,
+// not the chain itself, is the real problem — worth revisiting the UX (e.g. how optionality is
+// communicated form-wide) rather than just simplifying this derivation.
+const medewerkerLabel = computed(() => getMedewerkerLabel(selectedAfdelingHeeftMailbox.value));
+const medewerkerVerplichtToelichting = getMedewerkerVerplichtToelichting("afdeling");
+const geenMedewerkerBeschikbaarMelding = getGeenMedewerkerBeschikbaarMelding("afdeling");
 const selectedMedewerker = ref<string>("");
 
 const { loading: medewerkerLoading, data: medewerkerOptions } = useLoader(() => {

--- a/InterneTaakAfhandeling.Web.Client/src/components/contactverzoek-doorsturen/ContactverzoekDoorsturenAfdeling.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/contactverzoek-doorsturen/ContactverzoekDoorsturenAfdeling.vue
@@ -15,16 +15,26 @@
       <small-spinner />
     </utrecht-form-field>
     <utrecht-form-field v-else-if="medewerkerOptions?.length">
-      <utrecht-form-label for="afdeling-groep-medewerker-combobox"
-        >Medewerker (optioneel)</utrecht-form-label
-      >
+      <utrecht-form-label for="afdeling-groep-medewerker-combobox">{{
+        medewerkerLabel
+      }}</utrecht-form-label>
       <utrecht-combobox
         id="afdeling-groep-medewerker-combobox"
         :options="medewerkerOptions"
         v-model="selectedMedewerker"
+        :required="!selectedAfdelingHeeftMailbox"
         placeholder="Zoek op naam..."
         aria-label="Medewerker zoeken binnen selectie"
       />
+      <utrecht-paragraph v-if="!selectedAfdelingHeeftMailbox">
+        Verplicht: deze afdeling heeft geen groepsmailbox.
+      </utrecht-paragraph>
+    </utrecht-form-field>
+    <utrecht-form-field v-else-if="!selectedAfdelingHeeftMailbox">
+      <utrecht-alert type="warning">
+        Deze afdeling heeft geen groepsmailbox en er zijn geen medewerkers beschikbaar om te
+        koppelen. Kies een andere afdeling of neem contact op met functioneel beheer.
+      </utrecht-alert>
     </utrecht-form-field>
     <input v-if="selectedMedewerker" type="hidden" name="medewerker" :value="selectedMedewerker" />
   </template>
@@ -36,12 +46,22 @@ import { get } from "@/utils/fetchWrapper";
 import { computed, ref } from "vue";
 import UtrechtCombobox from "../UtrechtCombobox.vue";
 import SmallSpinner from "@/components/SmallSpinner.vue";
+import UtrechtAlert from "@/components/UtrechtAlert.vue";
 
-const props = defineProps<{ afdelingen: Array<{ label: string; value: string }> }>();
+const props = defineProps<{
+  afdelingen: Array<{ label: string; value: string; heeftGroepsmailbox: boolean }>;
+}>();
 
 const selectedAfdeling = ref<string>("");
-const afdelingLabel = computed(
-  () => props.afdelingen.find((a) => a.value === selectedAfdeling.value)?.label
+const afdelingMatch = computed(() =>
+  props.afdelingen.find((a) => a.value === selectedAfdeling.value)
+);
+const afdelingLabel = computed(() => afdelingMatch.value?.label);
+const selectedAfdelingHeeftMailbox = computed(
+  () => afdelingMatch.value?.heeftGroepsmailbox ?? true
+);
+const medewerkerLabel = computed(() =>
+  selectedAfdelingHeeftMailbox.value ? "Medewerker (optioneel)" : "Medewerker"
 );
 const selectedMedewerker = ref<string>("");
 

--- a/InterneTaakAfhandeling.Web.Client/src/components/contactverzoek-doorsturen/ContactverzoekDoorsturenGroep.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/contactverzoek-doorsturen/ContactverzoekDoorsturenGroep.vue
@@ -24,14 +24,13 @@
         placeholder="Zoek op naam..."
         aria-label="Medewerker zoeken binnen selectie"
       />
-      <utrecht-paragraph v-if="!selectedGroepHeeftMailbox">
-        Verplicht: deze groep heeft geen groepsmailbox.
-      </utrecht-paragraph>
+      <utrecht-alert type="info" v-if="!selectedGroepHeeftMailbox">
+        {{ medewerkerVerplichtToelichting }}
+      </utrecht-alert>
     </utrecht-form-field>
     <utrecht-form-field v-else-if="!selectedGroepHeeftMailbox">
       <utrecht-alert type="warning">
-        Deze groep heeft geen groepsmailbox en er zijn geen medewerkers beschikbaar om te koppelen.
-        Kies een andere groep of neem contact op met functioneel beheer.
+        {{ geenMedewerkerBeschikbaarMelding }}
       </utrecht-alert>
     </utrecht-form-field>
     <input v-if="selectedMedewerker" type="hidden" name="medewerker" :value="selectedMedewerker" />
@@ -45,6 +44,11 @@ import { computed, ref } from "vue";
 import UtrechtCombobox from "../UtrechtCombobox.vue";
 import SmallSpinner from "@/components/SmallSpinner.vue";
 import UtrechtAlert from "@/components/UtrechtAlert.vue";
+import {
+  getMedewerkerLabel,
+  getMedewerkerVerplichtToelichting,
+  getGeenMedewerkerBeschikbaarMelding
+} from "@/constants/medewerkerVerplichtTeksten";
 
 const props = defineProps<{
   groepen: Array<{ label: string; value: string; heeftGroepsmailbox: boolean }>;
@@ -54,9 +58,13 @@ const selectedGroep = ref<string>("");
 const groepMatch = computed(() => props.groepen.find((g) => g.value === selectedGroep.value));
 const groepLabel = computed(() => groepMatch.value?.label);
 const selectedGroepHeeftMailbox = computed(() => groepMatch.value?.heeftGroepsmailbox ?? true);
-const medewerkerLabel = computed(() =>
-  selectedGroepHeeftMailbox.value ? "Medewerker (optioneel)" : "Medewerker"
-);
+// Refactor: this computed-on-computed-on-computed chain exists only to toggle an
+// "(optioneel)" label, which no other optional field in this form shows. That inconsistency,
+// not the chain itself, is the real problem — worth revisiting the UX (e.g. how optionality is
+// communicated form-wide) rather than just simplifying this derivation.
+const medewerkerLabel = computed(() => getMedewerkerLabel(selectedGroepHeeftMailbox.value));
+const medewerkerVerplichtToelichting = getMedewerkerVerplichtToelichting("groep");
+const geenMedewerkerBeschikbaarMelding = getGeenMedewerkerBeschikbaarMelding("groep");
 const selectedMedewerker = ref<string>("");
 
 const { loading: medewerkerLoading, data: medewerkerOptions } = useLoader(() => {

--- a/InterneTaakAfhandeling.Web.Client/src/components/contactverzoek-doorsturen/ContactverzoekDoorsturenGroep.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/contactverzoek-doorsturen/ContactverzoekDoorsturenGroep.vue
@@ -15,9 +15,7 @@
       <small-spinner />
     </utrecht-form-field>
     <utrecht-form-field v-else-if="medewerkerOptions?.length">
-      <utrecht-form-label for="groep-medewerker-combobox">{{
-        medewerkerLabel
-      }}</utrecht-form-label>
+      <utrecht-form-label for="groep-medewerker-combobox">{{ medewerkerLabel }}</utrecht-form-label>
       <utrecht-combobox
         id="groep-medewerker-combobox"
         :options="medewerkerOptions"
@@ -32,8 +30,8 @@
     </utrecht-form-field>
     <utrecht-form-field v-else-if="!selectedGroepHeeftMailbox">
       <utrecht-alert type="warning">
-        Deze groep heeft geen groepsmailbox en er zijn geen medewerkers beschikbaar om te
-        koppelen. Kies een andere groep of neem contact op met functioneel beheer.
+        Deze groep heeft geen groepsmailbox en er zijn geen medewerkers beschikbaar om te koppelen.
+        Kies een andere groep of neem contact op met functioneel beheer.
       </utrecht-alert>
     </utrecht-form-field>
     <input v-if="selectedMedewerker" type="hidden" name="medewerker" :value="selectedMedewerker" />

--- a/InterneTaakAfhandeling.Web.Client/src/components/contactverzoek-doorsturen/ContactverzoekDoorsturenGroep.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/contactverzoek-doorsturen/ContactverzoekDoorsturenGroep.vue
@@ -15,16 +15,26 @@
       <small-spinner />
     </utrecht-form-field>
     <utrecht-form-field v-else-if="medewerkerOptions?.length">
-      <utrecht-form-label for="groep-medewerker-combobox"
-        >Medewerker (optioneel)</utrecht-form-label
-      >
+      <utrecht-form-label for="groep-medewerker-combobox">{{
+        medewerkerLabel
+      }}</utrecht-form-label>
       <utrecht-combobox
         id="groep-medewerker-combobox"
         :options="medewerkerOptions"
         v-model="selectedMedewerker"
+        :required="!selectedGroepHeeftMailbox"
         placeholder="Zoek op naam..."
         aria-label="Medewerker zoeken binnen selectie"
       />
+      <utrecht-paragraph v-if="!selectedGroepHeeftMailbox">
+        Verplicht: deze groep heeft geen groepsmailbox.
+      </utrecht-paragraph>
+    </utrecht-form-field>
+    <utrecht-form-field v-else-if="!selectedGroepHeeftMailbox">
+      <utrecht-alert type="warning">
+        Deze groep heeft geen groepsmailbox en er zijn geen medewerkers beschikbaar om te
+        koppelen. Kies een andere groep of neem contact op met functioneel beheer.
+      </utrecht-alert>
     </utrecht-form-field>
     <input v-if="selectedMedewerker" type="hidden" name="medewerker" :value="selectedMedewerker" />
   </template>
@@ -36,12 +46,18 @@ import { get } from "@/utils/fetchWrapper";
 import { computed, ref } from "vue";
 import UtrechtCombobox from "../UtrechtCombobox.vue";
 import SmallSpinner from "@/components/SmallSpinner.vue";
+import UtrechtAlert from "@/components/UtrechtAlert.vue";
 
-const props = defineProps<{ groepen: Array<{ label: string; value: string }> }>();
+const props = defineProps<{
+  groepen: Array<{ label: string; value: string; heeftGroepsmailbox: boolean }>;
+}>();
 
 const selectedGroep = ref<string>("");
-const groepLabel = computed(
-  () => props.groepen.find((g) => g.value === selectedGroep.value)?.label
+const groepMatch = computed(() => props.groepen.find((g) => g.value === selectedGroep.value));
+const groepLabel = computed(() => groepMatch.value?.label);
+const selectedGroepHeeftMailbox = computed(() => groepMatch.value?.heeftGroepsmailbox ?? true);
+const medewerkerLabel = computed(() =>
+  selectedGroepHeeftMailbox.value ? "Medewerker (optioneel)" : "Medewerker"
 );
 const selectedMedewerker = ref<string>("");
 

--- a/InterneTaakAfhandeling.Web.Client/src/constants/medewerkerVerplichtTeksten.ts
+++ b/InterneTaakAfhandeling.Web.Client/src/constants/medewerkerVerplichtTeksten.ts
@@ -1,0 +1,13 @@
+export type DoorstuurDoelType = "afdeling" | "groep";
+
+export function getMedewerkerLabel(heeftGroepsmailbox: boolean): string {
+  return heeftGroepsmailbox ? "Medewerker (optioneel)" : "Medewerker";
+}
+
+export function getMedewerkerVerplichtToelichting(doelType: DoorstuurDoelType): string {
+  return `De geselecteerde ${doelType} heeft geen eigen e-mailadres, daarom is het verplicht om een medewerker te selecteren.`;
+}
+
+export function getGeenMedewerkerBeschikbaarMelding(doelType: DoorstuurDoelType): string {
+  return `U kunt geen contactverzoeken doorsturen naar deze ${doelType}. Deze ${doelType} heeft geen e-mailadres en er zijn geen medewerkers beschikbaar binnen deze ${doelType}.`;
+}

--- a/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/AfdelingenOverzicht/AfdelingenOverzicht.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/AfdelingenOverzicht/AfdelingenOverzicht.cs
@@ -32,7 +32,7 @@ namespace InterneTaakAfhandeling.Web.Server.Features.ForwardContactRequest.Afdel
             {
                 var afdelingen = await GetAfdelingenRecursive(1);
   
-                var result = afdelingen.Select(x => new { x.Naam, x.Identificatie }).ToList();
+                var result = afdelingen.Select(x => new { x.Naam, x.Identificatie, HeeftGroepsmailbox = !string.IsNullOrWhiteSpace(x.Email) }).ToList();
                 return Ok(result);
             }
             catch (Exception ex)

--- a/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestService.cs
@@ -2,6 +2,7 @@
 using InterneTaakAfhandeling.Common.Helpers;
 using InterneTaakAfhandeling.Common.Services;
 using InterneTaakAfhandeling.Common.Services.Emailservices.Content;
+using InterneTaakAfhandeling.Common.Services.Emailservices.Recipients;
 using InterneTaakAfhandeling.Common.Services.Emailservices.SmtpMailService;
 using InterneTaakAfhandeling.Common.Services.ObjectApi;
 using InterneTaakAfhandeling.Common.Services.OpenKlantApi;
@@ -20,7 +21,7 @@ public class ForwardContactRequestService(
     IEmailService emailService,
     IEmailContentService emailContentService,
     ILogger<ForwardContactRequestService> logger,
-    IInterneTaakEmailInputService emailInputService,
+    IActorEmailResolutionService actorEmailResolutionService,
     IConfiguration configuration) : IForwardContactRequestService
 {
     private readonly string _itaBaseUrl = configuration.GetValue<string>("Ita:BaseUrl")
@@ -28,9 +29,17 @@ public class ForwardContactRequestService(
     public async Task<ForwardContactRequestResponse> ForwardAsync(Guid internetaakId,
         ForwardContactRequestModel request)
     {
-        await RequireMedewerkerIfNoGroepsmailbox(request);
-
         var actors = await GetTargetActors(request);
+
+        var actorEmailResult = await actorEmailResolutionService.ResolveActorsEmailAsync(actors);
+
+        if (actorEmailResult?.FoundEmails.Count < 1)
+        {
+            var errorMessage = GetResultMessageWhenNoEmails(actorEmailResult);
+            logger.LogWarning("No valid email addresses found for actors: {Actors}. Error: {ErrorMessage}", actors, errorMessage);
+            var doelType = !string.IsNullOrWhiteSpace(request.Afdeling) ? "afdeling" : "groep";
+            throw new ValidationException($"Selecteer een medewerker: de geselecteerde {doelType} heeft geen mailbox.");
+        }
 
         var internetaak = await openKlantApiClient.GetInternetaakByIdAsync(internetaakId);
 
@@ -54,7 +63,7 @@ public class ForwardContactRequestService(
         //Although the AanleidinggevendKlantcontact was returned from the patch endpoint, it does not contain all details (like Nummer) that are needed for the email notification. Therefore, we need to fetch the full Klantcontact details.
         updatedInternetaak.AanleidinggevendKlantcontact = await openKlantApiClient.GetKlantcontactAsync(updatedInternetaak.AanleidinggevendKlantcontact.Uuid);
         
-        var notficationResult = await NotifyInternetaakActors(updatedInternetaak, actors);
+        var notficationResult = await NotifyInternetaakActors(updatedInternetaak, actorEmailResult!);
 
         return new ForwardContactRequestResponse
         {
@@ -65,17 +74,12 @@ public class ForwardContactRequestService(
 
     private const string GenericError = "Het contactverzoek is doorgestuurd, maar hiervan kon geen e-mailnotificatie verstuurd worden";
 
-    private async Task<string> NotifyInternetaakActors(Internetaak internetaken, IReadOnlyList<Actor> actors)
+    private async Task<string> NotifyInternetaakActors(Internetaak internetaken, ActorEmailResolutionResult actorEmailResult)
     {
         try
         {
             if (!emailService.IsConfiguredCorrectly())
                 return GenericError;
-
-            var actorEmailResult = await emailInputService.ResolveActorsEmailAsync(actors);
-
-            if (!actorEmailResult.FoundEmails.Any())
-                return GetResultMessageWhenNoEmails(actorEmailResult);
 
             var contactmomentNummer = (internetaken.AanleidinggevendKlantcontact?.Nummer) ?? throw new InvalidOperationException(
                     $"AanleidinggevendKlantcontact.Nummer ontbreekt voor internetaak {internetaken.Nummer}");
@@ -103,7 +107,7 @@ public class ForwardContactRequestService(
     {
         return actorEmailResult.Errors.Any()
             ? $"Het contactverzoek is doorgestuurd, maar er kon geen e-mailnotificatie verstuurd worden: \n{string.Join("\n", actorEmailResult.Errors)}"
-            : "Het contactverzoek is doorgestuurd, maar er kon geen e-mailnotificatie verstuurd worden: geen geldig e-mailadres gevonden voor medewerker of groep.";
+            : "Het contactverzoek is doorgestuurd, maar er kon geen e-mailnotificatie verstuurd worden: geen geldig e-mailadres gevonden voor medewerker, afdeling of groep.";
     }
 
     private static string GetResultMessage(EmailResult[] results, ActorEmailResolutionResult actorEmailResult)
@@ -121,29 +125,6 @@ public class ForwardContactRequestService(
             return $"Het contactverzoek is doorgestuurd, maar niet elke e-mailnotificatie kon verstuurd worden: \n{string.Join("\n", actorEmailResult.Errors)}";
 
         return "Contactverzoek succesvol doorgestuurd";
-    }
-
-    private async Task RequireMedewerkerIfNoGroepsmailbox(ForwardContactRequestModel request)
-    {
-        if (!string.IsNullOrWhiteSpace(request.Medewerker))
-            return;
-
-        if (!string.IsNullOrWhiteSpace(request.Afdeling))
-        {
-            var afdeling = (await objectApiClient.GetAfdelingenByIdentificatie(request.Afdeling)).FirstOrDefault();
-            if (afdeling != null && string.IsNullOrWhiteSpace(afdeling.Email))
-            {
-                throw new ValidationException($"Selecteer een medewerker: afdeling '{afdeling.Naam}' heeft geen groepsmailbox.");
-            }
-        }
-        else if (!string.IsNullOrWhiteSpace(request.Groep))
-        {
-            var groep = (await objectApiClient.GetGroepenByIdentificatie(request.Groep)).FirstOrDefault();
-            if (groep != null && string.IsNullOrWhiteSpace(groep.Email))
-            {
-                throw new ValidationException($"Selecteer een medewerker: groep '{groep.Naam}' heeft geen groepsmailbox.");
-            }
-        }
     }
 
     private async Task<List<Actor>> GetTargetActors(ForwardContactRequestModel request)

--- a/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestService.cs
@@ -33,14 +33,43 @@ public class ForwardContactRequestService(
 
         var actorEmailResult = await actorEmailResolutionService.ResolveActorsEmailAsync(actors);
 
-        if (actorEmailResult?.FoundEmails.Count < 1)
+        // Reject the request upfront if no actor resolves to a usable email address. 
+        // Then, the internetaak is patched with the new actors and, on success, those recipients are notified by email.
+        ValidateEmailRecipients(actorEmailResult, request);
+
+        var (updatedInternetaak, errorResponse) = await PatchInternetaakActors(internetaakId, actors);
+        if (errorResponse != null)
+            return errorResponse;
+
+        //Although the AanleidinggevendKlantcontact was returned from the patch endpoint, it does not contain all details (like Nummer) that are needed for the email notification. Therefore, we need to fetch the full Klantcontact details.
+        updatedInternetaak.AanleidinggevendKlantcontact = await openKlantApiClient.GetKlantcontactAsync(updatedInternetaak.AanleidinggevendKlantcontact.Uuid);
+        
+        var notficationResult = await NotifyInternetaakActors(updatedInternetaak, actorEmailResult);
+
+        return new ForwardContactRequestResponse
         {
-            var errorMessage = GetResultMessageWhenNoEmails(actorEmailResult);
-            logger.LogWarning("No valid email addresses found for actors: {Actors}. Error: {ErrorMessage}", actors, errorMessage);
+            Internetaak = updatedInternetaak,
+            NotificationResult = notficationResult
+        };
+    }
+
+    private void ValidateEmailRecipients(ActorEmailResolutionResult actorEmailResult, ForwardContactRequestModel request)
+    {
+        if (actorEmailResult.Errors.Count != 0)
+        {
+            logger.LogWarning("Email address resolution errors: \n{Errors}", string.Join("\n", actorEmailResult.Errors));
+        }
+
+        if (actorEmailResult.FoundEmails.Count < 1)
+        {
             var doelType = !string.IsNullOrWhiteSpace(request.Afdeling) ? "afdeling" : "groep";
             throw new ValidationException($"Selecteer een medewerker: de geselecteerde {doelType} heeft geen mailbox.");
         }
+    }
 
+    private async Task<(Internetaak UpdatedInternetaak, ForwardContactRequestResponse? errorResponse)> PatchInternetaakActors(
+        Guid internetaakId, List<Actor> actors)
+    {
         var internetaak = await openKlantApiClient.GetInternetaakByIdAsync(internetaakId);
 
         var internetakenUpdateRequest = new InternetakenPatchActorsRequest
@@ -53,23 +82,14 @@ public class ForwardContactRequestService(
         if (updatedInternetaak.AanleidinggevendKlantcontact?.Uuid == null)
         {
             logger.LogError("Uuid van AanleidinggevendKlantcontact onbekend voor internetaak {Uuid}", internetaak.Uuid);
-            return new ForwardContactRequestResponse
+            return (updatedInternetaak, new ForwardContactRequestResponse
             {
                 Internetaak = updatedInternetaak,
                 NotificationResult = GenericError
-            };
+            });
         }
 
-        //Although the AanleidinggevendKlantcontact was returned from the patch endpoint, it does not contain all details (like Nummer) that are needed for the email notification. Therefore, we need to fetch the full Klantcontact details.
-        updatedInternetaak.AanleidinggevendKlantcontact = await openKlantApiClient.GetKlantcontactAsync(updatedInternetaak.AanleidinggevendKlantcontact.Uuid);
-        
-        var notficationResult = await NotifyInternetaakActors(updatedInternetaak, actorEmailResult!);
-
-        return new ForwardContactRequestResponse
-        {
-            Internetaak = updatedInternetaak,
-            NotificationResult = notficationResult
-        };
+        return (updatedInternetaak, null);
     }
 
     private const string GenericError = "Het contactverzoek is doorgestuurd, maar hiervan kon geen e-mailnotificatie verstuurd worden";
@@ -101,13 +121,6 @@ public class ForwardContactRequestService(
     {
         var tasks = emails.Select(email => emailService.SendEmailAsync(email, subject, content));
         return await Task.WhenAll(tasks);
-    }
-
-    private static string GetResultMessageWhenNoEmails(ActorEmailResolutionResult actorEmailResult)
-    {
-        return actorEmailResult.Errors.Any()
-            ? $"Het contactverzoek is doorgestuurd, maar er kon geen e-mailnotificatie verstuurd worden: \n{string.Join("\n", actorEmailResult.Errors)}"
-            : "Het contactverzoek is doorgestuurd, maar er kon geen e-mailnotificatie verstuurd worden: geen geldig e-mailadres gevonden voor medewerker, afdeling of groep.";
     }
 
     private static string GetResultMessage(EmailResult[] results, ActorEmailResolutionResult actorEmailResult)

--- a/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestService.cs
@@ -1,4 +1,5 @@
-﻿using InterneTaakAfhandeling.Common.Helpers;
+﻿using System.ComponentModel.DataAnnotations;
+using InterneTaakAfhandeling.Common.Helpers;
 using InterneTaakAfhandeling.Common.Services;
 using InterneTaakAfhandeling.Common.Services.Emailservices.Content;
 using InterneTaakAfhandeling.Common.Services.Emailservices.SmtpMailService;
@@ -27,6 +28,8 @@ public class ForwardContactRequestService(
     public async Task<ForwardContactRequestResponse> ForwardAsync(Guid internetaakId,
         ForwardContactRequestModel request)
     {
+        await EnsureMedewerkerVerplichtBijOntbrekendeGroepsmailbox(request);
+
         var actors = await GetTargetActors(request);
 
         var internetaak = await openKlantApiClient.GetInternetaakByIdAsync(internetaakId);
@@ -118,6 +121,29 @@ public class ForwardContactRequestService(
             return $"Het contactverzoek is doorgestuurd, maar niet elke e-mailnotificatie kon verstuurd worden: \n{string.Join("\n", actorEmailResult.Errors)}";
 
         return "Contactverzoek succesvol doorgestuurd";
+    }
+
+    private async Task EnsureMedewerkerVerplichtBijOntbrekendeGroepsmailbox(ForwardContactRequestModel request)
+    {
+        if (!string.IsNullOrWhiteSpace(request.Medewerker))
+            return;
+
+        if (!string.IsNullOrWhiteSpace(request.Afdeling))
+        {
+            var afdeling = (await objectApiClient.GetAfdelingenByIdentificatie(request.Afdeling)).FirstOrDefault();
+            if (afdeling != null && string.IsNullOrWhiteSpace(afdeling.Email))
+            {
+                throw new ValidationException($"Selecteer een medewerker: afdeling '{afdeling.Naam}' heeft geen groepsmailbox.");
+            }
+        }
+        else if (!string.IsNullOrWhiteSpace(request.Groep))
+        {
+            var groep = (await objectApiClient.GetGroepenByIdentificatie(request.Groep)).FirstOrDefault();
+            if (groep != null && string.IsNullOrWhiteSpace(groep.Email))
+            {
+                throw new ValidationException($"Selecteer een medewerker: groep '{groep.Naam}' heeft geen groepsmailbox.");
+            }
+        }
     }
 
     private async Task<List<Actor>> GetTargetActors(ForwardContactRequestModel request)

--- a/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestService.cs
@@ -99,8 +99,8 @@ public class ForwardContactRequestService(
     private static string GetResultMessageWhenNoEmails(ActorEmailResolutionResult actorEmailResult)
     {
         return actorEmailResult.Errors.Any()
-            ? $"Het contactverzoek is doorgestuurd, maar niet elke e-mailnotificatie kon verstuurd worden: \n{string.Join("\n", actorEmailResult.Errors)}"
-            : "Contactverzoek succesvol doorgestuurd";
+            ? $"Het contactverzoek is doorgestuurd, maar er kon geen e-mailnotificatie verstuurd worden: \n{string.Join("\n", actorEmailResult.Errors)}"
+            : "Het contactverzoek is doorgestuurd, maar er kon geen e-mailnotificatie verstuurd worden: geen geldig e-mailadres gevonden voor medewerker of groep.";
     }
 
     private static string GetResultMessage(EmailResult[] results, ActorEmailResolutionResult actorEmailResult)

--- a/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestService.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/ForwardContactRequestService.cs
@@ -28,7 +28,7 @@ public class ForwardContactRequestService(
     public async Task<ForwardContactRequestResponse> ForwardAsync(Guid internetaakId,
         ForwardContactRequestModel request)
     {
-        await EnsureMedewerkerVerplichtBijOntbrekendeGroepsmailbox(request);
+        await RequireMedewerkerIfNoGroepsmailbox(request);
 
         var actors = await GetTargetActors(request);
 
@@ -123,7 +123,7 @@ public class ForwardContactRequestService(
         return "Contactverzoek succesvol doorgestuurd";
     }
 
-    private async Task EnsureMedewerkerVerplichtBijOntbrekendeGroepsmailbox(ForwardContactRequestModel request)
+    private async Task RequireMedewerkerIfNoGroepsmailbox(ForwardContactRequestModel request)
     {
         if (!string.IsNullOrWhiteSpace(request.Medewerker))
             return;

--- a/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/GroepenOverzicht/GroepenOverzicht.cs
+++ b/InterneTaakAfhandeling.Web.Server/Features/ForwardContactRequest/GroepenOverzicht/GroepenOverzicht.cs
@@ -32,7 +32,7 @@ namespace InterneTaakAfhandeling.Web.Server.Features.ForwardContactRequest.Groep
             try
             {
                 var groepen = await GetGroepenRecursive(1); 
-                var result = groepen.Select(x => new { x.Naam, x.Identificatie }).ToList();
+                var result = groepen.Select(x => new { x.Naam, x.Identificatie, HeeftGroepsmailbox = !string.IsNullOrWhiteSpace(x.Email) }).ToList();
                 return Ok(result);
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary

Vandaag kan een contactverzoek worden doorgestuurd naar een afdeling of groep zonder groepsmailbox én zonder gekoppelde medewerker, waardoor het zonder enige notificatie blijft liggen. Daarnaast verstuurt de bestaande mailresolutielogica soms per ongeluk twee notificatiemails (naar zowel medewerker als groep) voor één toewijzing. Deze PR realiseert Feature #512: een contactverzoek krijgt altijd precies één duidelijke notificatie-ontvanger — de gekoppelde medewerker indien aanwezig, anders de groepsmailbox — en het doorsturen wordt geblokkeerd wanneer geen van beide beschikbaar is.

## Changes

- Afdelingen- en Groepenoverzicht endpoints (`/api/afdelingen`, `/api/groepen`) geven per afdeling/groep aan of er een groepsmailbox gekoppeld is (#538)
- Gedeelde mailresolutielogica (`InterneTaakEmailInputService`, gebruikt door zowel ITA als de Poller) past voortaan precedentie toe: medewerker-e-mail wint indien geldig, anders de afdelings-/groepsmailbox (#539)
- Backend-validatie maakt het medewerkerveld verplicht bij het doorsturen naar een afdeling/groep zonder groepsmailbox (#541)
- Doorstuurscherm toont de groepsmailbox-status, maakt het medewerkerveld conditioneel verplicht met toelichting, en toont een blokkerende melding wanneer er geen enkele medewerker beschikbaar is om te koppelen (#542)
- Duidelijkere afhandeling wanneer geen enkele notificatie-e-mail resolveert: geen vals-positief succesbericht meer in ITA, en het randgeval wordt in de Poller nu als waarschuwing gelogd in plaats van als routine-informatie (#543)

## Test plan

<!-- Checklist derived from Gherkin scenario names. At minimum one item per observable behavior changed. -->

- [ ] 

## Related

Closes #538
Closes #539
Closes #541
Closes #542
Closes #543
Closes #512