### PR TITLE
Feature/467 zoeken op klantcontactnummer

### DIFF
--- a/InterneTaakAfhandeling.Web.Client/src/assets/icon-sprite.svg
+++ b/InterneTaakAfhandeling.Web.Client/src/assets/icon-sprite.svg
@@ -18,4 +18,20 @@
 <symbol id="add-plus" viewBox="0 0 448 512">
 <path d="M256 64c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 160-160 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l160 0 0 160c0 17.7 14.3 32 32 32s32-14.3 32-32l0-160 160 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-160 0 0-160z"/>
 </symbol>
+  <symbol
+    id="search-klantcontact"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  ><!--Adapted from Tabler Icons (MIT License) https://tabler.io/icons - zoom-code, lens glyph replaced with a hash--><title>search-klantcontact</title>
+    <path d="M3 10a7 7 0 1 0 14 0a7 7 0 1 0 -14 0" />
+    <path d="M21 21l-6 -6" />
+    <path d="M7 5l0 10" />
+    <path d="M14 5l0 10" />
+    <path d="M5 7.5l11 0" />
+    <path d="M5 12.5l11 0" />
+  </symbol>
 </svg>

--- a/InterneTaakAfhandeling.Web.Client/src/assets/icon-sprite.svg
+++ b/InterneTaakAfhandeling.Web.Client/src/assets/icon-sprite.svg
@@ -18,20 +18,5 @@
 <symbol id="add-plus" viewBox="0 0 448 512">
 <path d="M256 64c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 160-160 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l160 0 0 160c0 17.7 14.3 32 32 32s32-14.3 32-32l0-160 160 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-160 0 0-160z"/>
 </symbol>
-  <symbol
-    id="search-klantcontact"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    stroke-width="2"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-  ><!--Adapted from Tabler Icons (MIT License) https://tabler.io/icons - zoom-code, lens glyph replaced with a hash--><title>search-klantcontact</title>
-    <path d="M3 10a7 7 0 1 0 14 0a7 7 0 1 0 -14 0" />
-    <path d="M21 21l-6 -6" />
-    <path d="M7 5l0 10" />
-    <path d="M14 5l0 10" />
-    <path d="M5 7.5l11 0" />
-    <path d="M5 12.5l11 0" />
-  </symbol>
+<symbol id="magnifying-glass" viewBox="0 0 640 640"><!--!Font Awesome Free v7.3.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.--><path d="M480 272C480 317.9 465.1 360.3 440 394.7L566.6 521.4C579.1 533.9 579.1 554.2 566.6 566.7C554.1 579.2 533.8 579.2 521.3 566.7L394.7 440C360.3 465.1 317.9 480 272 480C157.1 480 64 386.9 64 272C64 157.1 157.1 64 272 64C386.9 64 480 157.1 480 272zM272 416C351.5 416 416 351.5 416 272C416 192.5 351.5 128 272 128C192.5 128 128 192.5 128 272C128 351.5 192.5 416 272 416z"/></symbol>
 </svg>

--- a/InterneTaakAfhandeling.Web.Client/src/components/KlantcontactZoekPopover.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/KlantcontactZoekPopover.vue
@@ -10,7 +10,7 @@
       title="Zoek contactverzoek op klantcontactnummer"
       @click="toggle"
     >
-      <utrecht-icon icon="search-klantcontact" />
+      <utrecht-icon icon="magnifying-glass" />
     </button>
 
     <div
