### PR TITLE
feat(e2e): add Playwright tests for klantcontactnummer-zoekpopover

### DIFF
--- a/InterneTaakAfhandeling.EndToEndTest/AlleContactverzoeken/AlleContactverzoekenAccessScenarios.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/AlleContactverzoeken/AlleContactverzoekenAccessScenarios.cs
@@ -77,6 +77,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.AlleContactverzoeken
         //     await Step("Verify redirect to forbidden page");
         //     var forbiddenHeading = Page.GetByRole(AriaRole.Heading, new() { Name = "Toegang geweigerd" });
         //     await Expect(forbiddenHeading).ToBeVisibleAsync();
+        
         // }
 
         // TODO: Requires unauthenticated browser context (no stored auth session).

--- a/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/KlantcontactZoekenScenarios.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/KlantcontactZoekenScenarios.cs
@@ -1,0 +1,165 @@
+using InterneTaakAfhandeling.EndToEndTest.Infrastructure;
+using Microsoft.Playwright;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.RegularExpressions;
+
+namespace InterneTaakAfhandeling.EndToEndTest.Contactverzoek
+{
+    /// <summary>
+    /// E2E-tests voor de klantcontactnummer-zoekpopover in de hoofdnavigatie (Feature #467, Task #556).
+    /// Dekt de scenario's uit Task #552 en #553. Twee scenario's zijn niet geautomatiseerd:
+    ///   - "buiten bevoegdheid" — de enige geconfigureerde test-identity is Functioneel Beheerder, en
+    ///     <c>ContactverzoekAutorisatieGuardService</c> geeft die rol altijd toegang; een non-admin
+    ///     test-identity bestaat nog niet (zelfde blocker als de TODO in AlleContactverzoekenAccessScenarios).
+    ///   - "overige fout" — de frontend vangt elke fout buiten 403 op in dezelfde generieke melding als
+    ///     "niet gevonden"/"meerdere treffers"; er is geen reëel, niet-gemockt backend-scenario dat zich
+    ///     hiervan onderscheidt op UI-niveau, en QA.md verbiedt het mocken van API-responses.
+    /// </summary>
+    [TestClass]
+    [DoNotParallelize]
+    public class KlantcontactZoekenScenarios : ITAPlaywrightTest
+    {
+        // Scenario: Een medewerker vindt een Contactverzoek via het klantcontactnummer
+        [TestMethod("Een medewerker vindt een Contactverzoek via het klantcontactnummer")]
+        public async Task Medewerker_VindtContactverzoek_ViaKlantcontactnummer()
+        {
+            var onderwerp = $"Test_KlantcontactZoeken_Gevonden_{Guid.NewGuid().ToString()[..8]}";
+            var (contactmomentUuid, klantcontactNummer) =
+                await TestDataHelper.CreateContactverzoekWithMedewerkerOnly(onderwerp, DateTime.UtcNow);
+            RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(contactmomentUuid.ToString()));
+
+            await NavigateToAuthenticatedPage();
+
+            await Step($"Open de zoekpopover en zoek op klantcontactnummer {klantcontactNummer}");
+            await OpenZoekpopoverAndSearch(klantcontactNummer);
+
+            await Step("Verify navigatie naar de Contactverzoek detailpagina");
+            await Expect(Page).ToHaveURLAsync(new Regex($"/contactmoment/{Regex.Escape(klantcontactNummer)}"));
+            await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = $"Contactverzoek {klantcontactNummer}" }))
+                .ToBeVisibleAsync();
+        }
+
+        // Scenario: Een medewerker zoekt op een klantcontactnummer dat niet bestaat
+        [TestMethod("Een medewerker zoekt op een klantcontactnummer dat niet bestaat")]
+        public async Task Medewerker_ZoektOpNietBestaandKlantcontactnummer()
+        {
+            await NavigateToAuthenticatedPage();
+
+            var nietBestaandNummer = $"9999{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";
+
+            await Step($"Open de zoekpopover en zoek op niet-bestaand klantcontactnummer {nietBestaandNummer}");
+            await OpenZoekpopoverAndSearch(nietBestaandNummer);
+
+            await Step("Verify generieke foutmelding wordt getoond");
+            await Expect(Page.GetKlantcontactZoekErrorMessage())
+                .ToHaveTextAsync("Geen contactverzoek gevonden voor dit klantcontactnummer.");
+
+            await Step("Verify de popover blijft open (geen navigatie)");
+            await Expect(Page.GetKlantcontactZoekInput()).ToBeVisibleAsync();
+        }
+
+        // Scenario: Eén klantcontactnummer verwijst naar meerdere Contactverzoeken
+        [TestMethod("Eén klantcontactnummer verwijst naar meerdere Contactverzoeken")]
+        public async Task Medewerker_ZoektOpDubbelKlantcontactnummer_ToontGenericeFoutmelding()
+        {
+            var onderwerp = $"Test_KlantcontactZoeken_Ambigu_{Guid.NewGuid().ToString()[..8]}";
+            var (contactmomentUuid, klantcontactNummer) =
+                await TestDataHelper.CreateDuplicateKlantcontactInternetakenAsync(onderwerp);
+            RegisterCleanup(async () => await TestDataHelper.DeleteContactverzoekAsync(contactmomentUuid.ToString()));
+
+            await NavigateToAuthenticatedPage();
+
+            await Step($"Open de zoekpopover en zoek op het dubbele klantcontactnummer {klantcontactNummer}");
+            await OpenZoekpopoverAndSearch(klantcontactNummer);
+
+            await Step("Verify dezelfde generieke foutmelding wordt getoond — geen keuzescherm");
+            await Expect(Page.GetKlantcontactZoekErrorMessage())
+                .ToHaveTextAsync("Geen contactverzoek gevonden voor dit klantcontactnummer.");
+            await Expect(Page.GetByRole(AriaRole.Dialog)).Not.ToBeVisibleAsync();
+        }
+
+        // Scenario: De zoekpopover-knop toont het definitieve zoek-icoon
+        //
+        // Task #553's eigen Test Mapping (QA override) erkent al dat het `search-klantcontact`-symbool
+        // door commit e036459 (binnen dezelfde merged PR #554) weer uit icon-sprite.svg is verwijderd;
+        // de knop toont sindsdien `magnifying-glass`. Deze test asserteert het daadwerkelijk
+        // getoonde icoon i.p.v. het inmiddels niet meer bestaande `search-klantcontact`-symbool.
+        [TestMethod("De zoekpopover-knop toont het definitieve zoek-icoon")]
+        public async Task KlantcontactZoekButton_ToontIcoon()
+        {
+            await NavigateToAuthenticatedPage();
+
+            await Step("Verify de zoekpopover-knop is aanwezig in de hoofdnavigatie");
+            await Expect(Page.GetKlantcontactZoekButton()).ToBeVisibleAsync();
+
+            await Step("Verify het getoonde icoon (huidige sprite-referentie: magnifying-glass)");
+            var iconHref = await Page.GetKlantcontactZoekIconUse()
+                .EvaluateAsync<string>("el => el.getAttribute('xlink:href') || el.getAttribute('href') || ''");
+            Assert.IsTrue(iconHref.EndsWith("#magnifying-glass"),
+                $"Expected icon sprite reference to end with '#magnifying-glass'. Actual: '{iconHref}'");
+        }
+
+        // Scenario: Een medewerker zoekt op een klantcontactnummer buiten zijn bevoegdheid — NOT AUTOMATED.
+        // De enige geconfigureerde test-identity is Functioneel Beheerder; ContactverzoekAutorisatieGuardService
+        // geeft die rol altijd toegang (bypass van de afdeling/groep-check), dus een echte 403 is niet
+        // reproduceerbaar met de huidige testinfra. Zie ook de uitgecommentarieerde TODO in
+        // AlleContactverzoekenAccessScenarios.cs voor dezelfde, al eerder erkende blocker.
+        [TestMethod("Een medewerker zoekt op een klantcontactnummer buiten zijn bevoegdheid")]
+        [Ignore("Vereist een non-admin test-identity, nog niet beschikbaar in de testinfrastructuur")]
+        public async Task Medewerker_ZoektOpKlantcontactnummerBuitenBevoegdheid()
+        {
+            await Task.CompletedTask;
+        }
+
+        // Scenario: Een overige fout tijdens het zoeken — NOT AUTOMATED.
+        // De frontend vangt elke fout buiten 403 op in dezelfde generieke melding als "niet gevonden"/
+        // "meerdere treffers" (zie KlantcontactZoekPopover.vue's catch-blok). Er is geen reëel,
+        // niet-gemockt backend-scenario dat zich hiervan op UI-niveau onderscheidt, en QA.md verbiedt
+        // het mocken van API-responses in E2E-tests.
+        [TestMethod("Een overige fout tijdens het zoeken")]
+        [Ignore("Niet te onderscheiden van 'niet gevonden'/'meerdere treffers' op UI-niveau zonder mocking (verboden per QA.md)")]
+        public async Task Medewerker_ZoektMetOverigeFout()
+        {
+            await Task.CompletedTask;
+        }
+
+        // Private helpers
+
+        private async Task NavigateToAuthenticatedPage()
+        {
+            await Step("Navigate naar de hoofdpagina");
+            await SafeGotoAsync("/");
+            await Expect(Page.GetKlantcontactZoekButton()).ToBeVisibleAsync(new() { Timeout = 10000 });
+        }
+
+        private async Task OpenZoekpopoverAndSearch(string klantcontactNummer)
+        {
+            await Page.GetKlantcontactZoekButton().ClickAsync();
+            await Expect(Page.GetKlantcontactZoekInput()).ToBeVisibleAsync();
+
+            await Page.GetKlantcontactZoekInput().FillAsync(klantcontactNummer);
+            await Page.GetKlantcontactZoekZoekenButton().ClickAsync();
+        }
+
+        private async Task SafeGotoAsync(string url)
+        {
+            PlaywrightException? lastException = null;
+            for (var attempt = 1; attempt <= 3; attempt++)
+            {
+                try
+                {
+                    await Page.GotoAsync(url);
+                    return;
+                }
+                catch (PlaywrightException ex)
+                {
+                    lastException = ex;
+                    if (attempt < 3) await Task.Delay(1500);
+                }
+            }
+            throw new InvalidOperationException(
+                $"Failed to navigate to '{url}' after 3 attempts.",
+                lastException);
+        }
+    }
+}

--- a/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/KlantcontactZoekenScenarios.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Contactverzoek/KlantcontactZoekenScenarios.cs
@@ -60,7 +60,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.Contactverzoek
 
         // Scenario: Eén klantcontactnummer verwijst naar meerdere Contactverzoeken
         [TestMethod("Eén klantcontactnummer verwijst naar meerdere Contactverzoeken")]
-        public async Task Medewerker_ZoektOpDubbelKlantcontactnummer_ToontGenericeFoutmelding()
+        public async Task Medewerker_ZoektOpDubbelKlantcontactnummer_ToontGeneriekeFoutmelding()
         {
             var onderwerp = $"Test_KlantcontactZoeken_Ambigu_{Guid.NewGuid().ToString()[..8]}";
             var (contactmomentUuid, klantcontactNummer) =

--- a/InterneTaakAfhandeling.EndToEndTest/Infrastructure/Locators.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Infrastructure/Locators.cs
@@ -278,5 +278,21 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
 
         public static ILocator GetErrorToast(this IPage page) =>
             page.Locator("output[role='status']").Filter(new() { Has = page.Locator(".utrecht-alert--error") });
+
+        // Klantcontactnummer zoekpopover locators (Feature #467)
+        public static ILocator GetKlantcontactZoekButton(this IPage page) =>
+            page.GetByRole(AriaRole.Button, new() { Name = "Zoek contactverzoek op klantcontactnummer" });
+
+        public static ILocator GetKlantcontactZoekInput(this IPage page) =>
+            page.Locator("#klantcontact-nummer-input");
+
+        public static ILocator GetKlantcontactZoekZoekenButton(this IPage page) =>
+            page.Locator(".klantcontact-zoek__panel").GetByRole(AriaRole.Button, new() { Name = "Zoeken" });
+
+        public static ILocator GetKlantcontactZoekErrorMessage(this IPage page) =>
+            page.Locator(".klantcontact-zoek__error");
+
+        public static ILocator GetKlantcontactZoekIconUse(this IPage page) =>
+            page.Locator(".klantcontact-zoek__button svg use");
     }
 }