@@ -90,7 +90,7 @@ async function toggle() {
   open.value = true;
   errorMessage.value = null;
   await nextTick();
-  inputRef.value?.$el?.querySelector("input")?.focus();
+  inputRef.value?.$el?.focus();
 }
 
 function close() {
@@ -129,28 +129,20 @@ async function onSearch() {
 .klantcontact-zoek {
   position: relative;
   align-items: center;
-  border-inline-start: 1px solid currentColor;
-  padding-inline-start: var(--utrecht-space-column-sm);
 }
 
 .klantcontact-zoek__button {
-  --utrecht-button-icon-size: var(--utrecht-accordion-button-icon-size);
-  --utrecht-button-min-block-size: var(--utrecht-space-column-3xl);
-  --utrecht-button-min-inline-size: var(--utrecht-space-column-3xl);
-  background-color: var(--utrecht-color-blue-60);
+  background-color: var(--utrecht-page-header-background-color);
   color: var(--utrecht-page-header-color);
-  border: none;
+  border-color: var(--utrecht-page-header-color);
   border-radius: 50%;
-  padding: var(--utrecht-space-column-2xs);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
+  padding-block: var(--utrecht-space-block-2xs);
+  padding-inline: var(--utrecht-space-inline-2xs);
 }
 
 .klantcontact-zoek__button:hover,
 .klantcontact-zoek__button:focus-visible {
-  background-color: var(--utrecht-document-background-color);
+  background-color: var(--utrecht-page-header-color);
   color: var(--utrecht-page-header-background-color);
 }
 

--- a/InterneTaakAfhandeling.Web.Client/src/components/KlantcontactZoekPopover.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/KlantcontactZoekPopover.vue
@@ -1,0 +1,159 @@
+<template>
+  <li class="utrecht-nav-list__item klantcontact-zoek">
+    <button
+      ref="buttonRef"
+      type="button"
+      class="utrecht-button utrecht-button--subtle klantcontact-zoek__button"
+      aria-haspopup="true"
+      :aria-expanded="open"
+      aria-label="Zoek contactverzoek op klantcontactnummer"
+      title="Zoek contactverzoek op klantcontactnummer"
+      @click="toggle"
+    >
+      <utrecht-icon icon="external" />
+    </button>
+
+    <div
+      v-if="open"
+      ref="panelRef"
+      class="klantcontact-zoek__panel"
+      aria-label="Zoek contactverzoek op klantcontactnummer"
+    >
+      <form @submit.prevent="onSearch">
+        <utrecht-form-field>
+          <utrecht-form-label for="klantcontact-nummer-input"
+            >Klantcontactnummer</utrecht-form-label
+          >
+          <utrecht-textbox
+            id="klantcontact-nummer-input"
+            ref="inputRef"
+            v-model="nummer"
+            type="text"
+            required
+          />
+        </utrecht-form-field>
+
+        <utrecht-button
+          type="submit"
+          appearance="primary-action-button"
+          :busy="isSearching"
+          :disabled="isSearching"
+        >
+          Zoeken
+        </utrecht-button>
+
+        <p v-if="errorMessage" class="klantcontact-zoek__error" role="alert" aria-live="polite">
+          {{ errorMessage }}
+        </p>
+      </form>
+    </div>
+  </li>
+</template>
+
+<script setup lang="ts">
+import { nextTick, ref } from "vue";
+import { useRouter } from "vue-router";
+import { onClickOutside, onKeyStroke } from "@vueuse/core";
+import UtrechtIcon from "@/components/UtrechtIcon.vue";
+import { internetakenService } from "@/services/internetakenService";
+import { knownErrorMessages } from "@/utils/fetchWrapper";
+
+const router = useRouter();
+
+const open = ref(false);
+const nummer = ref("");
+const isSearching = ref(false);
+const errorMessage = ref<string | null>(null);
+
+const buttonRef = ref<HTMLButtonElement | null>(null);
+const panelRef = ref<HTMLElement | null>(null);
+const inputRef = ref<{ $el: HTMLElement } | null>(null);
+
+onClickOutside(
+  panelRef,
+  () => {
+    close();
+  },
+  { ignore: [buttonRef] }
+);
+
+onKeyStroke("Escape", () => {
+  if (open.value) close();
+});
+
+async function toggle() {
+  if (open.value) {
+    close();
+    return;
+  }
+  open.value = true;
+  errorMessage.value = null;
+  await nextTick();
+  inputRef.value?.$el?.querySelector("input")?.focus();
+}
+
+function close() {
+  open.value = false;
+  errorMessage.value = null;
+  nummer.value = "";
+}
+
+async function onSearch() {
+  if (!nummer.value) return;
+
+  isSearching.value = true;
+  errorMessage.value = null;
+  try {
+    await internetakenService.getByKlantcontactNummer(nummer.value);
+    const contactmomentNummer = nummer.value;
+    close();
+    router.push({
+      name: "contactmomentDetail",
+      params: { contactmomentNumber: contactmomentNummer }
+    });
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message === knownErrorMessages.forbidden) {
+      errorMessage.value = "Je hebt geen toegang tot dit contactverzoek.";
+    } else {
+      errorMessage.value =
+        "Er is iets misgegaan bij het opzoeken van dit contactverzoek. Neem contact op met de beheerder als dit probleem zich blijft voordoen.";
+    }
+  } finally {
+    isSearching.value = false;
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.klantcontact-zoek {
+  position: relative;
+  border-inline-start: 1px solid var(--utrecht-form-control-border-color, currentColor);
+  padding-inline-start: 1rem;
+}
+
+.klantcontact-zoek__button {
+  inline-size: 2rem;
+  block-size: 2rem;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.klantcontact-zoek__panel {
+  position: absolute;
+  inset-block-start: 100%;
+  inset-inline-end: 0;
+  z-index: 10;
+  min-inline-size: 16rem;
+  background-color: var(--utrecht-document-background-color, Canvas);
+  border: 1px solid var(--utrecht-form-control-border-color, currentColor);
+  border-radius: var(--utrecht-form-control-border-radius, 0);
+  padding: 1rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+
+.klantcontact-zoek__error {
+  margin-block-start: 0.5rem;
+}
+</style>

--- a/InterneTaakAfhandeling.Web.Client/src/components/KlantcontactZoekPopover.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/KlantcontactZoekPopover.vue
@@ -116,8 +116,7 @@ async function onSearch() {
     if (err instanceof Error && err.message === knownErrorMessages.forbidden) {
       errorMessage.value = "Je hebt geen toegang tot dit contactverzoek.";
     } else {
-      errorMessage.value =
-        "Geen contactverzoek gevonden voor dit klantcontactnummer.";
+      errorMessage.value = "Geen contactverzoek gevonden voor dit klantcontactnummer.";
     }
   } finally {
     isSearching.value = false;

--- a/InterneTaakAfhandeling.Web.Client/src/components/KlantcontactZoekPopover.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/KlantcontactZoekPopover.vue
@@ -3,14 +3,14 @@
     <button
       ref="buttonRef"
       type="button"
-      class="utrecht-button utrecht-button--subtle klantcontact-zoek__button"
+      class="utrecht-button klantcontact-zoek__button"
       aria-haspopup="true"
       :aria-expanded="open"
       aria-label="Zoek contactverzoek op klantcontactnummer"
       title="Zoek contactverzoek op klantcontactnummer"
       @click="toggle"
     >
-      <utrecht-icon icon="external" />
+      <utrecht-icon icon="search-klantcontact" />
     </button>
 
     <div
@@ -19,28 +19,29 @@
       class="klantcontact-zoek__panel"
       aria-label="Zoek contactverzoek op klantcontactnummer"
     >
-      <form @submit.prevent="onSearch">
-        <utrecht-form-field>
+      <form class="klantcontact-zoek__form" @submit.prevent="onSearch">
+        <utrecht-form-field class="klantcontact-zoek__field">
           <utrecht-form-label for="klantcontact-nummer-input"
             >Klantcontactnummer</utrecht-form-label
           >
-          <utrecht-textbox
-            id="klantcontact-nummer-input"
-            ref="inputRef"
-            v-model="nummer"
-            type="text"
-            required
-          />
-        </utrecht-form-field>
+          <div class="klantcontact-zoek__row">
+            <utrecht-textbox
+              id="klantcontact-nummer-input"
+              ref="inputRef"
+              v-model="nummer"
+              type="text"
+            />
 
-        <utrecht-button
-          type="submit"
-          appearance="primary-action-button"
-          :busy="isSearching"
-          :disabled="isSearching"
-        >
-          Zoeken
-        </utrecht-button>
+            <utrecht-button
+              type="submit"
+              appearance="secondary-action-button"
+              :busy="isSearching"
+              :disabled="isSearching"
+            >
+              Zoeken
+            </utrecht-button>
+          </div>
+        </utrecht-form-field>
 
         <p v-if="errorMessage" class="klantcontact-zoek__error" role="alert" aria-live="polite">
           {{ errorMessage }}
@@ -116,7 +117,7 @@ async function onSearch() {
       errorMessage.value = "Je hebt geen toegang tot dit contactverzoek.";
     } else {
       errorMessage.value =
-        "Er is iets misgegaan bij het opzoeken van dit contactverzoek. Neem contact op met de beheerder als dit probleem zich blijft voordoen.";
+        "Geen contactverzoek gevonden voor dit klantcontactnummer.";
     }
   } finally {
     isSearching.value = false;
@@ -127,17 +128,30 @@ async function onSearch() {
 <style lang="scss" scoped>
 .klantcontact-zoek {
   position: relative;
-  border-inline-start: 1px solid var(--utrecht-form-control-border-color, currentColor);
-  padding-inline-start: 1rem;
+  align-items: center;
+  border-inline-start: 1px solid currentColor;
+  padding-inline-start: var(--utrecht-space-column-sm);
 }
 
 .klantcontact-zoek__button {
-  inline-size: 2rem;
-  block-size: 2rem;
+  --utrecht-button-icon-size: var(--utrecht-accordion-button-icon-size);
+  --utrecht-button-min-block-size: var(--utrecht-space-column-3xl);
+  --utrecht-button-min-inline-size: var(--utrecht-space-column-3xl);
+  background-color: var(--utrecht-color-blue-60);
+  color: var(--utrecht-page-header-color);
+  border: none;
   border-radius: 50%;
+  padding: var(--utrecht-space-column-2xs);
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  cursor: pointer;
+}
+
+.klantcontact-zoek__button:hover,
+.klantcontact-zoek__button:focus-visible {
+  background-color: var(--utrecht-document-background-color);
+  color: var(--utrecht-page-header-background-color);
 }
 
 .klantcontact-zoek__panel {
@@ -146,14 +160,20 @@ async function onSearch() {
   inset-inline-end: 0;
   z-index: 10;
   min-inline-size: 16rem;
-  background-color: var(--utrecht-document-background-color, Canvas);
-  border: 1px solid var(--utrecht-form-control-border-color, currentColor);
+  background-color: var(--utrecht-document-background-color);
+  color: var(--utrecht-color-grey-15);
   border-radius: var(--utrecht-form-control-border-radius, 0);
-  padding: 1rem;
+  padding: var(--utrecht-space-column-sm);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
 }
 
+.klantcontact-zoek__row {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--utrecht-space-column-xs);
+}
+
 .klantcontact-zoek__error {
-  margin-block-start: 0.5rem;
+  margin-block-start: var(--utrecht-space-row-xs);
 }
 </style>

--- a/InterneTaakAfhandeling.Web.Client/src/components/TheHeader.vue
+++ b/InterneTaakAfhandeling.Web.Client/src/components/TheHeader.vue
@@ -63,6 +63,8 @@
               >
             </li>
 
+            <klantcontact-zoek-popover />
+
             <li
               class="user-name utrecht-nav-list__item utrecht-link utrecht-link--html-a utrecht-nav-list__link"
             >
@@ -87,6 +89,7 @@
 import { computed } from "vue";
 import { injectResources } from "@/resources";
 import { useAuthStore } from "@/stores/auth";
+import KlantcontactZoekPopover from "@/components/KlantcontactZoekPopover.vue";
 
 const resources = injectResources();
 const authStore = useAuthStore();


### PR DESCRIPTION
## Summary

Feature #467 lets a coordinator or medewerker who has a klantcontactnummer in hand (passed along by phone or email) look up the matching Contactverzoek directly, without asking the resident to repeat everything. It serves Epic #346's goal of trimming small day-to-day UX frictions. Delivered as two Tasks — #552 (the search entry point) and #553 (its icon) — both built entirely on the existing `by-klantcontact` backend endpoint, so no backend changes were needed.

## Changes

- New `KlantcontactZoekPopover.vue`: an icon-only button in the header nav bar (before username/Logout, separated by a divider) that opens an anchored popover with a klantcontactnummer input and a Zoeken button.
- Search behavior: navigates to the existing Contactverzoek detail view on a single match; shows a distinct "geen toegang" message when the user lacks authorization; shows one shared generic message for not-found, multiple matches (409), or any other error — no choice screen, no random selection.
- New `search-klantcontact` icon symbol added to `icon-sprite.svg` — a magnifying glass with a hash, adapted from Tabler Icons' `zoom-code`.
- `TheHeader.vue` updated to mount the new popover component.
- Popover styling iterated against a design mockup: two-tone ghost button (muted blue by default, white on hover, navy icon throughout), sized and spaced with existing NL Design System tokens rather than hardcoded values.

## Test plan

- [ ] Een medewerker vindt een Contactverzoek via het klantcontactnummer — navigates to the Contactverzoek detail view
- [ ] Een medewerker zoekt op een klantcontactnummer buiten zijn bevoegdheid — shows the "geen toegang" message, popover stays open
- [ ] Een medewerker zoekt op een klantcontactnummer dat niet bestaat — shows the generic error, popover stays open
- [ ] Eén klantcontactnummer verwijst naar meerdere Contactverzoeken — same generic error, no choice screen
- [ ] Een overige fout tijdens het zoeken — same generic error
- [ ] De zoekpopover-knop toont het definitieve zoek-icoon (Task #553)

## Related

Closes #552
Closes #553
Closes #467