--- a/InterneTaakAfhandeling.EndToEndTest/Infrastructure/TestDataHelper.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Infrastructure/TestDataHelper.cs
@@ -231,6 +231,35 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
             return (contactmoment.Uuid, contactmoment.Nummer!);
         }
 
+        // Creates two internetaken pointing at the same klantcontact, so tests can verify the
+        // ambiguity/conflict behavior when a klantcontactnummer resolves to multiple internetaken.
+        public async Task<(Guid ContactmomentUuid, string KlantcontactNummer)> CreateDuplicateKlantcontactInternetakenAsync(
+            string onderwerp)
+        {
+            await CleanupExistingContactmomenten(onderwerp);
+
+            var contactmoment = await CreateContactmoment(
+                onderwerp,
+                "This is a test contact request created during an end-to-end test run.",
+                klantnaam: null);
+
+            var submitterActor = await GetOrCreateSubmitterActor();
+            await ConnectActorToContactmoment(submitterActor, contactmoment.Uuid);
+
+            var medewerkerActor = await GetOrCreateMedewerkerActor(Username);
+
+            await CreateInternetaak(
+                GenerateUniqueInternetaakNummer(),
+                contactmoment.Uuid,
+                new List<Guid> { Guid.Parse(medewerkerActor.Uuid) });
+            await CreateInternetaak(
+                GenerateUniqueInternetaakNummer(),
+                contactmoment.Uuid,
+                new List<Guid> { Guid.Parse(medewerkerActor.Uuid) });
+
+            return (contactmoment.Uuid, contactmoment.Nummer!);
+        }
+
         // Creates `count` separate overdue contactverzoeken all assigned to the current user, so
         // the daily-reminder aggregation scenario can verify a single mail bundling multiple
         // contactverzoeken rather than one mail per contactverzoek.

--- a/InterneTaakAfhandeling.EndToEndTest/Infrastructure/TestDataHelper.cs
+++ b/InterneTaakAfhandeling.EndToEndTest/Infrastructure/TestDataHelper.cs
@@ -661,7 +661,7 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
         {
             var contactmoment = await OpenKlantApiClient.GetKlantcontactAsync(contactmomentUuid);
             var internetaak = contactmoment?.Expand?.LeiddeTotInterneTaken?.FirstOrDefault();
-            
+
             if (internetaak?.Uuid == null)
             {
                 return null;
@@ -672,9 +672,36 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
                 return parsedGuid;
             }
 
-            Logger.LogWarning("Invalid UUID string received for internetaak: '{UuidString}' from contactmoment {ContactmomentUuid}", 
+            Logger.LogWarning("Invalid UUID string received for internetaak: '{UuidString}' from contactmoment {ContactmomentUuid}",
                 internetaak.Uuid, contactmomentUuid);
             return null;
+        }
+
+        private async Task<List<Guid>> GetInternetaakUuidsFromContactmomentAsync(Guid contactmomentUuid)
+        {
+            var contactmoment = await OpenKlantApiClient.GetKlantcontactAsync(contactmomentUuid);
+            var internetaken = contactmoment?.Expand?.LeiddeTotInterneTaken;
+
+            if (internetaken == null || internetaken.Count == 0)
+            {
+                return new List<Guid>();
+            }
+
+            var uuids = new List<Guid>();
+            foreach (var internetaak in internetaken)
+            {
+                if (internetaak.Uuid != null && Guid.TryParse(internetaak.Uuid, out var parsedGuid))
+                {
+                    uuids.Add(parsedGuid);
+                }
+                else
+                {
+                    Logger.LogWarning("Invalid UUID string received for internetaak: '{UuidString}' from contactmoment {ContactmomentUuid}",
+                        internetaak.Uuid, contactmomentUuid);
+                }
+            }
+
+            return uuids;
         }
 
   
@@ -713,10 +740,10 @@ namespace InterneTaakAfhandeling.EndToEndTest.Infrastructure
 
             foreach (var existing in contactmomenten)
             {
-                var internetaakUuid = await GetInternetaakUuidFromContactmomentAsync(existing.Uuid);
-                if (internetaakUuid.HasValue)
+                var internetaakUuids = await GetInternetaakUuidsFromContactmomentAsync(existing.Uuid);
+                foreach (var internetaakUuid in internetaakUuids)
                 {
-                    await OpenKlantApiClient.DeleteInterneTaakAsync(internetaakUuid.Value);
+                    await OpenKlantApiClient.DeleteInterneTaakAsync(internetaakUuid);
                 }
                 await OpenKlantApiClient.DeleteKlantcontactAsync(existing.Uuid);
             }


### PR DESCRIPTION
## Summary

Feature #467 (zoeken op klantcontactnummer) is only fully done once its Gherkin scenarios are confirmed against a real, deployed environment (QA.md Phase 2). This PR delivers that E2E coverage for Task #556, running Playwright tests against `https://ita.test.icatt.nl` for the scenarios implemented in Task #552 (search popover) and Task #553 (icon).

## Changes

- New `Contactverzoek/KlantcontactZoekenScenarios.cs`: 4 real E2E tests (happy path, not-found, ambiguous-match, icon) plus 2 `[Ignore]`-marked scenarios with documented rationale.
- `Locators.cs`: added page-object extension methods for the zoekpopover button, input, submit button, and error alert.
- `TestDataHelper.cs`: added `CreateDuplicateKlantcontactInternetakenAsync`, which creates two internetaken on a single klantcontact so the ambiguity/409 scenario can be tested against real backend data (no mocks, per QA.md).
- The icon scenario asserts the actually-shipped `magnifying-glass` sprite reference rather than `search-klantcontact` — that symbol was removed from `icon-sprite.svg` within the same merged PR #554 that shipped #552/#553; Task #553's own Test Mapping already flagged this discrepancy via a QA override.
- The "buiten bevoegdheid" (no-access) and "overige fout" (other error) scenarios are `[Ignore]`-marked rather than automated: no non-admin test identity exists (`ContactverzoekAutorisatieGuardService` always grants access to the current Functioneel Beheerder test user — same blocker as the existing TODO in `AlleContactverzoekenAccessScenarios.cs`), and the frontend collapses every non-403 error into one identical UI message, so there's no real, non-mocked way to distinguish "other error" from "not found"/"ambiguous".

## Test plan

- [x] Een medewerker vindt een Contactverzoek via het klantcontactnummer — passing against `ita.test.icatt.nl`
- [x] Een medewerker zoekt op een klantcontactnummer dat niet bestaat — passing against `ita.test.icatt.nl`
- [x] Eén klantcontactnummer verwijst naar meerdere Contactverzoeken — passing against `ita.test.icatt.nl`
- [x] De zoekpopover-knop toont het definitieve zoek-icoon — passing against `ita.test.icatt.nl` (asserts `magnifying-glass`, see note above)
- [ ] Een medewerker zoekt op een klantcontactnummer buiten zijn bevoegdheid — not automated, see Changes
- [ ] Een overige fout tijdens het zoeken — not automated, see Changes

## Related

Closes #556
